### PR TITLE
drop bad queue time events

### DIFF
--- a/ddprof-lib/src/main/cpp/javaApi.cpp
+++ b/ddprof-lib/src/main/cpp/javaApi.cpp
@@ -229,7 +229,13 @@ Java_com_datadoghq_profiler_JavaProfiler_recordQueueEnd0(JNIEnv* env, jobject un
     JniString task_str(env, task);
     JniString scheduler_str(env, scheduler);
     int task_offset = Profiler::instance()->lookupClass(task_str.c_str(), task_str.length());
+    if (task_offset < 0) {
+        return;
+    }
     int scheduler_offset = Profiler::instance()->lookupClass(scheduler_str.c_str(), scheduler_str.length());
+    if (scheduler_offset < 0) {
+        return;
+    }
     u64 now = TSC::ticks();
     QueueTimeEvent event;
     event._start = now - endTime + startTime;


### PR DESCRIPTION
**What does this PR do?**:
Queue time events which are committed during a profiler dump may end up with null scheduler and task attributes, if they are committed just as the class map is being cleared, because the lock can't be acquired when looking up the class name. These events aren't very useful so we'll drop them for now.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
