### PR TITLE
use lastJava ucontext when last Java frame not found in native state

### DIFF
--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -55,7 +55,8 @@
     X(CODECACHE_RUNTIME_STUBS_SIZE_BYTES, "codecache_runtime_stubs_size_bytes") \
     X(AGCT_NOT_REGISTERED_IN_TLS, "agct_not_registered_in_tls") \
     X(AGCT_NOT_JAVA, "agct_not_java") \
-    X(AGCT_NATIVE_NO_JAVA_CONTEXT, "agct_native_no_java_context") \
+    X(AGCT_NATIVE_NO_JAVA_CONTEXT, "agct_native_no_java_context")     \
+    X(AGCT_BLOCKED_IN_VM, "agct_blocked_in_vm") \
     X(HANDLED_SIGSEGV_SAFEFETCH, "handled_sigsegv_safefetch") \
     X(HANDLED_SIGSEGV_WALKVM, "handled_sigsegv_walkvm")
 #define X_ENUM(a, b) a,

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -389,14 +389,6 @@ int Profiler::getJavaTraceAsync(void* ucontext, ASGCT_CallFrame* frames, int max
             }
             return 1;
         }
-        int state = vm_thread->state();
-        if (state == 8 || state == 9) {
-             if (DWARF_SUPPORTED && java_ctx->sp != 0) {
-                // If a thread is in Java state, unwind manually to the last known Java frame,
-                // since JVM does not always correctly unwind native frames
-                frame.restore((uintptr_t)java_ctx->pc, java_ctx->sp, java_ctx->fp);
-            }
-        }
     } else {
         return 0;
     }
@@ -419,27 +411,21 @@ int Profiler::getJavaTraceAsync(void* ucontext, ASGCT_CallFrame* frames, int max
         _thread_max_state         = 12  // maximum thread state+1 - used for statistics allocation
     };
      */
-    // avoid unwinding during deoptimization
-    if (vm_thread->osThreadState() == ThreadState::RUNNABLE && (state == 10 || state == 11)) {
-        return 0;
-    }
     bool in_java = (state == 8 || state == 9);
     if (in_java && java_ctx->sp != 0) {
         // skip ahead to the Java frames before calling AGCT
         frame.restore((uintptr_t)java_ctx->pc, java_ctx->sp, java_ctx->fp);
     }
-    // do not attempt to unwind
-    bool in_native = (state == 4 || state == 5);
-    if (in_native) {
-        if (java_ctx->sp != 0) {
-            // skip ahead to the Java frames before calling AGCT
-            frame.restore((uintptr_t)java_ctx->pc, java_ctx->sp, java_ctx->fp);
-        } else {
-            // we've tried to unwind some native code without frame pointers,
-            // and we don't know where the top Java frame is, so we don't want to call AGCT
-            Counters::increment(AGCT_NATIVE_NO_JAVA_CONTEXT);
-            return 0;
-        }
+    if (!in_java && vm_thread->lastJavaSP() == 0) {
+        // we haven't found the top Java frame ourselves, and the lastJavaSP wasn't recorded either
+        Counters::increment(AGCT_NATIVE_NO_JAVA_CONTEXT);
+        return 0;
+    }
+    bool blocked_in_vm = (state == 10 || state == 11);
+    // avoid unwinding during deoptimization
+    if (blocked_in_vm && vm_thread->osThreadState() == ThreadState::RUNNABLE) {
+        Counters::increment(AGCT_BLOCKED_IN_VM);
+        return 0;
     }
 
     JitWriteProtection jit(false);

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativelibs/NativeLibrariesTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativelibs/NativeLibrariesTest.java
@@ -70,7 +70,7 @@ public class NativeLibrariesTest extends AbstractProfilerTest {
                 modeCounters.computeIfAbsent(mode, x -> new AtomicInteger()).incrementAndGet();
                 if ("NATIVE".equals(mode)) {
                     String library = "";
-                    if (stacktrace.contains("net_jpountz_lz4_LZ4JNI")) {
+                    if (stacktrace.contains("LZ4JNI")) {
                         library = "LZ4";
                     } else if (stacktrace.contains("Java_org_xerial_snappy_SnappyNative")) {
                         library = "SNAPPY";
@@ -85,7 +85,7 @@ public class NativeLibrariesTest extends AbstractProfilerTest {
         }
         assertTrue(modeCounters.containsKey("JVM"), "no JVM samples");
         assertTrue(modeCounters.containsKey("NATIVE"), "no NATIVE samples");
-        assertTrue(Platform.isMac() || libraryCounters.containsKey("LZ4"), "no lz4-java samples");
+        assertTrue(libraryCounters.containsKey("LZ4"), "no lz4-java samples");
         // looks like we might drop these samples with FP unwinding (which we have to use on MacOS)
         // flaky
         // assertTrue(isMusl || Platform.isMac() || libraryCounters.containsKey("SNAPPY"), "no snappy-java samples");


### PR DESCRIPTION
**What does this PR do?**:

We don't need to find the top Java frame in JNI calls, we just shouldn't call AGCT if the lastJavaSP is unset

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
