### PR TITLE
turn counters on in release builds

### DIFF
--- a/ddprof-lib/build.gradle
+++ b/ddprof-lib/build.gradle
@@ -53,7 +53,7 @@ tasks.withType(CppCompile).configureEach {
     }
     def taskIncludes = ["${javaHome()}/include"]
     def taskArgs = ["-fno-omit-frame-pointer", "-momit-leaf-frame-pointer", "-fvisibility=hidden",
-    "-fdata-sections", "-ffunction-sections", "-std=c++11", "-DPROFILER_VERSION=\"${version}\""]
+    "-fdata-sections", "-ffunction-sections", "-std=c++11", "-DPROFILER_VERSION=\"${version}\"", "-DCOUNTERS"]
 
     if (os().isMacOsX()) {
         taskIncludes.add "${javaHome()}/include/darwin"
@@ -66,7 +66,7 @@ tasks.withType(CppCompile).configureEach {
     }
 
     if (it.name.contains('Debug')) {
-        taskArgs.addAll(["-DDEBUG", "-DCOUNTERS"])
+        taskArgs.add("-DDEBUG")
     } else {
         taskArgs.add("-DNDEBUG")
     }


### PR DESCRIPTION
**What does this PR do?**:
Sets counters unconditionally.

**Motivation**:
Always be able to make deductions about profiler internal state from the profiles it produces

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
Benchmark and reliability environments

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
