### PR TITLE
do not unwind stack if last Java stack-pointer is NULL

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -355,6 +355,12 @@ int Profiler::getJavaTraceAsync(void* ucontext, ASGCT_CallFrame* frames, int max
         return 0;
     }
 
+    if (VM::isHotspot() && vm_thread->lastJavaSP() == 0 && vm_thread->lastJavaPC() != 0) {
+        // lastJavaSP set to NULL when stack is in unparseable state, see:
+        // https://github.com/openjdk/jdk/blob/2e2d49c76d7bb43a431b5c4f2552beef8798258b/src/hotspot/share/runtime/deoptimization.cpp#L870
+        return  0;
+    }
+
     StackFrame frame(ucontext);
     uintptr_t saved_pc, saved_sp, saved_fp;
     if (ucontext != NULL) {


### PR DESCRIPTION
**What does this PR do?**:
The last Java SP is set to NULL is used to indicate that the stack is currently unparseable, so we don't attempt to get a stack trace from AsyncGetCallTrace.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
