### PR TITLE
check osthreadstate is not null before dereferencing

### DIFF
--- a/ddprof-lib/src/main/cpp/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/vmStructs.h
@@ -463,8 +463,9 @@ class VMThread : VMStructs {
     ThreadState osThreadState() {
         if (_thread_osthread_offset >= 0 && _osthread_state_offset >= 0) {
             const char* osthread = *(const char**) at(_thread_osthread_offset);
-            // an attempt to read the state from an invalid memory location will yield ThreadState::UNKNOWN(0) state
-            return static_cast<ThreadState>(SafeAccess::load32((u32*)(osthread + _osthread_state_offset), 0));
+            if (osthread != nullptr) {
+                return static_cast<ThreadState>(*(int *) (osthread + _osthread_state_offset));
+            }
         }
         return ThreadState::UNKNOWN;
     }

--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -70,14 +70,16 @@ void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext, u64
 
     ExecutionEvent event;
     VMThread* vm_thread = VMThread::current();
+    int raw_thread_state = vm_thread ? vm_thread->state() : 0;
+    bool is_initialized = raw_thread_state >= 4 && raw_thread_state < 12;
     ThreadState state = ThreadState::UNKNOWN;
     ExecutionMode mode = ExecutionMode::UNKNOWN;
-    if (vm_thread) {
+    if (vm_thread && is_initialized) {
         ThreadState os_state = vm_thread->osThreadState();
         if (os_state != ThreadState::UNKNOWN) {
             state = os_state;
         }
-        mode = VM::jni() != NULL ? convertJvmExecutionState(vm_thread->state()) : ExecutionMode::JVM;
+        mode = VM::jni() != NULL ? convertJvmExecutionState(raw_thread_state) : ExecutionMode::JVM;
     }
     if (state == ThreadState::UNKNOWN) {
         if (inSyscall(ucontext)) {


### PR DESCRIPTION
**What does this PR do?**:
In the original bug report, we had the following information:

```
Current thread (0x00007f665b5ef090):  Thread [stack: 0x00007f661685f000,0x00007f661695fa90] [id=0]

Stack: [0x00007f661685f000,0x00007f661695fa90],  sp=0x00007f661695ef30,  free space=1023k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libjavaProfiler1675892613987672088.so+0x39634]  WallClock::signalHandler(int, siginfo_t*, void*, unsigned long long)+0x244


siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR), si_addr: 0x00007f6632402020

Register to memory mapping:

RAX=0x00007f6632402010 points into unknown readable memory: 0x0000000000000000 | 00 00 00 00 00 00 00 00
```

Which shows that 0x00007f6632402010 (`const char* osthread`) points to null, so adding the thread state offset (`_osthread_state_offset`) to get `0x00007f6632402020` would produce a segfault when dereferencing. Instead of using `SafeAccess::load32`, which causes obscure crashes, we can check the pointer, but also check if the thread is even initialized before trying to access the `OSThread*` to make avoiding crashing here less racy.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
