### PR TITLE
terminate unwinding at call_stub

### DIFF
--- a/ddprof-lib/src/main/cpp/os.h
+++ b/ddprof-lib/src/main/cpp/os.h
@@ -50,7 +50,6 @@ class JitWriteProtection {
     ~JitWriteProtection();
 };
 
-
 class OS {
   public:
     static const size_t page_size;
@@ -79,7 +78,8 @@ class OS {
     static bool isLinux();
 
     static SigAction installSignalHandler(int signo, SigAction action, SigHandler handler = NULL);
-    static SigAction replaceCrashHandler(SigAction action);
+    static SigAction replaceSigsegvHandler(SigAction action);
+    static SigAction replaceSigbusHandler(SigAction action);
     static bool sendSignalToThread(int thread_id, int signo);
 
     static void* safeAlloc(size_t size);

--- a/ddprof-lib/src/main/cpp/os_linux.cpp
+++ b/ddprof-lib/src/main/cpp/os_linux.cpp
@@ -244,12 +244,21 @@ SigAction OS::installSignalHandler(int signo, SigAction action, SigHandler handl
     return oldsa.sa_sigaction;
 }
 
-SigAction OS::replaceCrashHandler(SigAction action) {
+SigAction OS::replaceSigsegvHandler(SigAction action) {
     struct sigaction sa;
     sigaction(SIGSEGV, NULL, &sa);
     SigAction old_action = sa.sa_sigaction;
     sa.sa_sigaction = action;
     sigaction(SIGSEGV, &sa, NULL);
+    return old_action;
+}
+
+SigAction OS::replaceSigbusHandler(SigAction action) {
+    struct sigaction sa;
+    sigaction(SIGBUS, NULL, &sa);
+    SigAction old_action = sa.sa_sigaction;
+    sa.sa_sigaction = action;
+    sigaction(SIGBUS, &sa, NULL);
     return old_action;
 }
 

--- a/ddprof-lib/src/main/cpp/os_macos.cpp
+++ b/ddprof-lib/src/main/cpp/os_macos.cpp
@@ -214,7 +214,16 @@ SigAction OS::installSignalHandler(int signo, SigAction action, SigHandler handl
     return oldsa.sa_sigaction;
 }
 
-SigAction OS::replaceCrashHandler(SigAction action) {
+SigAction OS::replaceSigsegvHandler(SigAction action) {
+    struct sigaction sa;
+    sigaction(SIGSEGV, NULL, &sa);
+    SigAction old_action = sa.sa_sigaction;
+    sa.sa_sigaction = action;
+    sigaction(SIGSEGV, &sa, NULL);
+    return old_action;
+}
+
+SigAction OS::replaceSigbusHandler(SigAction action) {
     struct sigaction sa;
     sigaction(SIGBUS, NULL, &sa);
     SigAction old_action = sa.sa_sigaction;

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -690,7 +690,7 @@ void Profiler::recordSample(void* ucontext, u64 counter, int tid, jint event_typ
         ASGCT_CallFrame *native_stop = frames + num_frames;
         num_frames += getNativeTrace(ucontext, native_stop, event_type, tid, &java_ctx, &truncated);
         if (_cstack == CSTACK_VM) {
-            num_frames += StackWalker::walkVM(ucontext, frames + num_frames, _max_stack_depth);
+            num_frames += StackWalker::walkVM(ucontext, frames + num_frames, _max_stack_depth, _call_stub_begin, _call_stub_end);
         } else if (event_type == BCI_CPU || event_type == BCI_WALL) {
             int java_frames = 0;
             {

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -189,6 +189,8 @@ class Profiler {
     void lockAll();
     void unlockAll();
 
+    static bool crashHandler(int signo, siginfo_t* siginfo, void* ucontext);
+
     static Profiler* const _instance;
 
   public:
@@ -291,6 +293,7 @@ class Profiler {
     static void trapHandlerEntry(int signo, siginfo_t* siginfo, void* ucontext);
     void trapHandler(int signo, siginfo_t* siginfo, void* ucontext);
     static void segvHandler(int signo, siginfo_t* siginfo, void* ucontext);
+    static void busHandler(int signo, siginfo_t* siginfo, void* ucontext);
     static void setupSignalHandlers();
 
     static int registerThread(int tid);

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -217,7 +217,8 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
     return depth;
 }
 
-int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth) {
+int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
+                        const void* _termination_frame_begin, const void* _termination_frame_end) {
     const void* pc;
     uintptr_t fp;
     uintptr_t sp;
@@ -257,6 +258,9 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth) 
 
     // Walk until the bottom of the stack or until the first Java frame
     while (depth < max_depth) {
+        if (pc >= _termination_frame_begin && pc < _termination_frame_end) {
+            break;
+        }
         if (CodeHeap::contains(pc)) {
             NMethod* nm = CodeHeap::findNMethod(pc);
             if (nm == NULL) {

--- a/ddprof-lib/src/main/cpp/stackWalker.h
+++ b/ddprof-lib/src/main/cpp/stackWalker.h
@@ -37,7 +37,7 @@ class StackWalker {
   public:
     static int walkFP(void* ucontext, const void** callchain, int max_depth, StackContext* java_ctx, bool *truncated);
     static int walkDwarf(void* ucontext, const void** callchain, int max_depth, StackContext* java_ctx, bool *truncated);
-    static int walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth);
+    static int walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, const void* _termination_frame_begin, const void* _termination_frame_end);
 
     static void checkFault();
 };

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/VMStructsBasedCpuTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/VMStructsBasedCpuTest.java
@@ -1,0 +1,53 @@
+package com.datadoghq.profiler.cpu;
+
+import com.datadoghq.profiler.AbstractProfilerTest;
+import com.datadoghq.profiler.Platform;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.common.item.IItemIterable;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+
+public class VMStructsBasedCpuTest extends AbstractProfilerTest {
+
+    private ProfiledCode profiledCode;
+
+    @Override
+    protected void before() {
+        profiledCode = new ProfiledCode(profiler);
+    }
+
+    @Test
+    public void test() throws ExecutionException, InterruptedException {
+        for (int i = 0, id = 1; i < 100; i++, id += 3) {
+            profiledCode.method1(id);
+        }
+        stopProfiler();
+        IItemCollection events = verifyEvents("datadog.ExecutionSample");
+        for (IItemIterable it : events) {
+            IMemberAccessor<String, IItem> stackTraceAccessor = JdkAttributes.STACK_TRACE_STRING.getAccessor(it.getType());
+            for (IItem item : it) {
+                String stacktrace = stackTraceAccessor.getMember(item);
+                assertFalse(stacktrace.contains("JavaCalls::call_virtual()"),
+                        "JavaCalls::call_virtual() (above call_stub) found in stack trace");
+                assertFalse(stacktrace.contains("call_stub()"),
+                        "call_stub() (sentinel value used to halt unwinding) found in stack trace");
+            }
+        }
+    }
+
+    @Override
+    protected String getProfilerCommand() {
+        return "cpu=10ms" + (vmstructsUnwinderSupported() ? ",cstack=vm" : "");
+    }
+
+    private boolean vmstructsUnwinderSupported() {
+        return !Platform.isJ9() && !Platform.isZing();
+    }
+}


### PR DESCRIPTION
**What does this PR do?**:
The long prefix of the stack trace isn't useful, we can trim it by terminating the `VMStructs` based unwinder when we encounter `call_stub`. 
<img width="690" alt="Screenshot 2024-01-19 at 10 34 05" src="https://github.com/DataDog/java-profiler/assets/16439049/5bb1b48e-fbcd-42ab-9839-af207577246e">

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
