### PR TITLE
add operation to trace root event

### DIFF
--- a/ddprof-lib/src/main/cpp/event.h
+++ b/ddprof-lib/src/main/cpp/event.h
@@ -144,9 +144,10 @@ class TraceRootEvent {
   public:
     u64 _local_root_span_id;
     u32 _label;
+    u32 _operation;
 
-    TraceRootEvent(u64 local_root_span_id, u32 label) :
-        _local_root_span_id(local_root_span_id), _label(label) {};
+    TraceRootEvent(u64 local_root_span_id, u32 label, u32 operation) :
+        _local_root_span_id(local_root_span_id), _label(label), _operation(operation) {};
 };
 
 typedef struct QueueTimeEvent {

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1236,6 +1236,7 @@ void Recording::recordTraceRoot(Buffer* buf, int tid, TraceRootEvent* event) {
     buf->putVar32(tid);
     buf->put8(0);
     buf->putVar32(event->_label);
+    buf->putVar32(event->_operation);
     buf->putVar64(event->_local_root_span_id);
     writeEventSizePrefix(buf, start);
     flushIfNeeded(buf);

--- a/ddprof-lib/src/main/cpp/jfrMetadata.cpp
+++ b/ddprof-lib/src/main/cpp/jfrMetadata.cpp
@@ -170,6 +170,7 @@ void JfrMetadata::initialize(const std::vector<std::string>& contextAttributes) 
                 << field("eventThread", T_THREAD, "Event Thread", F_CPOOL)
                 << field("stackTrace", T_STACK_TRACE, "Stack Trace", F_CPOOL)
                 << field("endpoint", T_STRING, "Endpoint", F_CPOOL)
+                << field("operation", T_ATTRIBUTE_VALUE, "Operation", F_CPOOL)
                 << field("localRootSpanId", T_LONG, "Local Root Span ID"))
 
             << (type("datadog.QueueTime", T_QUEUE_TIME, "Queue Time")

--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
@@ -212,8 +212,16 @@ public final class JavaProfiler {
     /**
      * Records the completion of the trace root
      */
+    public boolean recordTraceRoot(long rootSpanId, String endpoint, String operation, int sizeLimit) {
+        return recordTrace0(rootSpanId, endpoint, operation, sizeLimit);
+    }
+
+    /**
+     * Records the completion of the trace root
+     */
+    @Deprecated
     public boolean recordTraceRoot(long rootSpanId, String endpoint, int sizeLimit) {
-        return recordTrace0(rootSpanId, endpoint, sizeLimit);
+        return recordTrace0(rootSpanId, endpoint, null, sizeLimit);
     }
 
     /**
@@ -517,7 +525,7 @@ public final class JavaProfiler {
     private static native long getContextPageOffset0(int tid);
     private static native int getMaxContextPages0();
 
-    private static native boolean recordTrace0(long rootSpanId, String endpoint, int sizeLimit);
+    private static native boolean recordTrace0(long rootSpanId, String endpoint, String operation, int sizeLimit);
 
     private static native int registerConstant0(String value);
 

--- a/ddprof-lib/src/test/cpp/demangle_ut.cpp
+++ b/ddprof-lib/src/test/cpp/demangle_ut.cpp
@@ -4,6 +4,8 @@
 
 #include <cxxabi.h>
 
+#ifndef __APPLE__
+
 struct DemangleTestContent {
   std::string test;
   std::string answer;
@@ -181,3 +183,4 @@ TEST(DemangleTest, Positive) {
     free(demangled);
   }
 }
+#endif

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/AbstractProfilerTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/AbstractProfilerTest.java
@@ -62,6 +62,9 @@ public abstract class AbstractProfilerTest {
   public static final IAttribute<IQuantity> SPAN_ID = attr("spanId", "spanId",
           "spanId", NUMBER);
 
+  public static final IAttribute<String> OPERATION = attr("operation", "operation",
+          "operation", PLAIN_TEXT);
+
 
 
   public static final IAttribute<String> THREAD_STATE =


### PR DESCRIPTION
<!-- A brief description of the change being made with this pull request. -->

Adds the operation of the root span. Also disables the rust demangler unit test on MacOS because it appears to be failing locally. I will revisit this in a different PR to figure out why.

**Motivation**:
This allows a new kind of resource utilisation metric to be reported.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
