### PR TITLE
Retrieve the Java method modifiers

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -141,6 +141,9 @@ void Lookup::fillJavaMethodInfo(MethodInfo* mi, jmethodID method, bool first_tim
     u32 method_name_id = 0;
     u32 method_sig_id = 0;
 
+    jint modifiers;
+    jint class_modifiers;
+
     jint line_number_table_size = 0;
     jvmtiLineNumberEntry* line_number_table = NULL;
 
@@ -152,6 +155,11 @@ void Lookup::fillJavaMethodInfo(MethodInfo* mi, jmethodID method, bool first_tim
             jvmti->GetMethodName(method, &method_name, &method_sig, NULL) == 0) {
 
             if (first_time) {
+                if (jvmti->GetClassModifiers(method_class, &class_modifiers) == 0 && jvmti->GetMethodModifiers(method, &modifiers) == 0) {
+                    // class constants are written without the modifiers info
+                    // in order to be able to identify 'hidden' frames the relevant modifiers will be propagated to methods
+                    mi->_modifiers = modifiers | (class_modifiers & ACC_HIDDEN);
+                }
                 jvmti->GetLineNumberTable(method, &line_number_table_size, &line_number_table);
             }
 


### PR DESCRIPTION
**What does this PR do?**:
It reintroduces the collection of Java method modifiers, but only the first time a particular method is being resolved.

**Motivation**:
The modifiers are used to determine the 'hidden' status of a stackframe. Not collecting the modifiers has the unintended consequence of marking all Java frames as hidden.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-9261]

Unsure? Have a question? Request a review!


[PROF-9261]: https://datadoghq.atlassian.net/browse/PROF-9261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ