### PR TITLE
Resolve JNI problems discovered with `-Xcheck:jni`

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -46,6 +46,7 @@
 #include "tsc.h"
 #include "vmStructs.h"
 #include "counters.h"
+#include "jniHelper.h"
 
 static SpinLock _rec_lock(1);
 
@@ -159,8 +160,9 @@ void Lookup::fillJavaMethodInfo(MethodInfo* mi, jmethodID method, bool first_tim
                 jni->GetMethodID(jni->FindClass("java/lang/Class"), "equals", "(Ljava/lang/Object;)Z");
             jclass klass = method_class;
             do {
-                if (jni->CallBooleanMethod(Thread_class, equals, klass)) {
-                    entry = true;
+                entry = jni->CallBooleanMethod(Thread_class, equals, klass);
+                jniExceptionCheck(jni);
+                if (entry) {
                     break;
                 }
             } while ((klass = jni->GetSuperclass(klass)) != NULL);
@@ -529,8 +531,10 @@ bool Recording::parseAgentProperties() {
         jmethodID to_string = env->GetMethodID(env->FindClass("java/lang/Object"), "toString", "()Ljava/lang/String;");
         if (get_agent_props != NULL && to_string != NULL) {
             jobject props = env->CallStaticObjectMethod(vm_support, get_agent_props);
+            jniExceptionCheck(env);
             if (props != NULL) {
                 jstring str = (jstring)env->CallObjectMethod(props, to_string);
+                jniExceptionCheck(env);
                 if (str != NULL) {
                     _agent_properties = (char*)env->GetStringUTFChars(str, NULL);
                 }

--- a/ddprof-lib/src/main/cpp/jniHelper.h
+++ b/ddprof-lib/src/main/cpp/jniHelper.h
@@ -1,0 +1,12 @@
+#ifndef JAVA_PROFILER_JNIHELPER_H
+#define JAVA_PROFILER_JNIHELPER_H
+
+#include <jni.h>
+
+static void jniExceptionCheck(JNIEnv* jni) {
+    if(jni->ExceptionCheck()) {
+        jni->ExceptionClear();
+    }
+}
+
+#endif

--- a/ddprof-lib/src/main/cpp/jniHelper.h
+++ b/ddprof-lib/src/main/cpp/jniHelper.h
@@ -3,8 +3,11 @@
 
 #include <jni.h>
 
-static void jniExceptionCheck(JNIEnv* jni) {
+static void jniExceptionCheck(JNIEnv* jni, bool describe = false) {
     if(jni->ExceptionCheck()) {
+        if (describe) {
+            jni->ExceptionDescribe();
+        }
         jni->ExceptionClear();
     }
 }

--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -137,11 +137,11 @@ Error LivenessTracker::initialize_table(int sampling_interval) {
         static jmethodID _max_memory;
 
         if (!(_rt = env->FindClass("java/lang/Runtime"))) {
-            env->ExceptionDescribe();
+            jniExceptionCheck(env, true);
         } else if (!(_get_rt = env->GetStaticMethodID(_rt, "getRuntime", "()Ljava/lang/Runtime;"))) {
-            env->ExceptionDescribe();
+            jniExceptionCheck(env, true);
         } else if (!(_max_memory = env->GetMethodID(_rt, "maxMemory", "()J"))) {
-            env->ExceptionDescribe();
+            jniExceptionCheck(env, true);
         } else {
             jobject rt = (jobject)env->CallStaticObjectMethod(_rt, _get_rt);
             jniExceptionCheck(env);
@@ -208,10 +208,10 @@ Error LivenessTracker::initialize(Arguments& args) {
         return _stored_error = Error::OK;
     }
     if (!(_Class = env->FindClass("java/lang/Class"))) {
-        env->ExceptionDescribe();
+        jniExceptionCheck(env, true);
         err = Error("Unable to find java/lang/Class");
     } else if (!(_Class_getName = env->GetMethodID(_Class, "getName", "()Ljava/lang/String;"))) {
-        env->ExceptionDescribe();
+        jniExceptionCheck(env, true);
         err = Error("Unable to find java/lang/Class.getName");
     }
     if (err) {
@@ -229,8 +229,6 @@ Error LivenessTracker::initialize(Arguments& args) {
 
     _gc_epoch = 0;
     _last_gc_epoch = 0;
-
-    env->ExceptionClear();
 
     return _stored_error = Error::OK;
 }

--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -248,6 +248,8 @@ void LivenessTracker::track(JNIEnv* env, AllocEvent &event, jint tid, jobject ob
 
 retry:
     if (!_table_lock.tryLockShared()) {
+        // we failed to add the weak reference to the table so it won't get cleaned up otherwise
+        env->DeleteWeakGlobalRef(ref);
         return;
     }
 

--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -28,6 +28,7 @@
 #include "thread.h"
 #include "tsc.h"
 #include "vmStructs.h"
+#include "jniHelper.h"
 
 LivenessTracker* const LivenessTracker::_instance = new LivenessTracker();
 
@@ -98,6 +99,7 @@ void LivenessTracker::flush_table(std::set<int> *tracked_thread_ids) {
             event._ctx = _table[i].ctx;
 
             jstring name_str = (jstring)env->CallObjectMethod(env->GetObjectClass(ref), _Class_getName);
+            jniExceptionCheck(env);
             const char *name = env->GetStringUTFChars(name_str, NULL);
             event._id = name != NULL ? Profiler::instance()->lookupClass(name, strlen(name)) : 0;
             env->ReleaseStringUTFChars(name_str, name);
@@ -142,6 +144,7 @@ Error LivenessTracker::initialize_table(int sampling_interval) {
             env->ExceptionDescribe();
         } else {
             jobject rt = (jobject)env->CallStaticObjectMethod(_rt, _get_rt);
+            jniExceptionCheck(env);
             max_heap = (jlong)env->CallLongMethod(rt, _max_memory);
         }
     }

--- a/ddprof-lib/src/main/cpp/vmEntry.cpp
+++ b/ddprof-lib/src/main/cpp/vmEntry.cpp
@@ -28,6 +28,7 @@
 #include "profiler.h"
 #include "log.h"
 #include "vmStructs.h"
+#include "jniHelper.h"
 
 
 // JVM TI agent return codes
@@ -336,6 +337,7 @@ void VM::ready(jvmtiEnv* jvmti, JNIEnv* jni) {
 
     jmethodID getSystemClassLoaderMethod = jni->GetStaticMethodID(clClass, "getSystemClassLoader", "()Ljava/lang/ClassLoader;");
     jobject localSystemClassLoader = jni->CallStaticObjectMethod(clClass, getSystemClassLoaderMethod);
+    jniExceptionCheck(jni);
 
     jmethodID getPlatformClassLoaderMethod = jni->GetStaticMethodID(clClass, "getPlatformClassLoader", "()Ljava/lang/ClassLoader;");
     if (jni->ExceptionCheck()) { // check if an exception occurred
@@ -345,6 +347,7 @@ void VM::ready(jvmtiEnv* jvmti, JNIEnv* jni) {
     _global_system_classloader = jni->NewGlobalRef(localSystemClassLoader);
     if (getPlatformClassLoaderMethod != nullptr) {
         jobject localPlatformClassLoader = jni->CallStaticObjectMethod(clClass, getPlatformClassLoaderMethod);
+        jniExceptionCheck(jni);
         _global_platform_classloader = jni->NewGlobalRef(localPlatformClassLoader);
     }
 }

--- a/ddprof-lib/src/main/cpp/vmEntry.cpp
+++ b/ddprof-lib/src/main/cpp/vmEntry.cpp
@@ -48,8 +48,6 @@ bool VM::_zing = false;
 bool VM::_can_sample_objects = false;
 bool VM::_can_intercept_binding = false;
 bool VM::_is_adaptive_gc_boundary_flag_set = false;
-jobject VM::_global_system_classloader = nullptr;
-jobject VM::_global_platform_classloader = nullptr;
 
 jvmtiError (JNICALL *VM::_orig_RedefineClasses)(jvmtiEnv*, jint, const jvmtiClassDefinition*);
 jvmtiError (JNICALL *VM::_orig_RetransformClasses)(jvmtiEnv*, jint, const jclass* classes);
@@ -331,25 +329,6 @@ void VM::ready(jvmtiEnv* jvmti, JNIEnv* jni) {
     _orig_RetransformClasses = functions->RetransformClasses;
     functions->RedefineClasses = RedefineClassesHook;
     functions->RetransformClasses = RetransformClassesHook;
-
-    // capture the 'stable' classloaders (calssloaders which will stay present for the duration of the process)
-    jclass clClass = jni->FindClass("java/lang/ClassLoader");
-
-    jmethodID getSystemClassLoaderMethod = jni->GetStaticMethodID(clClass, "getSystemClassLoader", "()Ljava/lang/ClassLoader;");
-    jobject localSystemClassLoader = jni->CallStaticObjectMethod(clClass, getSystemClassLoaderMethod);
-    jniExceptionCheck(jni);
-
-    jmethodID getPlatformClassLoaderMethod = jni->GetStaticMethodID(clClass, "getPlatformClassLoader", "()Ljava/lang/ClassLoader;");
-    if (jni->ExceptionCheck()) { // check if an exception occurred
-        jni->ExceptionClear(); // clear the exception
-        getPlatformClassLoaderMethod = NULL;
-    }
-    _global_system_classloader = jni->NewGlobalRef(localSystemClassLoader);
-    if (getPlatformClassLoaderMethod != nullptr) {
-        jobject localPlatformClassLoader = jni->CallStaticObjectMethod(clClass, getPlatformClassLoaderMethod);
-        jniExceptionCheck(jni);
-        _global_platform_classloader = jni->NewGlobalRef(localPlatformClassLoader);
-    }
 }
 
 void VM::applyPatch(char* func, const char* patch, const char* end_patch) {
@@ -414,17 +393,6 @@ void VM::restartProfiler() {
     Profiler::instance()->restart(_agent_args);
 }
 
-bool VM::isSystemClassLoader(JNIEnv* jni, jobject& cl) {
-    if (!cl) {
-        // bootstrap classloader
-        return true;
-    }
-    if (jni->IsSameObject(cl, _global_system_classloader) || (_global_platform_classloader && jni->IsSameObject(cl, _global_platform_classloader))) {
-        return true;
-    }
-    return false;
-}
-
 void JNICALL VM::VMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
     ready(jvmti, jni);
     loadAllMethodIDs(jvmti, jni);
@@ -438,10 +406,6 @@ void JNICALL VM::VMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
 
 void JNICALL VM::VMDeath(jvmtiEnv* jvmti, JNIEnv* jni) {
     Profiler::instance()->shutdown(_agent_args);
-    jni->DeleteGlobalRef(_global_system_classloader);
-    if (_global_platform_classloader) {
-        jni->DeleteGlobalRef(_global_platform_classloader);
-    }
 }
 
 jvmtiError VM::RedefineClassesHook(jvmtiEnv* jvmti, jint class_count, const jvmtiClassDefinition* class_definitions) {

--- a/ddprof-lib/src/main/cpp/vmEntry.h
+++ b/ddprof-lib/src/main/cpp/vmEntry.h
@@ -103,9 +103,6 @@ class VM {
     static bool _can_intercept_binding;
     static bool _is_adaptive_gc_boundary_flag_set;
 
-    static jobject _global_system_classloader;
-    static jobject _global_platform_classloader;
-
 
     static jvmtiError (JNICALL *_orig_RedefineClasses)(jvmtiEnv*, jint, const jvmtiClassDefinition*);
     static jvmtiError (JNICALL *_orig_RetransformClasses)(jvmtiEnv*, jint, const jclass* classes);
@@ -175,8 +172,6 @@ class VM {
     static bool isUseAdaptiveGCBoundarySet() {
         return _is_adaptive_gc_boundary_flag_set;
     }
-
-    static bool isSystemClassLoader(JNIEnv* jni, jobject& cl);
 
     static void JNICALL VMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);
     static void JNICALL VMDeath(jvmtiEnv* jvmti, JNIEnv* jni);

--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -23,6 +23,7 @@
 #include "j9Ext.h"
 #include "vector"
 #include "safeAccess.h"
+#include "jniHelper.h"
 
 
 CodeCache* VMStructs::_libjvm = NULL;
@@ -482,8 +483,10 @@ void VMStructs::initMemoryUsage(JNIEnv* env) {
     jclass memoryBeanClass = env->FindClass("java/lang/management/MemoryMXBean");
     jmethodID get_memory = env->GetStaticMethodID(factory, "getMemoryMXBean", "()Ljava/lang/management/MemoryMXBean;");
     jobject memoryBean = env->CallStaticObjectMethod(factory, get_memory);
+    jniExceptionCheck(env);
     jmethodID get_heap = env->GetMethodID(memoryBeanClass, "getHeapMemoryUsage", "()Ljava/lang/management/MemoryUsage;");
     env->CallObjectMethod(memoryBean, get_heap);
+    jniExceptionCheck(env);
 }
 
 VMThread* VMThread::current() {


### PR DESCRIPTION
**What does this PR do?**:
I discovered a couple of issues:
1. Messages like `WARNING in native method: JNI call made without checking exceptions when required to from CallXYZ` because we weren't checking the exception status in some places after JNI upcalls
2. We use too many local references which results in messages like `WARNING: JNI local refs: 72, exceeds capacity: 32`. This patch improves the situation, but doesn't fix it entirely. We need to be more careful about deleting local references explicitly to avoid build up, but this will take a while to fix.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
