### PR TITLE
increase counter spacing

### DIFF
--- a/ddprof-lib/src/main/cpp/counters.cpp
+++ b/ddprof-lib/src/main/cpp/counters.cpp
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 
 long long* Counters::init() {
-    u32 alignment = sizeof(long long) * 8;
+    u32 alignment = sizeof(long long) * ALIGNMENT;
     long long* counters = (long long*) aligned_alloc(alignment, DD_NUM_COUNTERS * alignment);
     memset(counters, 0, DD_NUM_COUNTERS * alignment);
     return counters;

--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -61,6 +61,7 @@ typedef enum CounterId : int {
 
 class Counters {
 private:
+    static const u32 ALIGNMENT = 16;
     volatile long long* _counters;
     static long long* init();
     Counters() : _counters() {
@@ -78,7 +79,7 @@ public:
     void operator=(Counters const&) = delete;
 
     static constexpr int address(int index) {
-        return index * 8;
+        return index * ALIGNMENT;
     }
 
     static constexpr int size() {

--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
@@ -446,8 +446,8 @@ public final class JavaProfiler {
         ByteBuffer buffer = getDebugCounters0().order(ByteOrder.LITTLE_ENDIAN);
         if (buffer.hasRemaining()) {
             String[] names = describeDebugCounters0();
-            for (int i = 0; i < names.length && i * 64 < buffer.capacity(); i++) {
-                counters.put(names[i], buffer.getLong(i * 64));
+            for (int i = 0; i < names.length && i * 128 < buffer.capacity(); i++) {
+                counters.put(names[i], buffer.getLong(i * 128));
             }
         }
         return counters;


### PR DESCRIPTION
**What does this PR do?**:
Increases the spacing between counters to 128 bytes to be absolutely sure we don't induce false sharing on certain architectures. We have so few counters that this costs much less than 1KiB to avoid the problem entirely.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
