### PR TITLE
defer deletion of .so file to JVM shutdown

### DIFF
--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
@@ -118,7 +118,6 @@ public final class JavaProfiler {
             libLocation = libraryPath.toString();
         }
         System.load(libLocation);
-        Files.deleteIfExists(libraryPath == null ? Paths.get(libLocation) : libraryPath);
         profiler.initializeContextStorage();
         instance = profiler;
         return profiler;


### PR DESCRIPTION
**What does this PR do?**:
Deleting the temporary .so file eagerly prevents most dwarf unwinders from unwinding through our library calls which makes it harder to diagnose issues if things go wrong.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
