### PR TITLE
finer grained async sample mutex

### DIFF
--- a/ddprof-lib/src/main/cpp/itimer.cpp
+++ b/ddprof-lib/src/main/cpp/itimer.cpp
@@ -29,10 +29,6 @@ CStack ITimer::_cstack;
 
 void ITimer::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     if (!_enabled) return;
-    AsyncSampleMutex mutex;
-    if (!mutex.acquired()) {
-        return;
-    }
     int tid = 0;
     ProfiledThread* current = ProfiledThread::current();
     if (current != NULL) {

--- a/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
+++ b/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
@@ -702,10 +702,6 @@ void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
         // Looks like an external signal; don't treat as a profiling event
         return;
     }
-    AsyncSampleMutex mutex;
-    if (!mutex.acquired()) {
-        return;
-    }
 
     ProfiledThread* current = ProfiledThread::current();
     if (current != NULL) {

--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -57,10 +57,6 @@ void WallClock::sharedSignalHandler(int signo, siginfo_t* siginfo, void* ucontex
 }
 
 void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext, u64 last_sample) {
-    AsyncSampleMutex mutex;
-    if (!mutex.acquired()) {
-        return;
-    }
     ProfiledThread* current = ProfiledThread::current();
     int tid = current != NULL ? current->tid() : OS::threadId();
     Shims::instance().setSighandlerTid(tid);


### PR DESCRIPTION
**What does this PR do?**:
The mutex at the signal handler level is too coarse and we just need to prevent interrupting AsyncGetCallTrace. At this coarse level, in CPU bound workloads, the wallclock profiler can starve the CPU profiler.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
