### PR TITLE
do not call AGCT when VM is in blocked state

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -403,6 +403,10 @@ int Profiler::getJavaTraceAsync(void* ucontext, ASGCT_CallFrame* frames, int max
         _thread_max_state         = 12  // maximum thread state+1 - used for statistics allocation
     };
      */
+    // avoid unwinding during deoptimization
+    if (_state == 10 || _state == 11) {
+        return 0;
+    }
     bool in_java = (state == 8 || state == 9);
     if (in_java && java_ctx->sp != 0) {
         // skip ahead to the Java frames before calling AGCT


### PR DESCRIPTION
**What does this PR do?**:
This avoids calling AsyncGetCallTrace when the JVM is at a safepoint or doing deoptimization.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
