### PR TITLE
Fix fall-through on 'stop' action

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1260,7 +1260,7 @@ Error Profiler::runInternal(Arguments& args, std::ostream& out) {
         }
         case ACTION_STOP: {
             Error error = stop();
-            // Fall through
+            break;
         }
 
         case ACTION_CHECK: {


### PR DESCRIPTION
**What does this PR do?**:
Fixes the unexpected fall-through

**Motivation**:
Fixing the unexpected output when shutting down a profiled applications

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
- [x] JIRA Ticket: [PROF-8512](https://datadoghq.atlassian.net/browse/PROF-8512)

Unsure? Have a question? Request a review!


[PROF-8512]: https://datadoghq.atlassian.net/browse/PROF-8512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ