### PR TITLE
Use the VM thread state to check for deopt

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -404,7 +404,7 @@ int Profiler::getJavaTraceAsync(void* ucontext, ASGCT_CallFrame* frames, int max
     };
      */
     // avoid unwinding during deoptimization
-    if (vm_thread->osThreadState() == ThreadState::RUNNABLE && (_state == 10 || _state == 11)) {
+    if (vm_thread->osThreadState() == ThreadState::RUNNABLE && (state == 10 || state == 11)) {
         return 0;
     }
     bool in_java = (state == 8 || state == 9);


### PR DESCRIPTION
**What does this PR do?**:
Fixes the usage of an incorrect variable

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
