### PR TITLE
deallocate key when writing system properties

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -870,6 +870,7 @@ void Recording::writeSystemProperties(Buffer* buf) {
             buf->putVar32(start, buf->offset() - start);
             jvmti->Deallocate((unsigned char*)value);
         }
+        jvmti->Deallocate((unsigned char*)key);
     }
     flushIfNeeded(buf);
 


### PR DESCRIPTION
**What does this PR do?**:
We've diverged too much to take this commit from async-profiler, but it fixes a verified memory leak https://github.com/async-profiler/async-profiler/commit/3b2d969b4918e4d8a71a780a941af1700717d6d8

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
