### PR TITLE
use lastJava ucontext when last Java frame not found in native state

### DIFF
--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -55,7 +55,8 @@
     X(CODECACHE_RUNTIME_STUBS_SIZE_BYTES, "codecache_runtime_stubs_size_bytes") \
     X(AGCT_NOT_REGISTERED_IN_TLS, "agct_not_registered_in_tls") \
     X(AGCT_NOT_JAVA, "agct_not_java") \
-    X(AGCT_NATIVE_NO_JAVA_CONTEXT, "agct_native_no_java_context") \
+    X(AGCT_NATIVE_NO_JAVA_CONTEXT, "agct_native_no_java_context")     \
+    X(AGCT_BLOCKED_IN_VM, "agct_blocked_in_vm") \
     X(HANDLED_SIGSEGV_SAFEFETCH, "handled_sigsegv_safefetch") \
     X(HANDLED_SIGSEGV_WALKVM, "handled_sigsegv_walkvm")
 #define X_ENUM(a, b) a,

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativelibs/NativeLibrariesTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativelibs/NativeLibrariesTest.java
@@ -70,7 +70,7 @@ public class NativeLibrariesTest extends AbstractProfilerTest {
                 modeCounters.computeIfAbsent(mode, x -> new AtomicInteger()).incrementAndGet();
                 if ("NATIVE".equals(mode)) {
                     String library = "";
-                    if (stacktrace.contains("net_jpountz_lz4_LZ4JNI")) {
+                    if (stacktrace.contains("LZ4JNI")) {
                         library = "LZ4";
                     } else if (stacktrace.contains("Java_org_xerial_snappy_SnappyNative")) {
                         library = "SNAPPY";
@@ -85,12 +85,11 @@ public class NativeLibrariesTest extends AbstractProfilerTest {
         }
         assertTrue(modeCounters.containsKey("JVM"), "no JVM samples");
         assertTrue(modeCounters.containsKey("NATIVE"), "no NATIVE samples");
-        assertTrue(Platform.isMac() || libraryCounters.containsKey("LZ4"), "no lz4-java samples");
+        assertTrue(libraryCounters.containsKey("LZ4"), "no lz4-java samples");
         // looks like we might drop these samples with FP unwinding (which we have to use on MacOS)
         // flaky
         // assertTrue(isMusl || Platform.isMac() || libraryCounters.containsKey("SNAPPY"), "no snappy-java samples");
-        // cannot unwind these samples with FP unwinding (which we have to use on MacOS)
-        assertTrue(Platform.isMac() || libraryCounters.containsKey("ZSTD"), "no zstd-jni samples");
+        assertTrue(libraryCounters.containsKey("ZSTD"), "no zstd-jni samples");
         modeCounters.forEach((mode, count) -> System.err.println(mode + ": " + count.get()));
         libraryCounters.forEach((lib, count) -> System.err.println(lib + ": " + count.get()));
     }


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
