### PR TITLE
fix calltrace storage and classes counters

### DIFF
--- a/ddprof-lib/src/main/cpp/callTraceStorage.cpp
+++ b/ddprof-lib/src/main/cpp/callTraceStorage.cpp
@@ -113,6 +113,8 @@ void CallTraceStorage::clear() {
     _current_table->clear();
     _allocator.clear();
     _overflow = 0;
+    Counters::set(CALLTRACE_STORAGE_BYTES, 0);
+    Counters::set(CALLTRACE_STORAGE_TRACES, 0);
     _lock.unlock();
 }
 

--- a/ddprof-lib/src/main/cpp/dictionary.h
+++ b/ddprof-lib/src/main/cpp/dictionary.h
@@ -64,8 +64,8 @@ class Dictionary {
     Dictionary() : Dictionary(0) {}
     Dictionary(int id) : _id(id) {
         _table = (DictTable*)calloc(1, sizeof(DictTable));
-        Counters::increment(DICTIONARY_PAGES, 1, id);
-        Counters::increment(DICTIONARY_BYTES, sizeof(DictTable), id);
+        Counters::set(DICTIONARY_PAGES, 1, id);
+        Counters::set(DICTIONARY_BYTES, sizeof(DictTable), id);
         _table->base_index = _base_index = 1;
         _size = 0;
     }


### PR DESCRIPTION
**What does this PR do?**:
* the calltrace storage counters didn't get reset when cleared
* reset dictionary counters to zero when cleared

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
