### PR TITLE
Fix the partial kernel/userspace stackwalking

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -311,7 +311,8 @@ int Profiler::getNativeTrace(void* ucontext, ASGCT_CallFrame* frames, int event_
 
     if (event_type == BCI_CPU && _cpu_engine == &perf_events) {
         native_frames += PerfEvents::walkKernel(tid, callchain + native_frames, MAX_NATIVE_FRAMES - native_frames, java_ctx);
-    } else if (_cstack == CSTACK_VM) {
+    }
+    if (_cstack == CSTACK_VM) {
         return 0;
     } else if (_cstack == CSTACK_DWARF) {
         native_frames += StackWalker::walkDwarf(ucontext, callchain + native_frames, MAX_NATIVE_FRAMES - native_frames, java_ctx, truncated);


### PR DESCRIPTION
**What does this PR do?**:
It fixes the mixed kernel/userspace stackwalking

**Motivation**:
The current logic seems flawed when using perf_event_open scheduler and it fails to get the non-kernel part of the stacktrace.
The fix is trivial and it does fix the issue.

**How to test the change?**:
One must have a system with perf_event_open available. Collected stacktraces should not contain a significant number of `UNKNOWN_PACKAGE` frames.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA ticket: [PROF-9142] 

Unsure? Have a question? Request a review!


[PROF-9142]: https://datadoghq.atlassian.net/browse/PROF-9142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ