### PR TITLE
avoid unwinding the same stack for wallclock samples

### DIFF
--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -60,7 +60,8 @@
     X(AGCT_NATIVE_NO_JAVA_CONTEXT, "agct_native_no_java_context")     \
     X(AGCT_BLOCKED_IN_VM, "agct_blocked_in_vm") \
     X(HANDLED_SIGSEGV_SAFEFETCH, "handled_sigsegv_safefetch") \
-    X(HANDLED_SIGSEGV_WALKVM, "handled_sigsegv_walkvm")
+    X(HANDLED_SIGSEGV_WALKVM, "handled_sigsegv_walkvm") \
+    X(SKIPPED_WALLCLOCK_UNWINDS, "skipped_wallclock_unwinds")
 #define X_ENUM(a, b) a,
 typedef enum CounterId : int {
     DD_COUNTER_TABLE(X_ENUM) DD_NUM_COUNTERS

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -193,7 +193,7 @@ void CTimer::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     int tid = 0;
     ProfiledThread* current = ProfiledThread::current();
     if (current != NULL) {
-        current->noteCPUSample();
+        current->noteCPUSample(Profiler::instance()->recordingEpoch());
         tid = current->tid();
     } else {
         tid = OS::threadId();
@@ -207,7 +207,7 @@ void CTimer::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
                 ? convertJvmExecutionState(vm_thread->state())
                 : ExecutionMode::JVM;
     }
-    Profiler::instance()->recordSample(ucontext, _interval, tid, BCI_CPU, &event);
+    Profiler::instance()->recordSample(ucontext, _interval, tid, BCI_CPU, 0, &event);
     Shims::instance().setSighandlerTid(-1);
 }
 

--- a/ddprof-lib/src/main/cpp/event.h
+++ b/ddprof-lib/src/main/cpp/event.h
@@ -40,8 +40,9 @@ class ExecutionEvent : public Event {
     ThreadState _thread_state;
     ExecutionMode _execution_mode;
     u64 _weight;
+    u32 _call_trace_id;
 
-    ExecutionEvent() : Event(), _thread_state(ThreadState::RUNNABLE), _weight(1), _execution_mode(ExecutionMode::UNKNOWN) {}
+    ExecutionEvent() : Event(), _thread_state(ThreadState::RUNNABLE), _weight(1), _execution_mode(ExecutionMode::UNKNOWN), _call_trace_id(0) {}
 };
 
 class AllocEvent : public Event {

--- a/ddprof-lib/src/main/cpp/itimer.cpp
+++ b/ddprof-lib/src/main/cpp/itimer.cpp
@@ -32,7 +32,7 @@ void ITimer::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     int tid = 0;
     ProfiledThread* current = ProfiledThread::current();
     if (current != NULL) {
-        current->noteCPUSample();
+        current->noteCPUSample(Profiler::instance()->recordingEpoch());
         tid = current->tid();
     } else {
         tid = OS::threadId();
@@ -46,7 +46,7 @@ void ITimer::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
                 ? convertJvmExecutionState(vm_thread->state())
                 : ExecutionMode::JVM;
     }
-    Profiler::instance()->recordSample(ucontext, _interval, tid, BCI_CPU, &event);
+    Profiler::instance()->recordSample(ucontext, _interval, tid, BCI_CPU, 0, &event);
     Shims::instance().setSighandlerTid(-1);
 }
 

--- a/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
+++ b/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
@@ -705,7 +705,7 @@ void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
 
     ProfiledThread* current = ProfiledThread::current();
     if (current != NULL) {
-        current->noteCPUSample();
+        current->noteCPUSample(Profiler::instance()->recordingEpoch());
     }
     int tid = current != NULL ? current->tid() : OS::threadId();
     if (_enabled) {
@@ -719,7 +719,7 @@ void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
                 ? convertJvmExecutionState(vm_thread->state())
                 : ExecutionMode::JVM;
         }
-        Profiler::instance()->recordSample(ucontext, counter, tid, BCI_CPU, &event);
+        Profiler::instance()->recordSample(ucontext, counter, tid, BCI_CPU, 0, &event);
         Shims::instance().setSighandlerTid(-1);
     } else {
         resetBuffer(tid);

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -127,7 +127,7 @@ class Profiler {
 
     time_t _start_time;
     time_t _stop_time;
-    int _epoch;
+    u32 _epoch;
     WaitableMutex _timer_lock;
     void* _timer_id;
 
@@ -252,6 +252,10 @@ class Profiler {
         }
     }
 
+    inline u32 recordingEpoch() {
+        return _epoch;
+    }
+
     Error run(Arguments& args);
     Error runInternal(Arguments& args, std::ostream& out);
     Error restart(Arguments& args);
@@ -263,7 +267,7 @@ class Profiler {
     Error dump(const char* path, const int length);
     void switchThreadEvents(jvmtiEventMode mode);
     int convertNativeTrace(int native_frames, const void** callchain, ASGCT_CallFrame* frames);
-    void recordSample(void* ucontext, u64 counter, int tid, jint event_type, Event* event);
+    void recordSample(void* ucontext, u64 counter, int tid, jint event_type, u32 call_trace_id, Event* event);
     void recordExternalSample(u64 counter, int tid, jvmtiFrameInfo *jvmti_frames, jint num_jvmti_frames, bool truncated, jint event_type, Event* event);
     void recordExternalSample(u64 counter, int tid, int num_frames, ASGCT_CallFrame* frames, bool truncated, jint event_type, Event* event);
     void recordWallClockEpoch(int tid, WallClockEpochEvent* event);

--- a/ddprof-lib/src/main/cpp/thread.cpp
+++ b/ddprof-lib/src/main/cpp/thread.cpp
@@ -158,22 +158,6 @@ void ProfiledThread::releaseFromBuffer() {
     }
 }
 
-bool ProfiledThread::noteWallSample(u64 context_key, u64* skipped_samples) {
-    if (_wall_epoch == _cpu_epoch && _context_key == context_key) {
-        *skipped_samples = ++_skipped_samples;
-        if (_skipped_samples % 10 != 0) {
-            _skipped_samples = 0;
-            return true;
-        }
-        return false;
-    }
-    _context_key = context_key;
-    _wall_epoch = _cpu_epoch;
-    *skipped_samples = _skipped_samples;
-    _skipped_samples = 0;
-    return true;
-}
-
 int ProfiledThread::currentTid() {
     ProfiledThread* tls = current();
     if (tls != NULL) {


### PR DESCRIPTION
**What does this PR do?**:
If we have the same pc, same span id, haven't dumped the recording (which means clearing the call trace storage), haven't taken any cpu samples on the same thread since the last wallclock sample was taken, we don't need to unwind the stack twice and can refer back to the last call trace id.

**Motivation**:
Reduce overhead, reduce number of calls to `AsyncGetCallTrace`

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
