### PR TITLE
re-enable logging

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1392,25 +1392,24 @@ void FlightRecorder::recordEvent(int lock_index, int tid, u32 call_trace_id,
 }
 
 void FlightRecorder::recordLog(LogLevel level, const char* message, size_t len) {
-    return;
-//    if (!_rec_lock.tryLockShared()) {
-//        // No active recording
-//        return;
-//    }
-//
-//    if (len > MAX_STRING_LENGTH) len = MAX_STRING_LENGTH;
-//    // cppcheck-suppress obsoleteFunctions
-//    Buffer* buf = (Buffer*)alloca(len + 40);
-//    buf->reset();
-//
-//    int start = buf->skip(5);
-//    buf->putVar64(T_LOG);
-//    buf->putVar64(TSC::ticks());
-//    buf->putVar64(level);
-//    buf->putUtf8(message, len);
-//    buf->putVar32(start, buf->offset() - start);
-//    _rec->flush(buf);
-//
-//    _rec_lock.unlockShared();
+    if (!_rec_lock.tryLockShared()) {
+        // No active recording
+        return;
+    }
+
+    if (len > MAX_STRING_LENGTH) len = MAX_STRING_LENGTH;
+    // cppcheck-suppress obsoleteFunctions
+    Buffer* buf = (Buffer*)alloca(len + 40);
+    buf->reset();
+
+    int start = buf->skip(5);
+    buf->putVar64(T_LOG);
+    buf->putVar64(TSC::ticks());
+    buf->putVar64(level);
+    buf->putUtf8(message, len);
+    buf->putVar32(start, buf->offset() - start);
+    _rec->flush(buf);
+
+    _rec_lock.unlockShared();
 }
 


### PR DESCRIPTION
**What does this PR do?**:
Re-enables logging for supportability purposes. Routes all warnings to the JFR by default, finer grained logging requires a configuration flag defined in dd-trace-java. Errors go to stdout and will never attempt to write to the JFR, because it probably isn't ready. This means we should never log at error level after the profiler is initialised, and never log at warn level before it is initialised.

**Motivation**:
Supportability.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
