### PR TITLE
check thread is in runnable state before checking if VM is blocked

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -404,7 +404,7 @@ int Profiler::getJavaTraceAsync(void* ucontext, ASGCT_CallFrame* frames, int max
     };
      */
     // avoid unwinding during deoptimization
-    if (_state == 10 || _state == 11) {
+    if (vm_thread->osThreadState() == ThreadState::RUNNABLE && (_state == 10 || _state == 11)) {
         return 0;
     }
     bool in_java = (state == 8 || state == 9);


### PR DESCRIPTION
**What does this PR do?**:
The VM blocked check is a bit too strict because it hides all parked threads from the wallclock profiler, so check if the thread is runnable to be a bit more precise.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
