### PR TITLE
disable the profiler if -XX:+UseAdaptiveGCBoundary is set

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1000,6 +1000,10 @@ Error Profiler::checkJvmCapabilities() {
         return Error("Could not find VMThread bridge. Unsupported JVM?");
     }
 
+    if (VM::isUseAdaptiveGCBoundarySet()) {
+        return Error("The user has explicitly set -XX:+UseAdaptiveGCBoundary so the profiler has been disabled to avoid the risk of crashing.");
+    }
+
     if (_dlopen_entry == NULL) {
         CodeCache* lib = findJvmLibrary("libj9prt");
         if (lib == NULL || (_dlopen_entry = lib->findGlobalOffsetEntry((void*)dlopen)) == NULL) {

--- a/ddprof-lib/src/main/cpp/vmEntry.cpp
+++ b/ddprof-lib/src/main/cpp/vmEntry.cpp
@@ -45,6 +45,7 @@ bool VM::_hotspot = false;
 bool VM::_zing = false;
 bool VM::_can_sample_objects = false;
 bool VM::_can_intercept_binding = false;
+bool VM::_is_adaptive_gc_boundary_flag_set = false;
 jobject VM::_global_system_classloader = nullptr;
 jobject VM::_global_platform_classloader = nullptr;
 
@@ -289,6 +290,13 @@ bool VM::init(JavaVM* vm, bool attach) {
         if (flag_addr != NULL) {
             *flag_addr = 1;
         }
+    }
+
+    // if the user sets -XX:+UseAdaptiveGCBoundary we will just disable the profiler to avoid the risk of crashing
+    // flag was made obsolete (inert) in 15 (see JDK-8228991) and removed in 16 (see JDK-8231560)
+    if (java_version() < 15) {
+        char* flag_addr = (char*)JVMFlag::find("UseAdaptiveGCBoundary");
+        _is_adaptive_gc_boundary_flag_set = flag_addr != NULL && *flag_addr == 1;
     }
 
     if (attach) {

--- a/ddprof-lib/src/main/cpp/vmEntry.h
+++ b/ddprof-lib/src/main/cpp/vmEntry.h
@@ -100,6 +100,7 @@ class VM {
     static bool _zing;
     static bool _can_sample_objects;
     static bool _can_intercept_binding;
+    static bool _is_adaptive_gc_boundary_flag_set;
 
     static jobject _global_system_classloader;
     static jobject _global_platform_classloader;
@@ -168,6 +169,10 @@ class VM {
 
     static bool isZing() {
         return _zing;
+    }
+
+    static bool isUseAdaptiveGCBoundarySet() {
+        return _is_adaptive_gc_boundary_flag_set;
     }
 
     static bool isSystemClassLoader(JNIEnv* jni, jobject& cl);


### PR DESCRIPTION
This flag was [made obsolete](https://bugs.openjdk.org/browse/JDK-8228991) in JDK15 (so that is has no effect) and was [removed entirely](https://bugs.openjdk.org/browse/JDK-8231560) in JDK16 (so that it causes an error when set), but has made its way into JVM tuning folklore so shows up from time to time. We have seen it crash the profiler with the following backtrace, which reproduces reliably with `-XX:+UseAdaptiveGCBoundary` on older JDK versions:

```
Current thread (0x00007f22c9cce800):  JavaThread "dd-profiler-recording-scheduler" daemon [_thread_in_vm, id=1356, stack(0x00007f226232c000,0x00007f226242d000)]

Stack: [0x00007f226232c000,0x00007f226242d000],  sp=0x00007f226242af30,  free space=1019k
Native frames: (J=compiled Java code, A=aot compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x999dc6]  oopDesc::is_a(Klass*) const+0x26
V  [libjvm.so+0xa0b933]  jvmti_GetClassSignature+0x1e3
C  [libjavaProfiler3325426718231816309.so+0x41444]  Recording::writeCpool(Buffer*)+0x2314
C  [libjavaProfiler3325426718231816309.so+0x428a5]  Recording::finishChunk(bool)+0x845
C  [libjavaProfiler3325426718231816309.so+0x35dc8]  FlightRecorder::dump(char const*, int)+0x88
C  [libjavaProfiler3325426718231816309.so+0x28f2f]  Profiler::dump(char const*, int)+0xef
C  [libjavaProfiler3325426718231816309.so+0x12157]  Java_com_datadoghq_profiler_JavaProfiler_dump0+0x47
j  com.datadoghq.profiler.JavaProfiler.dump0(Ljava/lang/String;)V+0
j  com.datadoghq.profiler.JavaProfiler.dump(Ljava/nio/file/Path;)V+11
j  com.datadog.profiling.ddprof.DatadogProfiler.dump(Ljava/nio/file/Path;)V+5
j  com.datadog.profiling.ddprof.DatadogProfilerRecording.snapshot(Ljava/time/Instant;Ldatadog/trace/api/profiling/ProfilingSnapshot$Kind;)Lcom/datadog/profiling/controller/RecordingData;+17
j  com.datadog.profiling.controller.openjdk.OpenJdkOngoingRecording.snapshot(Ljava/time/Instant;Ldatadog/trace/api/profiling/ProfilingSnapshot$Kind;)Lcom/datadog/profiling/controller/RecordingData;+94
j  com.datadog.profiling.controller.ProfilingSystem$SnapshotRecording.snapshot(Z)V+38
j  com.datadog.profiling.controller.ProfilingSystem$SnapshotRecording.snapshot()V+2
j  com.datadog.profiling.controller.ProfilingSystem$$Lambda$555.run(Ljava/lang/Object;)V+4
J 22328 c2 datadog.trace.util.AgentTaskScheduler$PeriodicTask.run()V (25 bytes) @ 0x00007f22bfdf74b8 [0x00007f22bfdf7440+0x0000000000000078]
j  datadog.trace.util.AgentTaskScheduler$Worker.run()V+27
j  java.lang.Thread.run()V+11 java.base@11.0.17
v  ~StubRoutines::call_stub
V  [libjvm.so+0x8dc0ab]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, Thread*)+0x39b
V  [libjvm.so+0x8da06d]  JavaCalls::call_virtual(JavaValue*, Handle, Klass*, Symbol*, Symbol*, Thread*)+0x1ed
V  [libjvm.so+0x98912c]  thread_entry(JavaThread*, Thread*)+0x6c
V  [libjvm.so+0xedb02a]  JavaThread::thread_main_inner()+0x1ba
V  [libjvm.so+0xed7c2f]  Thread::call_run()+0x14f
V  [libjvm.so+0xc776a6]  thread_native_entry(Thread*)+0xe6
```