### PR TITLE
Manage mutex resources

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -992,7 +992,7 @@ void Recording::writeThreads(Buffer* buf) {
     _thread_set.clear();
 
     Profiler* profiler = Profiler::instance();
-    ThreadInfo t_info = profiler->_thread_info;
+    ThreadInfo* t_info = &profiler->_thread_info;
 
     char name_buf[32];
 
@@ -1001,7 +1001,7 @@ void Recording::writeThreads(Buffer* buf) {
     for (int i = 0; i < threads.size(); i++) {
         const char* thread_name;
         jlong thread_id;
-        std::pair<std::shared_ptr<std::string>, u64> info = t_info.get(threads[i]);
+        std::pair<std::shared_ptr<std::string>, u64> info = t_info->get(threads[i]);
         if (info.first) {
             thread_name = info.first->c_str();
             thread_id = info.second;

--- a/ddprof-lib/src/main/cpp/mutex.cpp
+++ b/ddprof-lib/src/main/cpp/mutex.cpp
@@ -15,13 +15,18 @@
  */
 
 #include "mutex.h"
-
+#include <stdio.h>
+#include <stdlib.h>
 
 Mutex::Mutex() {
-    pthread_mutexattr_t attr;
-    pthread_mutexattr_init(&attr);
-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
-    pthread_mutex_init(&_mutex, &attr);
+    pthread_mutexattr_init(&_attr);
+    pthread_mutexattr_settype(&_attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&_mutex, &_attr);
+}
+
+Mutex::~Mutex() {
+    pthread_mutex_destroy(&_mutex);
+    pthread_mutexattr_destroy(&_attr);
 }
 
 void Mutex::lock() {

--- a/ddprof-lib/src/main/cpp/mutex.h
+++ b/ddprof-lib/src/main/cpp/mutex.h
@@ -22,11 +22,14 @@
 
 
 class Mutex {
+  private:
+   pthread_mutexattr_t _attr;
   protected:
     pthread_mutex_t _mutex;
 
   public:
     Mutex();
+    ~Mutex();
 
     void lock();
     void unlock();

--- a/ddprof-lib/src/main/cpp/threadInfo.h
+++ b/ddprof-lib/src/main/cpp/threadInfo.h
@@ -13,6 +13,12 @@ class ThreadInfo {
     std::map<int, u64> _thread_ids;
 
   public:
+    // disallow copy and assign to avoid issues with the mutex
+    ThreadInfo(const ThreadInfo&) = delete;
+    ThreadInfo& operator=(const ThreadInfo&) = delete;
+
+    ThreadInfo() {}
+
     void set(int tid, const char* name, u64 java_thread_id);
     std::pair<std::shared_ptr<std::string>, u64> get(int tid);
 


### PR DESCRIPTION
**What does this PR do?**:
It adds explicit management of the mutex resources. 
It avoids copying of `ThreadInfo` instance which would include a `Mutex` instance without having copy-constructor defined.

**Motivation**:
It turns out that copying mutex instances without having an appropriate copy-constructor is somehow affecting the locking and intermittently blocks indefinitely on an attempt to obtain a lock.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-9733]

Unsure? Have a question? Request a review!


[PROF-9733]: https://datadoghq.atlassian.net/browse/PROF-9733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ