### PR TITLE
Workaround crashes caused by invalid jmethodID on J9

### DIFF
--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -53,6 +53,7 @@
     X(THREAD_NAMES_COUNT, "thread_names_count") \
     X(THREAD_FILTER_PAGES, "thread_filter_pages") \
     X(THREAD_FILTER_BYTES, "thread_filter_bytes") \
+    X(JMETHODID_SKIPPED, "jmethodid_skipped_count") \
     X(JMETHODID_MAP_BYTES, "jmethodid_map_bytes") \
     X(JMETHODID_MAP_MISS, "jmethodid_map_miss") \
     X(JMETHODID_MAP_PURGED_ITEMS, "jmethodid_map_purged_items")

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -207,6 +207,7 @@ void Lookup::fillJavaMethodInfo(MethodInfo* mi, jmethodID method, bool first_tim
             method_sig_id = _symbols.lookup(method_sig);
         }
     } else {
+        Counters::increment(JMETHODID_SKIPPED);
         class_name_id = _classes->lookup("");
         method_name_id = _symbols.lookup("jvmtiError");
         method_sig_id = _symbols.lookup("()L;");

--- a/ddprof-lib/src/main/cpp/j9Ext.h
+++ b/ddprof-lib/src/main/cpp/j9Ext.h
@@ -57,10 +57,8 @@ class J9Ext {
 
   public:
     static bool can_use_ASGCT() {
-        return (VM::java_version() == 8 && VM::java_update_version() >= 361);
-        //  ASGCT with concurrent class loading in JDK 11+ is inherently unstable and leads to JVM crashes
-        //        (VM::java_version() == 11 && VM::java_update_version() >= 18) ||
-        //        (VM::java_version() == 17 && VM::java_update_version() >= 6);
+        // ASGCT usage on J9 is inherently unstable
+        return false;
     }
 
     static bool initialize(jvmtiEnv* jvmti, const void* j9thread_self);

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -838,7 +838,7 @@ void Profiler::setupSignalHandlers() {
         orig_trapHandler = NULL;
     }
     if (VM::java_version() > 0) {
-        // HotSpot tolerates interposed SIGSEGV/SIGBUS handler; other JVMs probably not
+        // HotSpot and J9 tolerate interposed SIGSEGV/SIGBUS handler; other JVMs probably not
         orig_segvHandler = OS::replaceCrashHandler(segvHandler);
     }
 }

--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -531,6 +531,13 @@ bool VMMethod::check_jmethodID(jmethodID id) {
     if (id == NULL) {
         return false;
     }
+    if (VM::isOpenJ9()) {
+        return check_jmethodID_J9(id);
+    }
+    return check_jmethodID_hotspot(id);
+}
+
+bool VMMethod::check_jmethodID_hotspot(jmethodID id) {
     const char* method_ptr = (const char*) SafeAccess::load((void**) id);
     if (method_ptr == NULL) {
         return false;
@@ -565,6 +572,47 @@ bool VMMethod::check_jmethodID(jmethodID id) {
         if (cl_data == NULL) {
             return false;
         }
+    }
+    return true;
+}
+
+bool VMMethod::check_jmethodID_J9(jmethodID id) {
+    /*
+    The id can be cast to J9JNIMethodID*
+    The J9JNIMethodID structure is:
+    - J9Method* method
+    - UDATA vTableIndex
+    */
+    void* j9methodIDPtr = SafeAccess::load((void**) id); //*(void**)id;
+    if (j9methodIDPtr == nullptr) {
+        return false;
+    }
+
+    void* j9methodPtr = SafeAccess::load((void**) j9methodIDPtr); //*(void**)j9methodIDPtr;
+
+    if (j9methodPtr == nullptr) {
+        return false;
+    }
+
+    /*
+    The J9Method structure:
+    - U_8* bytecodes
+	- J9ConstantPool* constantPool
+	- void* methodRunAddress
+    */
+    void* constantPoolPtr = SafeAccess::load((void**) j9methodPtr + 1);
+    if (constantPoolPtr == nullptr) {
+        return false;
+    }
+
+    /*
+    The J9ConstantPool structure:
+    - J9Class* ramClass;
+	- J9ROMConstantPoolItem* romConstantPool;
+    */
+    void* ramClassPtr = SafeAccess::load((void**) constantPoolPtr);
+    if (ramClassPtr == nullptr) {
+        return false;
     }
     return true;
 }

--- a/ddprof-lib/src/main/cpp/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/vmStructs.h
@@ -313,6 +313,9 @@ class VMThread : VMStructs {
 };
 
 class VMMethod : VMStructs {
+  private:
+    static bool check_jmethodID_J9(jmethodID id);
+    static bool check_jmethodID_hotspot(jmethodID id);
   public:
     static VMMethod* fromMethodID(jmethodID id) {
         return *(VMMethod**)id;

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/context/TagContextTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/context/TagContextTest.java
@@ -1,8 +1,19 @@
 package com.datadoghq.profiler.context;
 
-import com.datadoghq.profiler.AbstractProfilerTest;
-import com.datadoghq.profiler.ContextSetter;
-import com.datadoghq.profiler.Platform;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jmc.common.item.IItem;
@@ -12,22 +23,17 @@ import org.openjdk.jmc.common.item.IMemberAccessor;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.IntStream;
-
-import static com.datadoghq.profiler.MoreAssertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import com.datadoghq.profiler.AbstractProfilerTest;
+import com.datadoghq.profiler.ContextSetter;
+import static com.datadoghq.profiler.MoreAssertions.DICTIONARY_PAGE_SIZE;
+import static com.datadoghq.profiler.MoreAssertions.assertBoundedBy;
+import com.datadoghq.profiler.Platform;
 
 public class TagContextTest extends AbstractProfilerTest {
 
     @Test
     public void test() throws InterruptedException {
-        Assumptions.assumeTrue(!Platform.isJ9() || (Platform.isJ9() && Platform.isJavaVersion(8)));
+        Assumptions.assumeTrue(!Platform.isJ9());
         registerCurrentThreadForWallClockProfiling();
         ContextSetter contextSetter = new ContextSetter(profiler, Arrays.asList("tag1", "tag2", "tag1"));
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/ContextCpuTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/ContextCpuTest.java
@@ -1,7 +1,12 @@
 package com.datadoghq.profiler.cpu;
 
-import com.datadoghq.profiler.AbstractProfilerTest;
-import com.datadoghq.profiler.Platform;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Assumptions;
 import org.junitpioneer.jupiter.RetryingTest;
 import org.openjdk.jmc.common.item.IItem;
@@ -11,14 +16,9 @@ import org.openjdk.jmc.common.item.IMemberAccessor;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-
+import com.datadoghq.profiler.AbstractProfilerTest;
 import static com.datadoghq.profiler.MoreAssertions.assertInRange;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.datadoghq.profiler.Platform;
 
 public class ContextCpuTest extends AbstractProfilerTest {
 
@@ -31,7 +31,7 @@ public class ContextCpuTest extends AbstractProfilerTest {
 
     @RetryingTest(10)
     public void test() throws ExecutionException, InterruptedException {
-        Assumptions.assumeTrue(!Platform.isJ9() || (Platform.isJ9() && Platform.isJavaVersion(8)));
+        Assumptions.assumeTrue(!Platform.isJ9());
         for (int i = 0, id = 1; i < 100; i++, id += 3) {
             profiledCode.method1(id);
         }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/LightweightContextCpuTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/LightweightContextCpuTest.java
@@ -34,7 +34,7 @@ public class LightweightContextCpuTest extends AbstractProfilerTest {
     }
 
     public void test() throws ExecutionException, InterruptedException {
-        Assumptions.assumeTrue(!Platform.isJ9() || (Platform.isJ9() && Platform.isJavaVersion(8)));
+        Assumptions.assumeTrue(!Platform.isJ9());
         for (int i = 0, id = 1; i < 100; i++, id += 3) {
             profiledCode.method1(id);
         }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/CollapsingSleepTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/CollapsingSleepTest.java
@@ -1,20 +1,19 @@
 package com.datadoghq.profiler.wallclock;
 
-import com.datadoghq.profiler.AbstractProfilerTest;
-import com.datadoghq.profiler.Platform;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 import org.openjdk.jmc.common.item.Aggregators;
 import org.openjdk.jmc.common.item.IItemCollection;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.Test;
+import com.datadoghq.profiler.AbstractProfilerTest;
+import com.datadoghq.profiler.Platform;
 
 public class CollapsingSleepTest extends AbstractProfilerTest {
 
     @Test
     public void testSleep() throws InterruptedException {
-        Assumptions.assumeTrue(!Platform.isJ9() || (Platform.isJ9() && Platform.isJavaVersion(8)));
+        Assumptions.assumeTrue(!Platform.isJ9());
         registerCurrentThreadForWallClockProfiling();
         Thread.sleep(1000);
         stopProfiler();

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContextWallClockTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContextWallClockTest.java
@@ -1,16 +1,5 @@
 package com.datadoghq.profiler.wallclock;
 
-import com.datadoghq.profiler.Platform;
-import com.datadoghq.profiler.AbstractProfilerTest;
-import com.datadoghq.profiler.context.ContextExecutor;
-import com.datadoghq.profiler.context.Tracing;
-import org.openjdk.jmc.common.item.IItem;
-import org.openjdk.jmc.common.item.IItemCollection;
-import org.openjdk.jmc.common.item.IItemIterable;
-import org.openjdk.jmc.common.item.IMemberAccessor;
-import org.openjdk.jmc.common.unit.IQuantity;
-import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -21,12 +10,24 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Assumptions;
-
-import static com.datadoghq.profiler.MoreAssertions.assertInRange;
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.junit.jupiter.api.Test;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.item.IItemIterable;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
+
+import com.datadoghq.profiler.AbstractProfilerTest;
+import static com.datadoghq.profiler.MoreAssertions.assertInRange;
+import com.datadoghq.profiler.Platform;
+import com.datadoghq.profiler.context.ContextExecutor;
+import com.datadoghq.profiler.context.Tracing;
 
 public class ContextWallClockTest extends AbstractProfilerTest {
 
@@ -42,10 +43,7 @@ public class ContextWallClockTest extends AbstractProfilerTest {
 
     @Test
     public void test() throws ExecutionException, InterruptedException {
-        Assumptions.assumeTrue(
-                (!Platform.isJ9() || (Platform.isJ9() && Platform.isJavaVersion(8))) &&
-                !Platform.isZing()
-        );
+        Assumptions.assumeTrue(!Platform.isJ9() && !Platform.isZing());
 
         registerCurrentThreadForWallClockProfiling();
         for (int i = 0, id = 1; i < 100; i++, id += 3) {

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/WallclockThreadFilterTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/WallclockThreadFilterTest.java
@@ -1,7 +1,6 @@
 package com.datadoghq.profiler.wallclock;
 
-import com.datadoghq.profiler.AbstractProfilerTest;
-import com.datadoghq.profiler.Platform;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jmc.common.item.IItem;
@@ -11,13 +10,14 @@ import org.openjdk.jmc.common.item.IMemberAccessor;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.datadoghq.profiler.AbstractProfilerTest;
+import com.datadoghq.profiler.Platform;
 
 public class WallclockThreadFilterTest extends AbstractProfilerTest {
 
     @Test
     public void test() throws InterruptedException {
-        Assumptions.assumeTrue(!Platform.isJ9() || (Platform.isJ9() && Platform.isJavaVersion(8)));
+        Assumptions.assumeTrue(!Platform.isJ9());
         registerCurrentThreadForWallClockProfiling();
         Thread.sleep(100);
         stopProfiler();


### PR DESCRIPTION
**What does this PR do?**:
Similarly to what we do for hotspot we check the data structures required to retrieve method metadata from a jmethodid before attempting to do that in JVMTI.

**Motivation**:
Increased frequency of crashes when profiling J9 due to invalid jmethodids.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
Assuming that `dd-java-agent.jar` contains the ddprof library with this change and you have downloaded the `renaiisance-gpl-0.14.2.jar` file to your homedirectory  you can run 
```
java  -Ddd.profiling.enabled=true -javaagent:/home/bits/dd-java-agent.jar -Ddd.profiling.start-force-first=true -Ddd.profiling.upload.period=10 -Ddd.trace.enabled=true -Ddd.env=test-jb -Ddd.integration.renaissance.enabled=true -Ddd.profiling.ddprof.enabled=true -Ddd.profiling.ddprof.wall.enabled=false -Ddd.profiling.ddprof.alloc.enabled=true  -Ddd.profiling.ddprof.liveheap.enabled=true -Ddd.instrumentation.telemetry.enabled=true -Ddd.instrumentation.appsec.enabled=true -jar ~/renaissance-gpl-0.14.2.jar dotty -r 100
```
and it should finish without crashing. When you switch `dd-java-agent.jar` for `dd-java-agent-1.20.1.jar` the same command should crash after ~10 seconds.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
