### PR TITLE
Be defensive when working with potentially unitialized thread structures

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -174,7 +174,7 @@ class Profiler {
     int getJavaTraceInternal(jvmtiFrameInfo* jvmti_frames, ASGCT_CallFrame* frames, int max_depth);
     int convertFrames(jvmtiFrameInfo* jvmti_frames, ASGCT_CallFrame* frames, int num_frames);
     void fillFrameTypes(ASGCT_CallFrame* frames, int num_frames, NMethod* nmethod);
-    void updateThreadName(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);
+    void updateThreadName(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread, bool self = false);
     void updateJavaThreadNames();
     void updateNativeThreadNames();
     void mangle(const char* name, char* buf, size_t size);

--- a/ddprof-lib/src/main/cpp/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/vmStructs.h
@@ -426,7 +426,7 @@ class VMThread : VMStructs {
     }
 
     static VMThread* fromJavaThread(JNIEnv* env, jthread thread) {
-        return (VMThread*)(uintptr_t)env->GetLongField(thread, _eetop);
+        return _eetop != NULL && thread != NULL ? (VMThread*)(uintptr_t)env->GetLongField(thread, _eetop) : NULL;
     }
 
     static VMThread* fromEnv(JNIEnv* env) {


### PR DESCRIPTION
**What does this PR do?**:
Make the code poking in the thread internals more resilient not to crash on unexpected states. Also, fall back to a different mode of retrieving the native thread id where it makes sense.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [X] JIRA: [PROF-9543]

Unsure? Have a question? Request a review!


[PROF-9543]: https://datadoghq.atlassian.net/browse/PROF-9543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ