### PR TITLE
add counters for codecaches

### DIFF
--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -157,6 +157,10 @@ class CodeCache {
 
     void setDwarfTable(FrameDesc* table, int length);
     FrameDesc* findFrameDesc(const void* pc);
+
+    long long memoryUsage() {
+        return _capacity * sizeof(CodeBlob*) + _count * sizeof(NativeFunc);
+    }
 };
 
 
@@ -182,6 +186,15 @@ class CodeCacheArray {
         int index = __atomic_load_n(&_count, __ATOMIC_ACQUIRE);
         _libs[index] = lib;
         __atomic_store_n(&_count, index + 1, __ATOMIC_RELEASE);
+    }
+
+    long long memoryUsage() {
+        int count = __atomic_load_n(&_count, __ATOMIC_ACQUIRE);
+        long long totalUsage = 0;
+        for (int i = 0; i < count; i++) {
+            totalUsage += _libs[i]->memoryUsage();
+        }
+        return totalUsage;
     }
 };
 

--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -48,8 +48,11 @@
     X(THREAD_IDS_COUNT, "thread_ids_count")  \
     X(THREAD_NAMES_COUNT, "thread_names_count") \
     X(THREAD_FILTER_PAGES, "thread_filter_pages") \
+    X(THREAD_FILTER_BYTES, "thread_filter_bytes") \
     X(JMETHODID_SKIPPED, "jmethodid_skipped_count") \
-    X(THREAD_FILTER_BYTES, "thread_filter_bytes")
+    X(CODECACHE_NATIVE_SIZE_BYTES, "codecache_native_size_bytes") \
+    X(CODECACHE_NATIVE_COUNT, "native_codecache_count") \
+    X(CODECACHE_RUNTIME_STUBS_SIZE_BYTES, "codecache_runtime_stubs_size_bytes")
 #define X_ENUM(a, b) a,
 typedef enum CounterId : int {
     DD_COUNTER_TABLE(X_ENUM) DD_NUM_COUNTERS

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1184,6 +1184,10 @@ Error Profiler::dump(const char* path, const int length) {
 
         updateJavaThreadNames();
         updateNativeThreadNames();
+
+        Counters::set(CODECACHE_NATIVE_COUNT, _native_libs.count());
+        Counters::set(CODECACHE_NATIVE_SIZE_BYTES, _native_libs.memoryUsage());
+        Counters::set(CODECACHE_RUNTIME_STUBS_SIZE_BYTES, _native_libs.memoryUsage());
         
         lockAll();
         Error err = _jfr.dump(path, length);


### PR DESCRIPTION
**What does this PR do?**:
Adds counters for the number of native lib codecaches (which includes libjvm and the linux kernel) and also the runtime stubs, so these can be reported automatically as an internal counter.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
