### PR TITLE
Add startTime to datadog.ProfilerCounter event

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1163,6 +1163,7 @@ void Recording::writeCounters(Buffer* buf) {
         for (int i = 0; i < names.size(); i++) {
             int start = buf->skip(1);
             buf->putVar64(T_DATADOG_COUNTER);
+            buf->putVar64(_start_ticks);
             buf->putUtf8(names[i]);
             buf->putVar64(counters[Counters::address(i)]);
             writeEventSizePrefix(buf, start);

--- a/ddprof-lib/src/main/cpp/jfrMetadata.cpp
+++ b/ddprof-lib/src/main/cpp/jfrMetadata.cpp
@@ -254,6 +254,7 @@ void JfrMetadata::initialize(const std::vector<std::string>& contextAttributes) 
 
             << (type("datadog.ProfilerCounter", T_DATADOG_COUNTER, "Datadog Profiler Internal Counter")
                 << category("Datadog")
+                << field("startTime", T_LONG, "Start Time", F_TIME_TICKS)
                 << field("name", T_COUNTER_NAME, "Name")
                 << field("count", T_LONG, "Count"))
 


### PR DESCRIPTION
**What does this PR do?**:
Fixes the generation of JFR dumps so they can be read by the `jfr` tool by adding `startTime` to `datadog.ProfilerCounter` event

**Motivation**:
The `jfr` tool could not open the dumps generated by the profiler, failing with:

```
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Long
        at jdk.jfr.consumer.EventParser.parse(EventParser.java:62)
```

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
