### PR TITLE
Sanitize `github.head_ref` value

### DIFF
--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -11,6 +11,8 @@ jobs:
   scan-build:
     if: needs.check-for-pr.outputs.skip != 'true'
     runs-on: ubuntu-latest
+    env:
+      HEAD_REF: ${{ github.head_ref }}
     steps:
       - uses: actions/checkout@v3
       - name: System setup
@@ -38,7 +40,7 @@ jobs:
       - name: Read Report
         id: read-report
         run: |
-          find ddprof-lib/build/reports/scan-build -name 'index.html' | xargs -I {} python .github/scripts/python_utils.py scanbuild_cleanup {} ${{ github.head_ref }} > comment.html
+          find ddprof-lib/build/reports/scan-build -name 'index.html' | xargs -I {} python .github/scripts/python_utils.py scanbuild_cleanup {} ${HEAD_REF} > comment.html
       - name: Post or update PR comment
         uses: ./.github/actions/pr_comment
         with:


### PR DESCRIPTION
**What does this PR do?**:
Avoids the usage of unsanitized head_ref value

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA Ticket: [VULN-5227]

Unsure? Have a question? Request a review!


[VULN-5227]: https://datadoghq.atlassian.net/browse/VULN-5227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ