### PR TITLE
fix fd leak

### DIFF
--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -183,6 +183,7 @@ void WallClock::timerLoop() {
                     }
                     tid = thread_list->next();
                 }
+                delete thread_list;
             }
             for (int i = 0; i < _reservoir_size && i < tids.size(); i++) {
                 reservoir.push_back(tids[i]);


### PR DESCRIPTION
hi, 

Our project uses the java-profiler code, and the Java process has a Too many open files error. After using strace -k -e trace=openat -f java-pid, I feel that I may have found the reason. After I modified it slightly, I have verified that the problem can be solved. I don't know if I can contribute a little code to java-profiler.

[WARN] perf_event_open for TID 30704 failed: Too many open files

ulimit -n
256

lsof -p 30499|grep '/proc/30499/task'|wc -l
202

lsof -p 30499|grep '/proc/30499/task'|head
java    30499 root   23r      DIR                0,3         0 61771716 /proc/30499/task
java    30499 root   24r      DIR                0,3         0 61771716 /proc/30499/task
java    30499 root   51r      DIR                0,3         0 61771716 /proc/30499/task
java    30499 root   52r      DIR                0,3         0 61771716 /proc/30499/task
java    30499 root   53r      DIR                0,3         0 61771716 /proc/30499/task
java    30499 root   54r      DIR                0,3         0 61771716 /proc/30499/task
java    30499 root   55r      DIR                0,3         0 61771716 /proc/30499/task
java    30499 root   56r      DIR                0,3         0 61771716 /proc/30499/task
java    30499 root   57r      DIR                0,3         0 61771716 /proc/30499/task
java    30499 root   58r      DIR                0,3         0 61771716 /proc/30499/task

