### PR TITLE
Fix the live sample table cleanup

### DIFF
--- a/ddprof-lib/src/main/cpp/livenessTracker.h
+++ b/ddprof-lib/src/main/cpp/livenessTracker.h
@@ -68,7 +68,7 @@ class LivenessTracker  {
     Error initialize(Arguments& args);
     Error initialize_table(int sampling_interval);
 
-    void cleanup_table();
+    void cleanup_table(bool force = false);
 
     void flush_table(std::set<int> *tracked_thread_ids);
 


### PR DESCRIPTION
**What does this PR do?**:
It makes sure that the live sample table cleanup does not remove too many entries

**Motivation**:
Hacking generation count metric in profiling backend

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] Attached JIRA ticket: PROF-8477

Unsure? Have a question? Request a review!
