### PR TITLE
Accurate CPU sampling without perf_events

### DIFF
--- a/ddprof-lib/src/main/cpp/arguments.h
+++ b/ddprof-lib/src/main/cpp/arguments.h
@@ -18,6 +18,7 @@
 #define _ARGUMENTS_H
 
 #include <stddef.h>
+#include <cstring>
 #include <vector>
 #include <string>
 
@@ -33,6 +34,7 @@ const char* const EVENT_CPU    = "cpu";
 const char* const EVENT_ALLOC  = "alloc";
 const char* const EVENT_WALL   = "wall";
 const char* const EVENT_ITIMER = "itimer";
+const char* const EVENT_CTIMER = "ctimer";
 
 enum Action {
     ACTION_NONE,
@@ -117,6 +119,10 @@ class Arguments {
     const char* expandFilePattern(const char* pattern);
     static long long hash(const char* arg);
     static long parseUnits(const char* str, const Multiplier* multipliers);
+    static bool isCpuEvent(const char* event) {
+        // event == NULL will default to EVENT_CPU
+        return event == NULL || strcmp(event, EVENT_CPU) == 0 || strcmp(event, EVENT_ITIMER) == 0 || strcmp(event, EVENT_CTIMER) == 0;
+    }
 
   public:
     Action _action;
@@ -182,6 +188,10 @@ class Arguments {
 
     bool hasOption(JfrOption option) const {
         return (_jfr_options & option) != 0;
+    }
+
+    long cpuSamplerInterval() const {
+        return isCpuEvent(_event) ? (_cpu > 0 ? _cpu : _interval > 0 ? _interval : DEFAULT_CPU_INTERVAL) : 0;
     }
 
     friend class FrameName;

--- a/ddprof-lib/src/main/cpp/ctimer.h
+++ b/ddprof-lib/src/main/cpp/ctimer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Andrei Pangin
+ * Copyright 2017 Andrei Pangin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,29 +14,39 @@
  * limitations under the License.
  */
 
-#ifndef _ITIMER_H
-#define _ITIMER_H
+#ifndef _CTIMER_H
+#define _CTIMER_H
 
-#include <signal.h>
 #include "engine.h"
 
+#ifdef __linux__
 
-class ITimer : public Engine {
+#include <signal.h>
+#include "arch.h"
+
+class CTimer : public Engine {
   private:
     static volatile bool _enabled;
     static long _interval;
     static CStack _cstack;
+    static int _signal;
 
+    static int _max_timers;
+    static int* _timers;
+
+    int registerThread(int tid);
+    void unregisterThread(int tid);
+
+    // cppcheck-suppress unusedPrivateFunction
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
 
   public:
-
     const char* units() {
         return "ns";
     }
 
     const char* name() {
-        return "ITimer";
+        return "CTimer";
     }
 
     long interval() const {
@@ -52,4 +62,23 @@ class ITimer : public Engine {
     }
 };
 
-#endif // _ITIMER_H
+#else
+
+class CTimer : public Engine {
+  public:
+    Error check(Arguments& args) {
+        return Error("CTimer is not supported on this platform");
+    }
+
+    Error start(Arguments& args) {
+        return Error("CTimer is not supported on this platform");
+    }
+
+    static bool supported() {
+        return false;
+    }
+};
+
+#endif // __linux__
+
+#endif // _CTIMER_H

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2023 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef __linux__
+
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include "ctimer.h"
+#include "debugSupport.h"
+#include "profiler.h"
+#include "vmStructs.h"
+
+
+#ifndef SIGEV_THREAD_ID
+#define SIGEV_THREAD_ID  4
+#endif
+
+static inline clockid_t thread_cpu_clock(unsigned int tid) {
+    return ((~tid) << 3) | 6;  // CPUCLOCK_SCHED | CPUCLOCK_PERTHREAD_MASK
+}
+
+static void** _pthread_entry = NULL;
+
+// Intercept thread creation/termination by patching libjvm's GOT entry for pthread_setspecific().
+// HotSpot puts VMThread into TLS on thread start, and resets on thread end.
+static int pthread_setspecific_hook(pthread_key_t key, const void* value) {
+    if (key != VMThread::key()) {
+        return pthread_setspecific(key, value);
+    }
+    if (pthread_getspecific(key) == value) {
+        return 0;
+    }
+
+    if (value != NULL) {
+        ProfiledThread::initCurrentThread();
+        int result = pthread_setspecific(key, value);
+        Profiler::registerThread(ProfiledThread::currentTid());
+        return result;
+    } else {
+        int tid = ProfiledThread::currentTid();
+        Profiler::unregisterThread(tid);
+        ProfiledThread::release();
+        return pthread_setspecific(key, value);
+    }
+}
+
+static void** lookupThreadEntry() {
+    // Depending on Zing version, pthread_setspecific is called either from libazsys.so or from libjvm.so
+    if (VM::isZing()) {
+        CodeCache* libazsys = Profiler::instance()->findLibraryByName("libazsys");
+        if (libazsys != NULL) {
+            void** entry = libazsys->findGlobalOffsetEntry((void*)&pthread_setspecific);
+            if (entry != NULL) {
+                return entry;
+            }
+        }
+    }
+
+    CodeCache* lib = Profiler::instance()->findJvmLibrary("libj9thr");
+    return lib != NULL ? lib->findGlobalOffsetEntry((void*)&pthread_setspecific) : NULL;
+}
+
+long CTimer::_interval;
+int CTimer::_max_timers = 0;
+int* CTimer::_timers = NULL;
+CStack CTimer::_cstack;
+volatile bool CTimer::_enabled = false;
+int CTimer::_signal;
+
+int CTimer::registerThread(int tid) {
+    if (tid >= _max_timers) {
+        Log::warn("tid[%d] > pid_max[%d]. Restart profiler after changing pid_max", tid, _max_timers);
+        return -1;
+    }
+
+    struct sigevent sev;
+    sev.sigev_value.sival_ptr = NULL;
+    sev.sigev_signo = _signal;
+    sev.sigev_notify = SIGEV_THREAD_ID;
+    ((int*)&sev.sigev_notify)[1] = tid;
+
+    // Use raw syscalls, since libc wrapper allows only predefined clocks
+    clockid_t clock = thread_cpu_clock(tid);
+    int timer;
+    if (syscall(__NR_timer_create, clock, &sev, &timer) < 0) {
+        return -1;
+    }
+
+    // Kernel timer ID may start with zero, but we use zero as an empty slot
+    if (!__sync_bool_compare_and_swap(&_timers[tid], 0, timer + 1)) {
+        // Lost race
+        syscall(__NR_timer_delete, timer);
+        return -1;
+    }
+
+    struct itimerspec ts;
+    ts.it_interval.tv_sec = (time_t)(_interval / 1000000000);
+    ts.it_interval.tv_nsec = _interval % 1000000000;
+    ts.it_value = ts.it_interval;
+    syscall(__NR_timer_settime, timer, 0, &ts, NULL);
+    return 0;
+}
+
+void CTimer::unregisterThread(int tid) {
+    if (tid >= _max_timers) {
+        return;
+    }
+
+    int timer = _timers[tid];
+    if (timer != 0 && __sync_bool_compare_and_swap(&_timers[tid], timer--, 0)) {
+        syscall(__NR_timer_delete, timer);
+    }
+}
+
+Error CTimer::check(Arguments& args) {
+    if (_pthread_entry == NULL && (_pthread_entry = lookupThreadEntry()) == NULL) {
+        return Error("Could not set pthread hook");
+    }
+
+    timer_t timer;
+    if (timer_create(CLOCK_THREAD_CPUTIME_ID, NULL, &timer) < 0) {
+        return Error("Failed to create CPU timer");
+    }
+    timer_delete(timer);
+
+    return Error::OK;
+}
+
+Error CTimer::start(Arguments& args) {
+    if (args._interval < 0) {
+        fprintf(stderr, "===> interval must be positive\n");
+        return Error("interval must be positive");
+    }
+    if (_pthread_entry == NULL && (_pthread_entry = lookupThreadEntry()) == NULL) {
+        fprintf(stderr, "===> Could not set pthread hook\n");
+        return Error("Could not set pthread hook");
+    }
+    _interval = args.cpuSamplerInterval();
+    _cstack = args._cstack;
+    _signal = SIGPROF;
+
+    int max_timers = OS::getMaxThreadId();
+    if (max_timers != _max_timers) {
+        free(_timers);
+        _timers = (int*)calloc(max_timers, sizeof(int));
+        _max_timers = max_timers;
+    }
+
+    OS::installSignalHandler(_signal, signalHandler);
+
+    // Enable pthread hook before traversing currently running threads
+    __atomic_store_n(_pthread_entry, (void*)pthread_setspecific_hook, __ATOMIC_RELEASE);
+
+    // Register all existing threads
+    Error result = Error::OK;
+    ThreadList* thread_list = OS::listThreads();
+    for (int tid; (tid = thread_list->next()) != -1; ) {
+        int err = registerThread(tid);
+        if (err != 0) {
+            fprintf(stderr, "===> Failed to register thread %d => %d\n", tid, err);
+            result = Error("Failed to register thread");
+        }
+    }
+    delete thread_list;
+
+    return Error::OK;
+}
+
+void CTimer::stop() {
+    __atomic_store_n(_pthread_entry, (void*)pthread_setspecific, __ATOMIC_RELEASE);
+    for (int i = 0; i < _max_timers; i++) {
+        unregisterThread(i);
+    }
+}
+
+void CTimer::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
+    if (!_enabled) return;
+    int tid = 0;
+    ProfiledThread* current = ProfiledThread::current();
+    if (current != NULL) {
+        current->noteCPUSample();
+        tid = current->tid();
+    } else {
+        tid = OS::threadId();
+    }
+    Shims::instance().setSighandlerTid(tid);
+
+    ExecutionEvent event;
+    VMThread* vm_thread = VMThread::current();
+    if (vm_thread) {
+        event._execution_mode = VM::jni() != NULL
+                ? convertJvmExecutionState(vm_thread->state())
+                : ExecutionMode::JVM;
+    }
+    Profiler::instance()->recordSample(ucontext, _interval, tid, BCI_CPU, &event);
+    Shims::instance().setSighandlerTid(-1);
+}
+
+#endif // __linux__

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -678,7 +678,7 @@ void Recording::writeSettings(Buffer* buf, Arguments& args) {
         writeBoolSetting(buf, T_EXECUTION_SAMPLE, "enabled", false);
     } else {
         writeBoolSetting(buf, T_EXECUTION_SAMPLE, "enabled", true);
-        writeIntSetting(buf, T_EXECUTION_SAMPLE, "interval", args._event != NULL ? args._interval : args._cpu);
+        writeIntSetting(buf, T_EXECUTION_SAMPLE, "interval", args.cpuSamplerInterval());
     }
     writeBoolSetting(buf, T_METHOD_SAMPLE, "enabled", args._wall >= 0);
     if (args._wall >= 0) {

--- a/ddprof-lib/src/main/cpp/itimer.cpp
+++ b/ddprof-lib/src/main/cpp/itimer.cpp
@@ -65,7 +65,7 @@ Error ITimer::check(Arguments& args) {
 }
 
 Error ITimer::start(Arguments& args) {
-    _interval = args._cpu > 0 ? args._cpu : DEFAULT_CPU_INTERVAL;
+    _interval = args.cpuSamplerInterval();
     _cstack = args._cstack;
 
     OS::installSignalHandler(SIGPROF, signalHandler);

--- a/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
+++ b/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
@@ -808,14 +808,17 @@ Error PerfEvents::start(Arguments& args) {
         return Error("Only arguments 1-4 can be counted");
     }
 
+    // if an arbitrary perf event type is specified pick the interval from args._interval directly
+    // otherwise ask for the effective CPU sampler interval
+    int interval = args._event != NULL && args._event != EVENT_CPU ? args._interval : args.cpuSamplerInterval();
+    if (interval < 0) {
+        return Error("interval must be positive");
+    }
+
     if (_pthread_entry == NULL && (_pthread_entry = lookupThreadEntry()) == NULL) {
         return Error("Could not set pthread hook");
     }
 
-    int interval = args._cpu > 0 ? args._cpu : (args._event != NULL && args._event != EVENT_CPU) ? args._interval : 0;
-    if (interval < 0) {
-        return Error("interval must be positive");
-    }
     _interval = interval ? interval : _event_type->default_interval;
 
     _ring = args._ring;

--- a/ddprof-lib/src/test/cpp/ddprof_ut.cpp
+++ b/ddprof-lib/src/test/cpp/ddprof_ut.cpp
@@ -9,7 +9,6 @@
     #include <vector>
 
     ssize_t callback(char* ptr, int len) {
-        fprintf(stderr, "here\n");
         return len;
     }
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/CTimerSamplerTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/CTimerSamplerTest.java
@@ -1,0 +1,62 @@
+package com.datadoghq.profiler.cpu;
+
+import com.datadoghq.profiler.AbstractProfilerTest;
+import com.datadoghq.profiler.Platform;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.RetryingTest;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.item.IItemIterable;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class CTimerSamplerTest extends AbstractProfilerTest {
+
+    private ProfiledCode profiledCode;
+
+    @Override
+    protected void before() {
+        profiledCode = new ProfiledCode(profiler);
+    }
+
+    @RetryingTest(10)
+    public void test() throws ExecutionException, InterruptedException {
+        // timer_create is available on Linux only
+        assumeTrue(Platform.isLinux());
+        for (int i = 0, id = 1; i < 100; i++, id += 3) {
+            profiledCode.method1(id);
+        }
+        stopProfiler();
+        IItemCollection events = verifyEvents("datadog.ExecutionSample");
+
+        for (IItemIterable cpuSamples : events) {
+            IMemberAccessor<String, IItem> frameAccessor = JdkAttributes.STACK_TRACE_STRING.getAccessor(cpuSamples.getType());
+            for (IItem sample : cpuSamples) {
+                String stackTrace = frameAccessor.getMember(sample);
+                assertFalse(stackTrace.contains("jvmtiError"));
+            }
+        }
+    }
+
+    @Override
+    protected void after() throws Exception {
+        profiledCode.close();
+    }
+
+    @Override
+    protected String getProfilerCommand() {
+        return "cpu=100us,event=ctimer";
+    }
+}


### PR DESCRIPTION
**What does this PR do?**:
Ports the create_timer sampler [implementation](https://github.com/async-profiler/async-profiler/issues/855) from async-profiler

**Motivation**:
Provide an accurate CPU sampler on systems with no accessible perf_events

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA ticket: [PROF-8841]

Unsure? Have a question? Request a review!


[PROF-8841]: https://datadoghq.atlassian.net/browse/PROF-8841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ