### PR TITLE
trust ticks parameters

### DIFF
--- a/ddprof-lib/src/main/cpp/javaApi.cpp
+++ b/ddprof-lib/src/main/cpp/javaApi.cpp
@@ -236,10 +236,9 @@ Java_com_datadoghq_profiler_JavaProfiler_recordQueueEnd0(JNIEnv* env, jobject un
     if (scheduler_offset < 0) {
         return;
     }
-    u64 now = TSC::ticks();
     QueueTimeEvent event;
-    event._start = now - endTime + startTime;
-    event._end = now;
+    event._start = startTime;
+    event._end = endTime;
     event._task = task_offset;
     event._scheduler = scheduler_offset;
     event._origin = origin_tid;


### PR DESCRIPTION
**What does this PR do?**:
Removes a workaround for ticks being provided with the wrong origin

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
