### PR TITLE
Use SafeAccess to load the OS thread state value

### DIFF
--- a/ddprof-lib/src/main/cpp/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/vmStructs.h
@@ -24,8 +24,9 @@
 #include "codeCache.h"
 #include "jniHelper.h"
 #include "jvmHeap.h"
-#include "vmEntry.h"
+#include "safeAccess.h"
 #include "threadState.h"
+#include "vmEntry.h"
 
 class HeapUsage;
 
@@ -303,7 +304,8 @@ class VMThread : VMStructs {
     ThreadState osThreadState() {
         if (_thread_osthread_offset >= 0 && _osthread_state_offset >= 0) {
             const char* osthread = *(const char**) at(_thread_osthread_offset);
-            return static_cast<ThreadState>(*(int*)(osthread + _osthread_state_offset));
+            // an attempt to read the state from an invalid memory location will yield ThreadState::UNKNOWN(0) state
+            return static_cast<ThreadState>(SafeAccess::load32((u32*)(osthread + _osthread_state_offset), 0));
         }
         return ThreadState::UNKNOWN;
     }


### PR DESCRIPTION
**What does this PR do?**:
Adds a SafeAccess to load the OS thread state

**Motivation**:
We had reports about unexplained crashes in WallClock sampler which were pinpointed to obtaining the OS thread state. This can be caused by sampling a thread too early or too late, when the associated osthread value is cleaned up and deallocated.
I was not able to forge a test to trigger this problem, however, I am rather confident that using SafeAccess should help preventing the crash.


**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA TIcket: [PROF-8840]

Unsure? Have a question? Request a review!


[PROF-8840]: https://datadoghq.atlassian.net/browse/PROF-8840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ