### PR TITLE
Improve the robustness of jmethodid checks

### DIFF
--- a/ddprof-lib/src/main/cpp/jniHelper.h
+++ b/ddprof-lib/src/main/cpp/jniHelper.h
@@ -3,13 +3,15 @@
 
 #include <jni.h>
 
-static void jniExceptionCheck(JNIEnv* jni, bool describe = false) {
+static bool jniExceptionCheck(JNIEnv* jni, bool describe = false) {
     if(jni->ExceptionCheck()) {
         if (describe) {
             jni->ExceptionDescribe();
         }
         jni->ExceptionClear();
+        return true;
     }
+    return false;
 }
 
 #endif

--- a/ddprof-lib/src/main/cpp/livenessTracker.h
+++ b/ddprof-lib/src/main/cpp/livenessTracker.h
@@ -66,7 +66,7 @@ class LivenessTracker  {
     size_t _used_after_last_gc;
 
     Error initialize(Arguments& args);
-    Error initialize_table(int sampling_interval);
+    Error initialize_table(JNIEnv* jni, int sampling_interval);
 
     void cleanup_table(bool force = false);
 

--- a/ddprof-lib/src/main/cpp/tsc.cpp
+++ b/ddprof-lib/src/main/cpp/tsc.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <jvmti.h>
+#include "jniHelper.h"
 #include "tsc.h"
 #include "vmEntry.h"
 
@@ -37,6 +38,9 @@ void TSC::initialize() {
             && ((counterTime = env->GetStaticMethodID(cls, "counterTime", "()J")) != NULL)) {
 
         u64 frequency = env->CallLongMethod(env->GetStaticObjectField(cls, jvm), getTicksFrequency);
+        if (jniExceptionCheck(env, true)) {
+            frequency = 0;
+        }
         if (frequency > 1000000000) {
             // Default 1GHz frequency might mean that rdtsc is not available
             u64 jvm_ticks = env->CallStaticLongMethod(cls, counterTime);

--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -97,6 +97,7 @@ VMStructs::HeapUsageFunc VMStructs::_heap_usage_func = NULL;
 VMStructs::MemoryUsageFunc VMStructs::_memory_usage_func = NULL;
 VMStructs::GCHeapSummaryFunc VMStructs::_gc_heap_summary_func = NULL;
 VMStructs::FindFlagFunc VMStructs::_find_flag_func = NULL;
+VMStructs::IsValidMethodFunc VMStructs::_is_valid_method_func = NULL;
 
 void** VMStructs::_collected_heap_addr = NULL;
 
@@ -412,6 +413,7 @@ void VMStructs::initJvmFunctions() {
     _find_flag_func =(FindFlagFunc) _libjvm->findSymbol("_ZN7JVMFlag9find_flagEPKcmbb");
     _heap_usage_func = (HeapUsageFunc) findHeapUsageFunc();
     _gc_heap_summary_func = (GCHeapSummaryFunc)_libjvm->findSymbol("_ZN13CollectedHeap19create_heap_summaryEv");
+    _is_valid_method_func = (IsValidMethodFunc)_libjvm->findSymbol("_ZN6Method15is_valid_methodEPKS_");
     initUnsafeFunctions();
 }
 
@@ -542,8 +544,14 @@ bool VMMethod::check_jmethodID(jmethodID id) {
 
 bool VMMethod::check_jmethodID_hotspot(jmethodID id) {
     const char* method_ptr = (const char*) SafeAccess::load((void**) id);
-    if (method_ptr == NULL) {
+    // check for NULL ptr and 'empty' ptr (JNIMethodBlock::_free_method)
+    if (method_ptr == NULL || (size_t)method_ptr == 55) {
         return false;
+    }
+    if (_is_valid_method_func != NULL) {
+        if (!_is_valid_method_func((void*)method_ptr)) {
+            return false;
+        }
     }
     // we can only perform the extended validity check if there are expected vmStructs in place
 

--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -395,7 +395,8 @@ const void* VMStructs::findHeapUsageFunc() {
             return _libjvm->findSymbol("_ZN15G1CollectedHeap12memory_usageEv");
         } else if (isFlagTrue("UseShenandoahGC")) {
             return _libjvm->findSymbol("_ZN14ShenandoahHeap12memory_usageEv");
-        } else if (isFlagTrue("UseZGC")) {
+        } else if (isFlagTrue("UseZGC") && VM::java_version() < 21) {
+            // acessing this method in JDK 21 (generational ZGC) wil cause SIGSEGV 
             return _libjvm->findSymbol("_ZN14ZCollectedHeap12memory_usageEv");
         }
     }

--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -23,7 +23,6 @@
 #include "j9Ext.h"
 #include "vector"
 #include "safeAccess.h"
-#include "jniHelper.h"
 
 
 CodeCache* VMStructs::_libjvm = NULL;

--- a/ddprof-lib/src/main/cpp/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/vmStructs.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "codeCache.h"
+#include "jniHelper.h"
 #include "jvmHeap.h"
 #include "vmEntry.h"
 #include "threadState.h"
@@ -455,22 +456,26 @@ class HeapUsage : VMStructs {
         static jmethodID _max_memory;
 
         if (!(_rt = env->FindClass("java/lang/Runtime"))) {
-            env->ExceptionDescribe();
+            jniExceptionCheck(env);
             return -1;
         }
 
         if (!(_get_rt = env->GetStaticMethodID(_rt, "getRuntime", "()Ljava/lang/Runtime;"))) {
-            env->ExceptionDescribe();
+            jniExceptionCheck(env);
             return -1;
         }
 
         if (!(_max_memory = env->GetMethodID(_rt, "maxMemory", "()J"))) {
-            env->ExceptionDescribe();
+            jniExceptionCheck(env);
             return -1;
         }
 
         jobject rt = (jobject)env->CallStaticObjectMethod(_rt, _get_rt);
-        return (jlong)env->CallLongMethod(rt, _max_memory);
+        jlong ret = (jlong)env->CallLongMethod(rt, _max_memory);
+        if (jniExceptionCheck(env)) {
+            return -1;
+        }
+        return ret;
     }
 
     static HeapUsage get() {

--- a/ddprof-lib/src/main/cpp/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/vmStructs.h
@@ -449,6 +449,30 @@ class HeapUsage : VMStructs {
         return _collected_heap_addr == NULL || (_heap_usage_func == NULL && _gc_heap_summary_func == NULL);
     }
 
+    static jlong getMaxHeap(JNIEnv* env) {      
+        static jclass _rt;
+        static jmethodID _get_rt;
+        static jmethodID _max_memory;
+
+        if (!(_rt = env->FindClass("java/lang/Runtime"))) {
+            env->ExceptionDescribe();
+            return -1;
+        }
+
+        if (!(_get_rt = env->GetStaticMethodID(_rt, "getRuntime", "()Ljava/lang/Runtime;"))) {
+            env->ExceptionDescribe();
+            return -1;
+        }
+
+        if (!(_max_memory = env->GetMethodID(_rt, "maxMemory", "()J"))) {
+            env->ExceptionDescribe();
+            return -1;
+        }
+
+        jobject rt = (jobject)env->CallStaticObjectMethod(_rt, _get_rt);
+        return (jlong)env->CallLongMethod(rt, _max_memory);
+    }
+
     static HeapUsage get() {
         return get(true);
     }

--- a/ddprof-lib/src/main/cpp/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/vmStructs.h
@@ -110,6 +110,9 @@ class VMStructs {
     typedef void* (*FindFlagFunc)(const char*, size_t, bool, bool);
     static FindFlagFunc _find_flag_func;
 
+    typedef bool (*IsValidMethodFunc)(void*);
+    static IsValidMethodFunc _is_valid_method_func;
+
     static uintptr_t readSymbol(const char* symbol_name);
     static void initOffsets();
     static void resolveOffsets();

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
**What does this PR do?**:
It is using a public function `Method::is_valid_method(method)` to avoid trying to resolve a jmethodid pointing to an invalid method.

**Motivation**:
Reduce (and possibly eliminate) the likelihood of JVM crashes due to jmethodid pointing to a partially cleaned (invalid) `Method` object.

**Additional notes**:
I had to modify the code for retrieving the heap usage as JDK 21 with generational ZGC is very unhappy about using the internal function which is working well for pre-JDK21 ZGC implementations.

**How to test the change?**:
It is not easy to trigger the condition with a partially cleaned method and I used an internal project's test suite which is using an extraordinary amount of mocked classes triggering a lot of class unloads for lambda forms.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-8526](https://datadoghq.atlassian.net/browse/PROF-8526)

Unsure? Have a question? Request a review!


[PROF-8526]: https://datadoghq.atlassian.net/browse/PROF-8526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ