### PR TITLE
Do not fail if requested cstack is not supported

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1041,9 +1041,11 @@ Error Profiler::start(Arguments& args, bool reset) {
     _wall_engine = selectWallEngine(args);
     _cstack = args._cstack;
     if (_cstack == CSTACK_DWARF && !DWARF_SUPPORTED) {
-        return Error("DWARF unwinding is not supported on this platform");
+        _cstack = CSTACK_NO;
+        Log::warn("DWARF unwinding is not supported on this platform. Defaulting to no native call stack unwinding.");
     } else if (_cstack == CSTACK_LBR && _cpu_engine != &perf_events) {
-        return Error("Branch stack is supported only with PMU events");
+        _cstack = CSTACK_NO;
+        Log::warn("Branch stack is supported only with PMU events");
     }
 
     // Kernel symbols are useful only for perf_events without --all-user


### PR DESCRIPTION
**What does this PR do?**:
It relaxes the checks for the validity of the requested 'cstack' value.
If the requested stack unwinding is not available default to 'no' and log a warning instead of disabling profiling.

**Motivation**:
The motivation is to be more lenient in cases when eg. the recomended `cstack=dwarf` is used but DWARF is not available.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA Ticket: PROF-8707

Unsure? Have a question? Request a review!
