### PR TITLE
add counters for pre-AsyncGetCallTrace checks

### DIFF
--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -52,7 +52,11 @@
     X(JMETHODID_SKIPPED, "jmethodid_skipped_count") \
     X(CODECACHE_NATIVE_SIZE_BYTES, "codecache_native_size_bytes") \
     X(CODECACHE_NATIVE_COUNT, "native_codecache_count") \
-    X(CODECACHE_RUNTIME_STUBS_SIZE_BYTES, "codecache_runtime_stubs_size_bytes")
+    X(CODECACHE_RUNTIME_STUBS_SIZE_BYTES, "codecache_runtime_stubs_size_bytes") \
+    X(AGCT_NOT_REGISTERED_IN_TLS, "agct_not_registered_in_tls") \
+    X(AGCT_NULL_SP, "agct_null_sp") \
+    X(AGCT_NOT_JAVA, "agct_not_java") \
+    X(AGCT_NATIVE_NO_JAVA_CONTEXT, "agct_native_no_java_context")
 #define X_ENUM(a, b) a,
 typedef enum CounterId : int {
     DD_COUNTER_TABLE(X_ENUM) DD_NUM_COUNTERS


### PR DESCRIPTION
**What does this PR do?**:
Adds counters so we can track how often these cases are hit.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
