### PR TITLE
Do not do detailed jmethodID validity check on J9

### DIFF
--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -588,44 +588,8 @@ bool VMMethod::check_jmethodID_hotspot(jmethodID id) {
 }
 
 bool VMMethod::check_jmethodID_J9(jmethodID id) {
-    /*
-    The id can be cast to J9JNIMethodID*
-    The J9JNIMethodID structure is:
-    - J9Method* method
-    - UDATA vTableIndex
-    */
-    void* j9methodIDPtr = SafeAccess::load((void**) id); //*(void**)id;
-    if (j9methodIDPtr == nullptr) {
-        return false;
-    }
-
-    void* j9methodPtr = SafeAccess::load((void**) j9methodIDPtr); //*(void**)j9methodIDPtr;
-
-    if (j9methodPtr == nullptr) {
-        return false;
-    }
-
-    /*
-    The J9Method structure:
-    - U_8* bytecodes
-	- J9ConstantPool* constantPool
-	- void* methodRunAddress
-    */
-    void* constantPoolPtr = SafeAccess::load((void**) j9methodPtr + 1);
-    if (constantPoolPtr == nullptr) {
-        return false;
-    }
-
-    /*
-    The J9ConstantPool structure:
-    - J9Class* ramClass;
-	- J9ROMConstantPoolItem* romConstantPool;
-    */
-    void* ramClassPtr = SafeAccess::load((void**) constantPoolPtr);
-    if (ramClassPtr == nullptr) {
-        return false;
-    }
-    return true;
+    // the J9 jmethodid check is not working properly, so we just check for NULL
+    return id != NULL && *((void**)id) != NULL;
 }
 
 NMethod* CodeHeap::findNMethod(char* heap, const void* pc) {

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/SmokeCpuTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/SmokeCpuTest.java
@@ -1,0 +1,53 @@
+package com.datadoghq.profiler.cpu;
+
+import com.datadoghq.profiler.AbstractProfilerTest;
+import org.junitpioneer.jupiter.RetryingTest;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.item.IItemIterable;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import com.datadoghq.profiler.Platform;
+
+public class SmokeCpuTest extends AbstractProfilerTest {
+    private ProfiledCode profiledCode;
+
+    @Override
+    protected void before() {
+        profiledCode = new ProfiledCode(profiler);
+    }
+
+    @RetryingTest(10)
+    public void test() throws ExecutionException, InterruptedException {
+        for (int i = 0, id = 1; i < 100; i++, id += 3) {
+            profiledCode.method1(id);
+        }
+        stopProfiler();
+        IItemCollection events = verifyEvents("datadog.ExecutionSample");
+
+        // on mac the usage of itimer to drive the sampling provides very unreliable outputs
+        if (!Platform.isMac()) {
+            for (IItemIterable cpuSamples : events) {
+                IMemberAccessor<String, IItem> frameAccessor = JdkAttributes.STACK_TRACE_STRING.getAccessor(cpuSamples.getType());
+                for (IItem sample : cpuSamples) {
+                    String stackTrace = frameAccessor.getMember(sample);
+                    assertFalse(stackTrace.contains("jvmtiError"));
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void after() throws Exception {
+        profiledCode.close();
+    }
+
+    @Override
+    protected String getProfilerCommand() {
+        return "cpu=10ms";
+    }
+}


### PR DESCRIPTION
**What does this PR do?**:
The change is to replace the detailed but buggy `jmethodID` check on J9 with just sanity NULL checks.

**Motivation**:
Most of the frames from J9 stacktraces are not resolved because the check marks the associated `jmethodID` as invalid.

**Additional Notes**:
Added a smoke CPU test because most of our tests are context related and excluded on J9. Therefore, this regression was not caught as soon as it was introduced.

**How to test the change?**:
A unit test failing before the fix and passing after the fix is provided.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] Jira ticket: [PROF-8660]

Unsure? Have a question? Request a review!


[PROF-8660]: https://datadoghq.atlassian.net/browse/PROF-8660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ