### PR TITLE
fix cpu interval config

### DIFF
--- a/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
+++ b/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
@@ -812,7 +812,7 @@ Error PerfEvents::start(Arguments& args) {
         return Error("Could not set pthread hook");
     }
 
-    int interval = args._event != NULL ? args._interval : args._cpu;
+    int interval = args._cpu > 0 ? args._cpu : (args._event != NULL && args._event != EVENT_CPU) ? args._interval : 0;
     if (interval < 0) {
         return Error("interval must be positive");
     }


### PR DESCRIPTION
**What does this PR do?**:
The event can get defaulted to `EVENT_CPU` at the end of parsing the arguments:

```cpp
if (_event == NULL && _cpu < 0 && _wall < 0 && _memory < 0) {
        _event = EVENT_CPU;
    }
```
so the null check may result in reading the interval, which is zero, which results in using the default period of 10ms cpu time.
**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
