### PR TITLE
Fix a pair of slow memory leaks

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -992,9 +992,8 @@ void Recording::writeThreads(Buffer* buf) {
     _thread_set.clear();
 
     Profiler* profiler = Profiler::instance();
-    MutexLocker ml(profiler->_thread_names_lock);
-    std::map<int, std::string>& thread_names = profiler->_thread_names;
-    std::map<int, jlong>& thread_ids = profiler->_thread_ids;
+    ThreadInfo t_info = profiler->_thread_info;
+
     char name_buf[32];
 
     buf->putVar64(T_THREAD);
@@ -1002,10 +1001,10 @@ void Recording::writeThreads(Buffer* buf) {
     for (int i = 0; i < threads.size(); i++) {
         const char* thread_name;
         jlong thread_id;
-        std::map<int, std::string>::const_iterator it = thread_names.find(threads[i]);
-        if (it != thread_names.end()) {
-            thread_name = it->second.c_str();
-            thread_id = thread_ids[threads[i]];
+        std::pair<std::shared_ptr<std::string>, u64> info = t_info.get(threads[i]);
+        if (info.first) {
+            thread_name = info.first->c_str();
+            thread_id = info.second;
         } else {
             snprintf(name_buf, sizeof(name_buf), "[tid=%d]", threads[i]);
             thread_name = name_buf;

--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -51,18 +51,21 @@ void LivenessTracker::cleanup_table(bool forced) {
     u32 sz, newsz = 0;
     std::set<jclass> kept_classes;
     for (u32 i = 0; i < (sz = _table_size); i++) {
-        if (_table[i].ref != NULL && !env->IsSameObject(_table[i].ref, NULL)) {
+        if (_table[i].ref != nullptr && !env->IsSameObject(_table[i].ref, nullptr)) {
             // it survived one more GarbageCollectionFinish event
             u32 target = newsz++;
             if (target != i) {
                 _table[target] = _table[i];
-                _table[i].ref = NULL;
+                _table[i].ref = nullptr;
+                assert(_table[i].frames == _table[target].frames);
+                _table[i].frames = nullptr;
             }
             _table[target].age += epoch_diff;
         } else {
             env->DeleteWeakGlobalRef(_table[i].ref);
-            _table[i].ref = NULL;
+            _table[i].ref = nullptr;
             delete[] _table[i].frames;
+            _table[i].frames = nullptr;
         }
     }
 
@@ -296,8 +299,6 @@ retry:
             }
         }
     }
-
-    delete[] frames;
 }
 
 void JNICALL LivenessTracker::GarbageCollectionFinish(jvmtiEnv *jvmti_env) {

--- a/ddprof-lib/src/main/cpp/objectSampler.cpp
+++ b/ddprof-lib/src/main/cpp/objectSampler.cpp
@@ -106,12 +106,11 @@ void ObjectSampler::recordAllocation(jvmtiEnv* jvmti, JNIEnv* jni, jthread threa
     }
 
     if (_record_liveness) {
-        // 'frames' will be released by the tracker
         LivenessTracker::instance()->track(jni, event, tid, object, frames_size, frames);
-    } else {
-        // otherwise the 'frames' need to be deleted here
-        delete[] frames;
     }
+
+    // it's safe to delete frames - the liveness tracker keeps a full copy of the frames and manages its own memory
+    delete[] frames;
 }
 
 Error ObjectSampler::check(Arguments& args) {

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -32,6 +32,7 @@
 #include "mutex.h"
 #include "spinLock.h"
 #include "threadFilter.h"
+#include "threadInfo.h"
 #include "trap.h"
 #include "vmEntry.h"
 #include "objectSampler.h"
@@ -112,10 +113,7 @@ class Profiler {
     NotifyClassUnloadedFunc _notify_class_unloaded_func;
     // --
 
-    Mutex _thread_names_lock;
-    // TODO: single map?
-    std::map<int, std::string> _thread_names;
-    std::map<int, jlong> _thread_ids;
+    ThreadInfo _thread_info;
     Dictionary _class_map;
     Dictionary _string_label_map;
     Dictionary _context_value_map;
@@ -176,7 +174,6 @@ class Profiler {
     int getJavaTraceInternal(jvmtiFrameInfo* jvmti_frames, ASGCT_CallFrame* frames, int max_depth);
     int convertFrames(jvmtiFrameInfo* jvmti_frames, ASGCT_CallFrame* frames, int num_frames);
     void fillFrameTypes(ASGCT_CallFrame* frames, int num_frames, NMethod* nmethod);
-    void setThreadInfo(int tid, const char* name, jlong java_thread_id);
     void updateThreadName(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);
     void updateJavaThreadNames();
     void updateNativeThreadNames();

--- a/ddprof-lib/src/main/cpp/threadInfo.cpp
+++ b/ddprof-lib/src/main/cpp/threadInfo.cpp
@@ -1,0 +1,84 @@
+#include "counters.h"
+#include "mutex.h"
+#include "threadInfo.h"
+
+void ThreadInfo::set(int tid, const char* name, u64 java_thread_id) {
+    MutexLocker ml(_ti_lock);
+    _thread_names[tid] = std::string(name);
+    _thread_ids[tid] = java_thread_id;
+}
+
+std::pair<std::shared_ptr<std::string>, u64> ThreadInfo::get(int threadId) {
+    MutexLocker ml(_ti_lock);
+    auto it = _thread_names.find(threadId);
+    if (it != _thread_names.end()) {
+        return std::make_pair(std::make_shared<std::string>(it->second), _thread_ids[threadId]);
+    }
+    return std::make_pair(nullptr, 0);
+}
+
+int ThreadInfo::getThreadId(int threadId) {
+    MutexLocker ml(_ti_lock);
+    auto it = _thread_ids.find(threadId);
+    if (it != _thread_ids.end()) {
+        return it->second;
+    }
+    return -1;
+}
+
+void ThreadInfo::clearAll() {
+    MutexLocker ml(_ti_lock);
+    _thread_names.clear();
+    _thread_ids.clear();
+}
+
+void ThreadInfo::clearAll(std::set<int> &live_thread_ids) {
+    // Reset thread names and IDs
+    MutexLocker ml(_ti_lock);
+    if (live_thread_ids.empty()) {
+        // take the fast path
+        _thread_names.clear();
+        _thread_ids.clear();
+    } else {
+        // we need to honor the thread referenced from the liveness tracker
+        std::map<int, std::string>::iterator name_itr = _thread_names.begin();
+        while (name_itr != _thread_names.end()) {
+            if (live_thread_ids.find(name_itr->first) == live_thread_ids.end()) {
+                name_itr = _thread_names.erase(name_itr);
+            } else {
+                ++name_itr;
+            }
+        }
+        std::map<int, u64>::iterator id_itr = _thread_ids.begin();
+        while (id_itr != _thread_ids.end()) {
+            if (live_thread_ids.find(id_itr->first) == live_thread_ids.end()) {
+                id_itr = _thread_ids.erase(id_itr);
+            } else {
+                ++id_itr;
+            }
+        }
+    }
+}
+
+int ThreadInfo::size() {
+    MutexLocker ml(_ti_lock);
+    return _thread_names.size();
+}
+
+void ThreadInfo::updateThreadName(int tid, std::function<std::unique_ptr<char[]>(int)> resolver) {
+    MutexLocker ml(_ti_lock);
+
+    std::map<int, std::string>::iterator it = _thread_names.lower_bound(tid);
+    if (it == _thread_names.end() || it->first != tid) {
+        std::unique_ptr<char[]> namePtr = resolver(tid);
+        if (namePtr.get() != nullptr) {
+            _thread_names.insert(it, std::map<int, std::string>::value_type(tid, static_cast<char*>(namePtr.get())));
+        }
+    }
+}
+
+void ThreadInfo::reportCounters() {
+    MutexLocker ml(_ti_lock);
+    Counters::set(THREAD_IDS_COUNT, _thread_ids.size());
+    Counters::set(THREAD_NAMES_COUNT, _thread_names.size());
+}

--- a/ddprof-lib/src/main/cpp/threadInfo.h
+++ b/ddprof-lib/src/main/cpp/threadInfo.h
@@ -1,0 +1,31 @@
+#include "mutex.h"
+#include "os.h"
+#include <functional>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+
+class ThreadInfo {
+  private:
+    Mutex _ti_lock;
+    std::map<int, std::string> _thread_names;
+    std::map<int, u64> _thread_ids;
+
+  public:
+    void set(int tid, const char* name, u64 java_thread_id);
+    std::pair<std::shared_ptr<std::string>, u64> get(int tid);
+
+    void updateThreadName(int threadId, std::function<std::unique_ptr<char[]>(int)> resolver);
+
+    int size();
+
+    void clearAll(std::set<int> &live_thread_ids);
+    void clearAll();
+
+    void reportCounters();
+
+    // For testing
+    int getThreadId(int threadId);
+};
+

--- a/ddprof-lib/src/test/CMakeLists.txt
+++ b/ddprof-lib/src/test/CMakeLists.txt
@@ -51,7 +51,8 @@ file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
     "${PROJECT_SOURCE_DIR}/../main/cpp/threadFilter.cpp"
     "${PROJECT_SOURCE_DIR}/../main/cpp/dictionary.cpp"
     "${PROJECT_SOURCE_DIR}/../main/cpp/methodCache.cpp"
-    "${PROJECT_SOURCE_DIR}/../main/cpp/counters.cpp"
+    "${PROJECT_SOURCE_DIR}/../main/cpp/mutex.cpp"
+    "${PROJECT_SOURCE_DIR}/../main/cpp/threadInfo.cpp"
 )
 
 add_compile_definitions(DEBUG)


### PR DESCRIPTION
**What does this PR do?**:
It fixes slow memory leaks as identified by the native heap profiler.

**How to test the change?**:
A new C++ unit test was added to make sure the thread info data are cleaned up properly - this required some refactoring but the code is now cleaner and is using C++ automatic memory management.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [SCP-414] 

Unsure? Have a question? Request a review!


[SCP-414]: https://datadoghq.atlassian.net/browse/SCP-414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ