### PR TITLE
Handle both SIGSEGV and SIGBUS for memory access violations

### DIFF
--- a/ddprof-lib/src/main/cpp/os.h
+++ b/ddprof-lib/src/main/cpp/os.h
@@ -50,7 +50,6 @@ class JitWriteProtection {
     ~JitWriteProtection();
 };
 
-
 class OS {
   public:
     static const size_t page_size;
@@ -79,7 +78,8 @@ class OS {
     static bool isLinux();
 
     static SigAction installSignalHandler(int signo, SigAction action, SigHandler handler = NULL);
-    static SigAction replaceCrashHandler(SigAction action);
+    static SigAction replaceSigsegvHandler(SigAction action);
+    static SigAction replaceSigbusHandler(SigAction action);
     static bool sendSignalToThread(int thread_id, int signo);
 
     static void* safeAlloc(size_t size);

--- a/ddprof-lib/src/main/cpp/os_linux.cpp
+++ b/ddprof-lib/src/main/cpp/os_linux.cpp
@@ -244,12 +244,21 @@ SigAction OS::installSignalHandler(int signo, SigAction action, SigHandler handl
     return oldsa.sa_sigaction;
 }
 
-SigAction OS::replaceCrashHandler(SigAction action) {
+SigAction OS::replaceSigsegvHandler(SigAction action) {
     struct sigaction sa;
     sigaction(SIGSEGV, NULL, &sa);
     SigAction old_action = sa.sa_sigaction;
     sa.sa_sigaction = action;
     sigaction(SIGSEGV, &sa, NULL);
+    return old_action;
+}
+
+SigAction OS::replaceSigbusHandler(SigAction action) {
+    struct sigaction sa;
+    sigaction(SIGBUS, NULL, &sa);
+    SigAction old_action = sa.sa_sigaction;
+    sa.sa_sigaction = action;
+    sigaction(SIGBUS, &sa, NULL);
     return old_action;
 }
 

--- a/ddprof-lib/src/main/cpp/os_macos.cpp
+++ b/ddprof-lib/src/main/cpp/os_macos.cpp
@@ -214,7 +214,16 @@ SigAction OS::installSignalHandler(int signo, SigAction action, SigHandler handl
     return oldsa.sa_sigaction;
 }
 
-SigAction OS::replaceCrashHandler(SigAction action) {
+SigAction OS::replaceSigsegvHandler(SigAction action) {
+    struct sigaction sa;
+    sigaction(SIGSEGV, NULL, &sa);
+    SigAction old_action = sa.sa_sigaction;
+    sa.sa_sigaction = action;
+    sigaction(SIGSEGV, &sa, NULL);
+    return old_action;
+}
+
+SigAction OS::replaceSigbusHandler(SigAction action) {
     struct sigaction sa;
     sigaction(SIGBUS, NULL, &sa);
     SigAction old_action = sa.sa_sigaction;

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -189,6 +189,8 @@ class Profiler {
     void lockAll();
     void unlockAll();
 
+    static bool crashHandler(int signo, siginfo_t* siginfo, void* ucontext);
+
     static Profiler* const _instance;
 
   public:
@@ -291,6 +293,7 @@ class Profiler {
     static void trapHandlerEntry(int signo, siginfo_t* siginfo, void* ucontext);
     void trapHandler(int signo, siginfo_t* siginfo, void* ucontext);
     static void segvHandler(int signo, siginfo_t* siginfo, void* ucontext);
+    static void busHandler(int signo, siginfo_t* siginfo, void* ucontext);
     static void setupSignalHandlers();
 
     static int registerThread(int tid);


### PR DESCRIPTION
**What does this PR do?**:
Explicitly handle both SIGSEGV and SIGBUS signals

**Motivation**:
On MacOS (aarch64) the current SIGBUS handler will not actually handle safeaccess attempts or failures in the vmstructs walker properly. The reason is that these errors will raise SIGSEGV whle we have handler only of SIGBUS.


**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
