### PR TITLE
refactor log level and enum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,8 @@ jobs:
             ddprof-test/build/reports/tests
             ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
             ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
+            ddprof-lib/build/tmp/linkDebugLinux/output.txt
+            ddprof-lib/build/tmp/*/output.txt
       - uses: actions/upload-artifact@v3
         if: success()
         with:
@@ -169,6 +171,8 @@ jobs:
             ddprof-test/build/reports/tests
             ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
             ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
+            ddprof-lib/build/tmp/linkDebugLinux/output.txt
+            ddprof-lib/build/tmp/*/output.txt
       - uses: actions/upload-artifact@v3
         if: success()
         with:

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -675,7 +675,7 @@ void Recording::writeSettings(Buffer* buf, Arguments& args) {
     writeIntSetting(buf, T_ACTIVE_RECORDING, "safemode", args._safe_mode);
     writeIntSetting(buf, T_ACTIVE_RECORDING, "jfropts", args._jfr_options);
     writeIntSetting(buf, T_ACTIVE_RECORDING, "tscfrequency", TSC::frequency());
-    writeStringSetting(buf, T_ACTIVE_RECORDING, "loglevel", Log::LEVEL_NAME[Log::level()]);
+    writeStringSetting(buf, T_ACTIVE_RECORDING, "loglevel", Log::level());
     writeBoolSetting(buf, T_ACTIVE_RECORDING, "hotspot", VM::isHotspot());
     writeBoolSetting(buf, T_ACTIVE_RECORDING, "openj9", VM::isOpenJ9());
     for (auto attribute : args._context_attributes) {

--- a/ddprof-lib/src/main/cpp/log.cpp
+++ b/ddprof-lib/src/main/cpp/log.cpp
@@ -18,16 +18,6 @@
 #include "log.h"
 #include "profiler.h"
 
-
-const char* const Log::LEVEL_NAME[] = {
-    "TRACE",
-    "DEBUG",
-    "INFO",
-    "WARN",
-    "ERROR",
-    "NONE"
-};
-
 FILE* Log::_file = stdout;
 LogLevel Log::_level = LOG_NONE;
 
@@ -94,8 +84,8 @@ void Log::log(LogLevel level, const char* msg, va_list args) {
         Profiler::instance()->writeLog(level, buf, len);
     }
 
-    // always log errors, but only errors
-    if (level == LOG_ERROR) {
+    // always log errors unless explicitly disabled
+    if (level == LOG_ERROR && _level <= LOG_ERROR) {
         fprintf(_file, "{\"@version\":\"1\",\"message\":\"%s\",\"logger_name\":\"java-profiler\",\"level\":\"%s\"}\n", buf, LEVEL_NAME[level]);
         fflush(_file);
     }

--- a/ddprof-lib/src/main/cpp/log.h
+++ b/ddprof-lib/src/main/cpp/log.h
@@ -26,14 +26,19 @@
 #define ATTR_FORMAT
 #endif
 
-enum LogLevel {
-    LOG_TRACE,
-    LOG_DEBUG,
-    LOG_INFO,
-    LOG_WARN,
-    LOG_ERROR,
-    LOG_NONE
-};
+#define DD_LOG_LEVELS(X) \
+    X(LOG_TRACE, "TRACE") \
+    X(LOG_DEBUG, "DEBUG") \
+    X(LOG_INFO, "INFO")  \
+    X(LOG_WARN, "WARN")  \
+    X(LOG_ERROR, "ERROR") \
+    X(LOG_NONE, "NONE")
+
+#define X_ENUM(a, b) a,
+typedef enum LogLevel : int {
+    DD_LOG_LEVELS(X_ENUM) DD_NUM_LOG_LEVELS
+} LogLevel;
+#undef X_ENUM
 
 class Arguments;
 
@@ -43,7 +48,11 @@ class Log {
     static LogLevel _level;
 
   public:
-    static const char* const LEVEL_NAME[];
+    #define X_NAME(a, b) b,
+        static constexpr const char* LEVEL_NAME[] = {
+                DD_LOG_LEVELS(X_NAME)
+        };
+    #undef X_NAME
 
     static void open(Arguments& args);
     static void open(const char* file_name, const char* level);
@@ -57,7 +66,12 @@ class Log {
     static void ATTR_FORMAT warn(const char* msg, ...);
     static void ATTR_FORMAT error(const char* msg, ...);
 
-    static LogLevel level() { return _level; }
+    static const char* level() {
+        if (_level >= 0 && _level < DD_NUM_LOG_LEVELS) {
+            return LEVEL_NAME[_level];
+        }
+        return "INVALID";
+    }
 };
 
 #endif // _LOG_H


### PR DESCRIPTION
**What does this PR do?**:
Minor refactor of the log level so we don't access the log level array, and don't need two parallel definitions of the log levels. Also makes sure we don't log to stdout if the log level is set to NONE.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
