### PR TITLE
Sanchda/rust demangling

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -85,8 +85,8 @@ void Lookup::fillNativeMethodInfo(MethodInfo* mi, const char* name, const char* 
             mi->_type = FRAME_CPP;
 
             // Rust legacy demangling
-            if (rustDemangler::is_probably_rust_legacy(demangled)) {
-                std::string rust_demangled = rustDemangler::demangle(demangled);
+            if (RustDemangler::is_probably_rust_legacy(demangled)) {
+                std::string rust_demangled = RustDemangler::demangle(demangled);
                 mi->_name = _symbols.lookup(rust_demangled.c_str());
             } else {
                 mi->_name = _symbols.lookup(demangled);

--- a/ddprof-lib/src/main/cpp/rustDemangler.cpp
+++ b/ddprof-lib/src/main/cpp/rustDemangler.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2021, 2023 Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "rustDemangler.h"
+
+#include <array>
+
+using namespace RustDemangler;
+
+// With some exceptions we don't handle here, v0 Rust symbols can end in a
+// prefix followed by a 16-hexdigit hash, which must be removed
+const std::string hash_pre = "::h";
+const std::string hash_eg = "0123456789abcdef";
+
+const std::array<std::pair<std::string, std::string>, 9> patterns = {{
+    {"..", "::"},
+    {"$C$", ","},
+    {"$BP$", "*"},
+    {"$GT$", ">"},
+    {"$LT$", "<"},
+    {"$LP$", "("},
+    {"$RP$", ")"},
+    {"$RF$", "&"},
+    {"$SP$", "@"},
+}};
+
+inline bool is_hexdig(const char c) {
+  return (c >= 'a' && c <= 'f') || (c >= '0' && c <= '9');
+}
+
+// Simple conversion from hex digit to integer
+inline int hex_to_int(char dig) {
+  constexpr int k_a_hex_value = 0xa;
+  if (dig >= '0' && dig <= '9') {
+    return dig - '0';
+  }
+  if (dig >= 'a' && dig <= 'f') {
+    return dig - 'a' + k_a_hex_value;
+  }
+  if (dig >= 'A' && dig <= 'F') {
+    return dig - 'A' + k_a_hex_value;
+  }
+  return -1;
+}
+
+// Minimal check that a string can end, and does end, in a hashlike substring
+inline bool has_hash(const std::string &str) {
+  // If the size can't conform, then the string is invalid
+  if (str.size() <= hash_pre.size() + hash_eg.size()) {
+    return false;
+  }
+
+  // Check that the string contains the hash prefix in the right position
+  if (str.compare(str.size() - hash_eg.size() - hash_pre.size(),
+                  hash_pre.size(), hash_pre)) {
+    return false;
+  }
+
+  // Check that the string ends in lowercase hex digits
+  for (size_t i = str.size() - hash_eg.size(); i < str.size(); ++i) {
+    if (!is_hexdig(str[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool is_probably_rust_legacy(const std::string &str) {
+  // Is the string too short to have a hash part in thefirst place?
+  if (!has_hash(str)) {
+    return false;
+  }
+
+  // Throw out `$$` and `$????$`, but not in-between
+  const char *ptr = str.data();
+  const char *end = ptr + str.size() - hash_pre.size() - hash_eg.size();
+  for (; ptr <= end; ++ptr) {
+    if (*ptr == '$') {
+      if (ptr[1] == '$') {
+        return false;
+      }
+      return ptr[2] == '$' || ptr[3] == '$' || ptr[4] == '$';
+    }
+    if (*ptr == '.') {
+      return '.' != ptr[1] ||
+          '.' != ptr[2]; // '.' and '..' are fine, '...' is not
+    }
+  }
+  return true;
+}
+
+// Demangles a Rust string by building a copy piece-by-piece
+std::string demangle(const std::string &str) {
+  std::string ret;
+  ret.reserve(str.size() - hash_eg.size() - hash_pre.size());
+
+  size_t i = 0;
+
+  // Special-case for repairing C++ demangling defect for Rust
+  if (str[0] == '_' && str[1] == '$') {
+    ++i;
+  }
+
+  for (; i < str.size() - hash_pre.size() - hash_eg.size(); ++i) {
+
+    // Fast sieve for pattern-matching, since we know first chars
+    if (str[i] == '.' || str[i] == '$') {
+      bool replaced = false;
+
+      // Try to replace one of the patterns
+      for (const auto &pair : patterns) {
+        const std::string &pattern = pair.first;
+        const std::string &replacement = pair.second;
+        if (!str.compare(i, pattern.size(), pattern)) {
+          ret += replacement;
+          i += pattern.size() - 1; // -1 because iterator inc
+          replaced = true;
+          break;
+        }
+      }
+
+      // If we failed to replace, try a few failovers.  Notably, we recognize
+      // that Rust may insert Unicode code points in the function name (other
+      // implementations treat many individual points as patterns to search on)
+      if (!replaced && str[i] == '.') {
+        // Special-case for '.'
+        ret += '-';
+      } else if (!replaced && !str.compare(i, 2, "$u") && str[i + 4] == '$') {
+        const size_t k_nb_read_chars = 5;
+        const int hexa_base = 16;
+        const int hi = hex_to_int(str[i + 2]);
+        const int lo = hex_to_int(str[i + 3]);
+        if (hi != -1 && lo != -1) {
+          ret += static_cast<unsigned char>(lo + hexa_base * hi);
+          i += k_nb_read_chars - 1; // - 1 because iterator inc
+        } else {
+          // We didn't have valid unicode values, but we should still skip
+          // the $u??$ sequence
+          ret += str.substr(i, k_nb_read_chars);
+          i += k_nb_read_chars - 1; // -1 because iterator inc
+        }
+      } else if (!replaced) {
+        ret += str[i];
+      }
+    } else {
+      ret += str[i];
+    }
+  }
+
+  return ret;
+}

--- a/ddprof-lib/src/main/cpp/rustDemangler.cpp
+++ b/ddprof-lib/src/main/cpp/rustDemangler.cpp
@@ -148,8 +148,8 @@ std::string demangle(const std::string &str) {
           ret += static_cast<unsigned char>(lo + hexa_base * hi);
           i += k_nb_read_chars - 1; // - 1 because iterator inc
         } else {
-          // We didn't have valid unicode values, but we should still skip
-          // the $u??$ sequence
+          // We didn't have valid unicode values.  No further processing is
+          // done, reinsert the `$u...$` sequence into the output string.
           ret += str.substr(i, k_nb_read_chars);
           i += k_nb_read_chars - 1; // -1 because iterator inc
         }

--- a/ddprof-lib/src/main/cpp/rustDemangler.cpp
+++ b/ddprof-lib/src/main/cpp/rustDemangler.cpp
@@ -19,7 +19,7 @@
 
 #include <array>
 
-using namespace RustDemangler;
+namespace RustDemangler {
 
 // With some exceptions we don't handle here, v0 Rust symbols can end in a
 // prefix followed by a 16-hexdigit hash, which must be removed
@@ -163,3 +163,4 @@ std::string demangle(const std::string &str) {
 
   return ret;
 }
+} // namespace RustDemangler

--- a/ddprof-lib/src/main/cpp/rustDemangler.h
+++ b/ddprof-lib/src/main/cpp/rustDemangler.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021, 2023 Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <string>
+
+namespace RustDemangler {
+  bool is_probably_rust_legacy(const std::string &str);
+  std::string demangle(const std::string &str);
+}; // namespace RustDemangler
+
+

--- a/ddprof-lib/src/test/CMakeLists.txt
+++ b/ddprof-lib/src/test/CMakeLists.txt
@@ -46,6 +46,7 @@ file(GLOB_RECURSE TEST_FILES CONFIGURE_DEPENDS
 file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
     "${PROJECT_SOURCE_DIR}/../main/cpp/os_${OS_SUFFIX}.cpp"
     "${PROJECT_SOURCE_DIR}/../main/cpp/context.cpp"
+    "${PROJECT_SOURCE_DIR}/../main/cpp/rustDemangler.cpp"
     "${PROJECT_SOURCE_DIR}/../main/cpp/counters.cpp"
     "${PROJECT_SOURCE_DIR}/../main/cpp/threadFilter.cpp"
     "${PROJECT_SOURCE_DIR}/../main/cpp/dictionary.cpp"

--- a/ddprof-lib/src/test/cpp/demangle_ut.cpp
+++ b/ddprof-lib/src/test/cpp/demangle_ut.cpp
@@ -1,0 +1,183 @@
+#include <gtest/gtest.h>
+
+#include "rustDemangler.h"
+
+#include <cxxabi.h>
+
+struct DemangleTestContent {
+  std::string test;
+  std::string answer;
+};
+
+// Partly borrowed from the LLVM unit tests
+std::vector<struct DemangleTestContent> s_demangle_cases = {
+    {"_", "_"},
+    {"_Z3fooi", "foo(int)"},
+    {"_RNvC3foo3bar", "foo::bar"},
+    {"_ZN4llvm4yaml7yamlizeISt6vectorINSt7__cxx1112basic_stringIcSt11char_"
+     "traitsIcESaIcEEESaIS8_EENS0_12EmptyContextEEENSt9enable_ifIXsr18has_"
+     "SequenceTraitsIT_EE5valueEvE4typeERNS0_2IOERSD_bRT0_",
+     "std::enable_if<has_SequenceTraits<std::vector<std::__cxx11::basic_string<"
+     "char, std::char_traits<char>, std::allocator<char> >, "
+     "std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, "
+     "std::allocator<char> > > > >::value, void>::type "
+     "llvm::yaml::yamlize<std::vector<std::__cxx11::basic_string<char, "
+     "std::char_traits<char>, std::allocator<char> >, "
+     "std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, "
+     "std::allocator<char> > > >, llvm::yaml::EmptyContext>(llvm::yaml::IO&, "
+     "std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, "
+     "std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, "
+     "std::char_traits<char>, std::allocator<char> > > >&, bool, "
+     "llvm::yaml::EmptyContext&)"},
+    {"_ZWowThisIsWrong", "_ZWowThisIsWrong"},
+
+    // Following cases were taken by the libiberty project and are used here
+    // with recognition
+    {"_ZN4main4main17he714a2e23ed7db23E", "main::main"},
+    {"_ZN4main4main17he714a2e23ed7db23E", "main::main"},
+    {"_ZN4main4main18h1e714a2e23ed7db23E", "main::main::h1e714a2e23ed7db23"},
+    {"_ZN4main4main16h714a2e23ed7db23E", "main::main::h714a2e23ed7db23"},
+    {"_ZN4main4main17he714a2e23ed7db2gE", "main::main::he714a2e23ed7db2g"},
+    {"_ZN4main4$99$17he714a2e23ed7db23E", "main::$99$"},
+    {"_ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$"
+     "GT$3bar17h930b740aa94f1d3aE",
+     "<Test + 'static as foo::Bar<Test>>::bar"},
+    {"_ZN54_$LT$I$u20$as$u20$core..iter..traits..IntoIterator$GT$9into_"
+     "iter17h8581507801fb8615E",
+     "<I as core::iter::traits::IntoIterator>::into_iter"},
+    {"_ZN10parse_tsan4main17hdbbfdf1c6a7e27d9E", "parse_tsan::main"},
+    {"_ZN65_$LT$std..env..Args$u20$as$u20$core..iter..iterator..Iterator$GT$"
+     "4next17h420a7c8d0c7eef40E",
+     "<std::env::Args as core::iter::iterator::Iterator>::next"},
+    {"_ZN4core3str9from_utf817hdcea28871313776dE", "core::str::from_utf8"},
+    {"_ZN4core3mem7size_of17h18bde9bb8c22e2cfE", "core::mem::size_of"},
+    {"_ZN5alloc4heap8allocate17hd55c03e6cb81d924E", "alloc::heap::allocate"},
+    {"_ZN4core3ptr8null_mut17h736cce09ca0ac11aE", "core::ptr::null_mut"},
+    {"_ZN40_$LT$alloc..raw_vec..RawVec$LT$T$GT$$GT$6double17h4166e2b47539e1ffE",
+     "<alloc::raw_vec::RawVec<T>>::double"},
+    {"_ZN39_$LT$collections..vec..Vec$LT$T$GT$$GT$4push17hd4b6b23c1b88141aE",
+     "<collections::vec::Vec<T>>::push"},
+    {"_ZN70_$LT$collections..vec..Vec$LT$T$GT$$u20$as$u20$core..ops..DerefMut$"
+     "GT$9deref_mut17hf299b860dc5a831cE",
+     "<collections::vec::Vec<T> as core::ops::DerefMut>::deref_mut"},
+    {"_ZN63_$LT$core..ptr..Unique$LT$T$GT$$u20$as$u20$core..ops..Deref$GT$"
+     "5deref17hc784b4a166cb5e5cE",
+     "<core::ptr::Unique<T> as core::ops::Deref>::deref"},
+    {"_ZN40_$LT$alloc..raw_vec..RawVec$LT$T$GT$$GT$3ptr17h7570b6e9070b693bE",
+     "<alloc::raw_vec::RawVec<T>>::ptr"},
+    {"_ZN53_$LT$$u5b$T$u5d$$u20$as$u20$core..slice..SliceExt$GT$10as_mut_"
+     "ptr17h153241df1c7d1666E",
+     "<[T] as core::slice::SliceExt>::as_mut_ptr"},
+    {"_ZN4core3ptr5write17h651fe53ec860e780E", "core::ptr::write"},
+    {"_ZN65_$LT$std..env..Args$u20$as$u20$core..iter..iterator..Iterator$GT$"
+     "4next17h420a7c8d0c7eef40E",
+     "<std::env::Args as core::iter::iterator::Iterator>::next"},
+    {"_ZN54_$LT$I$u20$as$u20$core..iter..traits..IntoIterator$GT$9into_"
+     "iter17he06cb713aae5b465E",
+     "<I as core::iter::traits::IntoIterator>::into_iter"},
+    {"_ZN71_$LT$collections..vec..IntoIter$LT$T$GT$$u20$as$u20$core..ops..Drop$"
+     "GT$4drop17hf7f23304ebe62eedE",
+     "<collections::vec::IntoIter<T> as core::ops::Drop>::drop"},
+    {"_ZN86_$LT$collections..vec..IntoIter$LT$T$GT$$u20$as$u20$core..iter.."
+     "iterator..Iterator$GT$4next17h04b3fbf148c39713E",
+     "<collections::vec::IntoIter<T> as core::iter::iterator::Iterator>::next"},
+    {"_ZN75_$LT$$RF$$u27$a$u20$mut$u20$I$u20$as$u20$core..iter..iterator.."
+     "Iterator$GT$4next17ha050492063e0fd20E",
+     "<&'a mut I as core::iter::iterator::Iterator>::next"},
+    {"_ZN13drop_contents17hfe3c0a68c8ad1c74E", "drop_contents"},
+    {"_ZN13drop_contents17h48cb59bef15bb555E", "drop_contents"},
+    {"_ZN4core3mem7size_of17h900b33157bf58f26E", "core::mem::size_of"},
+    {"_ZN67_$LT$alloc..raw_vec..RawVec$LT$T$GT$$u20$as$u20$core..ops..Drop$GT$"
+     "4drop17h96a5cf6e94807905E",
+     "<alloc::raw_vec::RawVec<T> as core::ops::Drop>::drop"},
+    {"_ZN68_$LT$core..nonzero..NonZero$LT$T$GT$$u20$as$u20$core..ops..Deref$GT$"
+     "5deref17hc49056f882aa46dbE",
+     "<core::nonzero::NonZero<T> as core::ops::Deref>::deref"},
+    {"_ZN63_$LT$core..ptr..Unique$LT$T$GT$$u20$as$u20$core..ops..Deref$GT$"
+     "5deref17h19f2ad4920655e85E",
+     "<core::ptr::Unique<T> as core::ops::Deref>::deref"},
+    {"_ZN11issue_609253foo37Foo$LT$issue_60925..llv$u6d$..Foo$GT$"
+     "3foo17h059a991a004536adE",
+     "issue_60925::foo::Foo<issue_60925::llvm::Foo>::foo"},
+    {"_RNvC6_123foo3bar", "123foo::bar"},
+    {"_RNqCs4fqI2P2rA04_11utf8_identsu30____7hkackfecea1cbdathfdh9hlq6y",
+     "utf8_idents::საჭმელად_გემრიელი_სადილი"},
+    {"_RNCNCNgCs6DXkGYLi8lr_2cc5spawn00B5_",
+     "cc::spawn::{closure#0}::{closure#0}"},
+    {"_RNCINkXs25_NgCsbmNqQUJIY6D_4core5sliceINyB9_4IterhENuNgNoBb_"
+     "4iter8iterator8Iterator9rpositionNCNgNpB9_6memchr7memrchrs_0E0Bb_",
+     "<core::slice::Iter<u8> as "
+     "core::iter::iterator::Iterator>::rposition::<core::slice::memchr::"
+     "memrchr::{closure#1}>::{closure#0}"},
+    {"_RINbNbCskIICzLVDPPb_5alloc5alloc8box_freeDINbNiB4_"
+     "5boxed5FnBoxuEp6OutputuEL_ECs1iopQbuBiw2_3std",
+     "alloc::alloc::box_free::<dyn alloc::boxed::FnBox<(), Output = ()>>"},
+    {"_RNvMC0INtC8arrayvec8ArrayVechKj7b_E3new",
+     "<arrayvec::ArrayVec<u8, 123>>::new"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_8UnsignedKhb_E",
+     "<const_generic::Unsigned<11>>"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_6SignedKs98_E",
+     "<const_generic::Signed<152>>"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_6SignedKanb_E",
+     "<const_generic::Signed<-11>>"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_4BoolKb0_E",
+     "<const_generic::Bool<false>>"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_4BoolKb1_E",
+     "<const_generic::Bool<true>>"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_4CharKc76_E",
+     "<const_generic::Char<'v'>>"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_4CharKca_E",
+     "<const_generic::Char<'\\n'>>"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_4CharKc2202_E",
+     "<const_generic::Char<'\\u{2202}'>>"},
+    {"_RNvNvMCs4fqI2P2rA04_13const_genericINtB4_3FooKpE3foo3FOO",
+     "<const_generic::Foo<_>>::foo::FOO"},
+    {"_RNvC6_123foo3bar", "123foo::bar"},
+    {"_RNqCs4fqI2P2rA04_11utf8_identsu30____7hkackfecea1cbdathfdh9hlq6y",
+     "utf8_idents::საჭმელად_გემრიელი_სადილი"},
+    {"_RNCNCNgCs6DXkGYLi8lr_2cc5spawn00B5_",
+     "cc::spawn::{closure#0}::{closure#0}"},
+    {"_RNCINkXs25_NgCsbmNqQUJIY6D_4core5sliceINyB9_4IterhENuNgNoBb_"
+     "4iter8iterator8Iterator9rpositionNCNgNpB9_6memchr7memrchrs_0E0Bb_",
+     "<core::slice::Iter<u8> as "
+     "core::iter::iterator::Iterator>::rposition::<core::slice::memchr::"
+     "memrchr::{closure#1}>::{closure#0}"},
+    {"_RINbNbCskIICzLVDPPb_5alloc5alloc8box_freeDINbNiB4_"
+     "5boxed5FnBoxuEp6OutputuEL_ECs1iopQbuBiw2_3std",
+     "alloc::alloc::box_free::<dyn alloc::boxed::FnBox<(), Output = ()>>"},
+    {"_RNvMC0INtC8arrayvec8ArrayVechKj7b_E3new",
+     "<arrayvec::ArrayVec<u8, 123>>::new"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_8UnsignedKhb_E",
+     "<const_generic::Unsigned<11>>"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_6SignedKs98_E",
+     "<const_generic::Signed<152>>"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_6SignedKanb_E",
+     "<const_generic::Signed<-11>>"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_4BoolKb0_E",
+     "<const_generic::Bool<false>>"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_4BoolKb1_E",
+     "<const_generic::Bool<true>>"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_4CharKc76_E",
+     "<const_generic::Char<'v'>>"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_4CharKca_E",
+     "<const_generic::Char<'\\n'>>"},
+    {"_RMCs4fqI2P2rA04_13const_genericINtB0_4CharKc2202_E",
+     "<const_generic::Char<'\\u{2202}'>>"},
+    {"_RNvNvMCs4fqI2P2rA04_13const_genericINtB4_3FooKpE3foo3FOO",
+     "<const_generic::Foo<_>>::foo::FOO"},
+};
+
+#define BUF_LEN 1024
+TEST(DemangleTest, Positive) {
+  for (auto const &tcase : s_demangle_cases) {
+    char *demangled = abi::__cxa_demangle(tcase.test.c_str(), nullptr, nullptr, nullptr);
+    if (demangled) {
+      std::string demangled_str{demangled};
+      if (!demangled_str.empty())
+        if (RustDemangler::is_probably_rust_legacy(demangled_str))
+          demangled_str = RustDemangler::demangle(demangled_str);
+      EXPECT_EQ(demangled_str, tcase.answer);
+    }
+    free(demangled);
+  }
+}


### PR DESCRIPTION
**What does this PR do?**:
Adds legacy Rust demangling to native code

**Motivation**:
I saw a flamegraph with tokio in the native parts and thought this might be useful.

**Additional Notes**:
Rust demangling isn't free, but I haven't really spent much time trying to speed it up.  This was taken from a similar implementation in the native profiler, but adapted to C++11

**How to test the change?**:
I added tests.  I believe this is fairly comprehensive, as it pulls from both llvm and libiberty.

**For Datadog employees**:
- [X] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
