### PR TITLE
fix async sample mutex

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -36,8 +36,6 @@
 #include "vmEntry.h"
 #include "objectSampler.h"
 #include "thread.h"
-#include "vmStructs.h"
-#include "stackFrame.h"
 
 // avoid linking against newer symbols here for wide compatibility
 #ifdef __GLIBC__
@@ -45,12 +43,6 @@
     __asm__(".symver log,log@GLIBC_2.17");
     __asm__(".symver exp,exp@GLIBC_2.17");
     #endif
-#endif
-
-#ifdef __clang__
-#  define NOINLINE __attribute__((noinline))
-#else
-#  define NOINLINE __attribute__((noinline,noclone))
 #endif
 
 const int MAX_NATIVE_FRAMES = 128;
@@ -193,10 +185,6 @@ class Profiler {
     Engine* selectWallEngine(Arguments& args);
     Engine* selectAllocEngine(Arguments& args);
     Error checkJvmCapabilities();
-    NOINLINE void getJavaTraceAsyncRetryPopStub(void* ucontext, ASGCT_CallTrace* trace, int max_depth, CodeBlob* stub, StackFrame& frame);
-    NOINLINE void getJavaTraceAsyncRetryPopMethod(void* ucontext, ASGCT_CallTrace* trace, int max_depth, CodeBlob* stub, StackFrame& frame, NMethod* nmethod);
-    NOINLINE void getJavaTraceAsyncRetryMakeFrameWalkable(void* ucontext, ASGCT_CallTrace* trace, int max_depth, VMThread* vm_thread);
-    NOINLINE void getJavaTraceAsyncRetryInvalidRuntimeStubFrameCompleteOffset(void* ucontext, ASGCT_CallTrace* trace, int max_depth, VMThread* vm_thread);
 
     void lockAll();
     void unlockAll();

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -85,7 +85,9 @@ public:
     }
     AsyncSampleMutex(AsyncSampleMutex& other) = delete;
     ~AsyncSampleMutex() {
-        try_set(false);
+        if (_acquired) {
+            try_set(false);
+        }
     }
     bool acquired() {
         return _acquired;


### PR DESCRIPTION
**What does this PR do?**:
Some regressions emerged after merging #43 
1. the thread local mutex behaviour is wrong when the the mutex isn't acquired successfully
2. I just encountered a SIGSEGV in `C  [libjavaProfiler10944739960193922920.so+0x44848]  Profiler::getJavaTraceAsyncRetryPopStub(void*, ASGCT_CallTrace*, int, CodeBlob*, StackFrame&)+0x40` locally

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
