### PR TITLE
fix dictionary_keys_bytes counters

### DIFF
--- a/ddprof-lib/src/main/cpp/dictionary.cpp
+++ b/ddprof-lib/src/main/cpp/dictionary.cpp
@@ -35,7 +35,6 @@ static inline bool keyEquals(const char* candidate, const char* key, size_t leng
 Dictionary::~Dictionary() {
     clear(_table, _id);
     free(_table);
-    Counters::set(DICTIONARY_KEYS, 0, _id);
     Counters::set(DICTIONARY_BYTES, 0, _id);
     Counters::set(DICTIONARY_PAGES, 0, _id);
 }
@@ -45,6 +44,7 @@ void Dictionary::clear() {
     memset(_table, 0, sizeof(DictTable));
     _table->base_index = _base_index = 1;
     Counters::set(DICTIONARY_KEYS, 0, _id);
+    Counters::set(DICTIONARY_KEYS_BYTES, 0, _id);
     Counters::set(DICTIONARY_BYTES, sizeof(DictTable), _id);
     Counters::set(DICTIONARY_PAGES, 1, _id);
     _size = 0;


### PR DESCRIPTION
**What does this PR do?**:
Fixes a trivial bug in these counters, where the keys_bytes counters would accumulate.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
