### PR TITLE
normalise generated reflection accessors and method handles

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -256,6 +256,9 @@ class Lookup {
     void fillNativeMethodInfo(MethodInfo* mi, const char* name, const char* lib_name);
     void cutArguments(char* func);
     void fillJavaMethodInfo(MethodInfo* mi, jmethodID method, bool first_time);
+    bool has_prefix(const char* str, const char* prefix) const {
+        return strncmp(str, prefix, strlen(prefix)) == 0;
+    }
 
   public:
     Lookup(Recording* rec, MethodMap* method_map, Dictionary* classes) :

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/metadata/MetadataNormalisationTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/metadata/MetadataNormalisationTest.java
@@ -1,0 +1,68 @@
+package com.datadoghq.profiler.metadata;
+
+import com.datadoghq.profiler.AbstractProfilerTest;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.item.IItemIterable;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class MetadataNormalisationTest extends AbstractProfilerTest {
+
+    @Test
+    public void test() throws Exception {
+        Constructor<?> arrayListConstructor = ArrayList.class.getConstructor();
+        Method arrayListAdd = ArrayList.class.getDeclaredMethod("add", Object.class);
+        Constructor<?> linkedListConstructor = LinkedList.class.getConstructor();
+        Method linkedListAdd = LinkedList.class.getDeclaredMethod("add", Object.class);
+        // need to invoke enough times to result in generation of accessors and to record some cpu time
+        int count = 0;
+        for (int i = 0; i < 100_000; i++) {
+            Object list = arrayListConstructor.newInstance();
+            arrayListAdd.invoke(list, "element");
+            count += ((List<?>) list).size();
+        }
+        for (int i = 0; i < 100_000; i++) {
+            Object list = linkedListConstructor.newInstance();
+            linkedListAdd.invoke(list, "element");
+            count += ((List<?>) list).size();
+        }
+        System.out.println(count);
+        stopProfiler();
+        IItemCollection executionSamples = verifyEvents("datadog.ExecutionSample");
+        Matcher[] forbiddenPatternMatchers = Stream.of(
+                "MH.*0x[A-Fa-f0-9]{3}", // method handles
+                        "GeneratedConstructorAccessor\\d+",
+                        "GeneratedMethodAccessor\\d+"
+                )
+                .map(regex -> Pattern.compile(regex).matcher(""))
+                .toArray(Matcher[]::new);
+        for (IItemIterable samples : executionSamples) {
+            IMemberAccessor<String, IItem> stacktraceAccessor = JdkAttributes.STACK_TRACE_STRING.getAccessor(samples.getType());
+            for (IItem item : samples) {
+                String stacktrace = stacktraceAccessor.getMember(item);
+                for (Matcher matcher : forbiddenPatternMatchers) {
+                    matcher.reset(stacktrace);
+                    assertFalse(matcher.find(), () -> matcher.pattern() + "\n" + stacktrace);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected String getProfilerCommand() {
+        return "cpu=1us";
+    }
+}


### PR DESCRIPTION
**What does this PR do?**:
This reduces the size of metadata resulting from heavy usage of reflection in the recorded profile and in memory. It does this by matching on the class names of generated accessors (prior to JDK18) and also normalises any method handles. In JDK18+ reflection was reimplemented in terms of method handles so the generated accessors checks are unnecessary (see [jep](https://openjdk.org/jeps/416). This is tested by heavy enough usage of reflection to provoke generation of accessors, and pattern matching the stack traces. 

MethodHandle frames such as 

```
java.lang.Object java.lang.invoke.LambdaForm$BMH.0x0000000801346000.invoke(java.lang.Object, java.lang.Object, java.lang.Object)
```

are replaced with:

```
java.lang.Object java.lang.invoke.LambdaForm$BMH.invoke(java.lang.Object, java.lang.Object, java.lang.Object)
```

Generated accessors such as

```
Object jdk.internal.reflect.GeneratedMethodAccessor740.invoke(Object, Object[])
```

are replaced with
```
Object jdk.internal.reflect.GeneratedMethodAccessor.invoke(Object, Object[])
```


Lambdas have been left alone for now, because it's not clear whether stripping the hex identifier out would be beneficial in terms of cardinality reduction (though it would result in a tiny space reduction):

```
java.lang.Object org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall$$Lambda$194.0x0000000801119bb8.apply(org.junit.jupiter.api.extension.InvocationInterceptor, org.junit.jupiter.api.extension.InvocationInterceptor$Invocation, org.junit.jupiter.api.extension.ReflectiveInvocationContext, org.junit.jupiter.api.extension.ExtensionContext)
```

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
