### PR TITLE
check thread is a Java thread before accessing the thread state

### DIFF
--- a/ddprof-lib/src/main/cpp/itimer.cpp
+++ b/ddprof-lib/src/main/cpp/itimer.cpp
@@ -44,7 +44,9 @@ void ITimer::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     ExecutionEvent event;
     VMThread* vm_thread = VMThread::current();
     if (vm_thread) {
-        event._execution_mode = convertJvmExecutionState(vm_thread->state());
+        event._execution_mode = VM::jni() != NULL
+                ? convertJvmExecutionState(vm_thread->state())
+                : ExecutionMode::JVM;
     }
     Profiler::instance()->recordSample(ucontext, _interval, tid, BCI_CPU, &event);
     Shims::instance().setSighandlerTid(-1);

--- a/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
+++ b/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
@@ -715,7 +715,9 @@ void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
         ExecutionEvent event;
         VMThread* vm_thread = VMThread::current();
         if (vm_thread) {
-            event._execution_mode = convertJvmExecutionState(vm_thread->state());
+            event._execution_mode = VM::jni() != NULL
+                ? convertJvmExecutionState(vm_thread->state())
+                : ExecutionMode::JVM;
         }
         Profiler::instance()->recordSample(ucontext, counter, tid, BCI_CPU, &event);
         Shims::instance().setSighandlerTid(-1);

--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -77,7 +77,7 @@ void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext, u64
         if (os_state != ThreadState::UNKNOWN) {
             state = os_state;
         }
-        mode = convertJvmExecutionState(vm_thread->state());
+        mode = VM::jni() != NULL ? convertJvmExecutionState(vm_thread->state()) : ExecutionMode::JVM;
     }
     if (state == ThreadState::UNKNOWN) {
         if (inSyscall(ucontext)) {


### PR DESCRIPTION
The thread state is a `JavaThread` property in VMStructs, use the existence of `JNIEnv` to filter out JVM threads.