### PR TITLE
Use CTimer as default

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -960,7 +960,7 @@ Engine* Profiler::selectCpuEngine(Arguments& args) {
             // signal based samplers are unstable on J9 before 8.0.362, 11.0.18 and 17.0.6
             return (Engine*)&j9_engine;
         }
-        return !perf_events.check(args) ? (Engine*)&perf_events : (!ctimer.check(args) ? (Engine*)&ctimer : (Engine*)&itimer);
+        return !ctimer.check(args) ? (Engine*)&ctimer : (!perf_events.check(args) ? (Engine*)&perf_events : (Engine*)&itimer);
     } else if (strcmp(args._event, EVENT_WALL) == 0) {
         return &noop_engine;
     } else if (strcmp(args._event, EVENT_ITIMER) == 0) {


### PR DESCRIPTION
**What does this PR do?**:
Changes the default CPU engine to CTimer

**Motivation**:
We are not using kernel stacktraces and CTimer is a more lightweight approach with the same precission as perf_event_open

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
