### PR TITLE
add mode to omit line numbers to control overhead

### DIFF
--- a/ddprof-lib/src/main/cpp/arguments.cpp
+++ b/ddprof-lib/src/main/cpp/arguments.cpp
@@ -277,16 +277,10 @@ Error Arguments::parse(const char* args) {
                 }
 
             CASE("lightweight")
-                if (value != NULL) {
-                    switch (value[0]) {
-                        case 'y': // yes
-                        case 't': // true
-                            _lightweight = true;
-                            break;
-                        default:
-                            _lightweight = false;
-                    }
-                }
+                _lightweight = parseBool(value);
+
+            CASE("linenumbers")
+                _record_line_numbers = parseBool(value);
 
             DEFAULT()
                 if (_unknown_arg == NULL) _unknown_arg = arg;

--- a/ddprof-lib/src/main/cpp/arguments.h
+++ b/ddprof-lib/src/main/cpp/arguments.h
@@ -118,6 +118,13 @@ class Arguments {
     static long long hash(const char* arg);
     static long parseUnits(const char* str, const Multiplier* multipliers);
 
+    bool parseBool(const char* arg) {
+        if (arg) {
+            return arg[0] == 'y' || arg[0] == 't';
+        }
+        return false;
+    }
+
   public:
     Action _action;
     Ring _ring;
@@ -142,6 +149,8 @@ class Arguments {
     int _jfr_options;
     std::vector<std::string> _context_attributes;
     bool _lightweight;
+    bool _record_line_numbers;
+    bool _record_modifiers;
 
     Arguments(bool persistent = false) :
         _buf(NULL),
@@ -169,7 +178,8 @@ class Arguments {
         _cstack(CSTACK_DEFAULT),
         _jfr_options(0),
         _context_attributes({}),
-        _lightweight(false) {
+        _lightweight(false),
+        _record_line_numbers (true) {
     }
 
     ~Arguments();

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -143,7 +143,7 @@ void Lookup::fillJavaMethodInfo(MethodInfo* mi, jmethodID method, bool first_tim
             jvmti->GetClassSignature(method_class, &class_name, NULL) == 0 &&
             jvmti->GetMethodName(method, &method_name, &method_sig, NULL) == 0) {
 
-            if (first_time) {
+            if (first_time && _line_numbers) {
                 jvmti->GetLineNumberTable(method, &line_number_table_size, &line_number_table);
             }
 
@@ -899,7 +899,7 @@ void Recording::writeCpool(Buffer* buf) {
 
     // Profiler::instance()->classMap() provides access to non-locked _class_map instance
     // The non-locked access is ok here as this code will never run concurrently to _class_map.clear()
-    Lookup lookup(this, &_method_map, Profiler::instance()->classMap());
+    Lookup lookup(this, &_method_map, Profiler::instance()->classMap(), _args._record_line_numbers);
     writeFrameTypes(buf);
     writeThreadStates(buf);
     writeExecutionModes(buf);

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -251,6 +251,7 @@ class Lookup {
     Dictionary* _classes;
     Dictionary _packages;
     Dictionary _symbols;
+    bool _line_numbers;
 
   private:
     void fillNativeMethodInfo(MethodInfo* mi, const char* name, const char* lib_name);
@@ -261,8 +262,8 @@ class Lookup {
     }
 
   public:
-    Lookup(Recording* rec, MethodMap* method_map, Dictionary* classes) :
-        _rec(rec), _method_map(method_map), _classes(classes), _packages(), _symbols() {}
+    Lookup(Recording* rec, MethodMap* method_map, Dictionary* classes, bool line_numbers) :
+        _rec(rec), _method_map(method_map), _classes(classes), _packages(), _symbols(), _line_numbers(line_numbers) {}
 
     MethodInfo* resolveMethod(ASGCT_CallFrame& frame);
     u32 getPackage(const char* class_name);

--- a/ddprof-lib/src/main/cpp/vmEntry.h
+++ b/ddprof-lib/src/main/cpp/vmEntry.h
@@ -33,6 +33,7 @@
 // Denotes ASGCT_CallFrame where method_id has special meaning (not jmethodID)
 enum ASGCT_CallFrameType {
     BCI_CPU                 =   0,  // cpu time
+    BCI_OMITTED             =  -1,  // intentionally omitted
     BCI_WALL                = -10,  // wall time
     BCI_NATIVE_FRAME        = -11,  // native function name (char*)
     BCI_ALLOC               = -12,  // name of the allocated class

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/NoLineNumbersContextCpuTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/NoLineNumbersContextCpuTest.java
@@ -1,0 +1,28 @@
+package com.datadoghq.profiler.cpu;
+
+import com.datadoghq.profiler.AbstractProfilerTest;
+import com.datadoghq.profiler.Platform;
+import org.junit.jupiter.api.Assumptions;
+import org.junitpioneer.jupiter.RetryingTest;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.item.IItemIterable;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import static com.datadoghq.profiler.MoreAssertions.assertInRange;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NoLineNumbersContextCpuTest extends ContextCpuTest {
+
+
+    @Override
+    protected String getProfilerCommand() {
+        return "cpu=1us,linenumbers=false";
+    }
+}


### PR DESCRIPTION
**What does this PR do?**:
Create a mode where the user can choose to opt out of line numbers, which reduces the number of distinct stack traces, reducing the size of call trace storage and shortening the loop over the stack traces during symbolisation. This needs to be wired up from the Java agent before it can be used.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
