### PR TITLE
remove JVMTI Agent hooks

### DIFF
--- a/ddprof-lib/src/main/cpp/vmEntry.h
+++ b/ddprof-lib/src/main/cpp/vmEntry.h
@@ -121,8 +121,6 @@ class VM {
 
     static bool init(JavaVM* vm, bool attach);
 
-    static void restartProfiler();
-
     static jvmtiEnv* jvmti() {
         return _jvmti;
     }


### PR DESCRIPTION
**What does this PR do?**:
We don't need any of these hooks, and removing them would simplify the Arguments class, which currently has a complicated and error prone sharing mechanism which I would like to simplify. I've left VMDeath in place even though we could replicate this in the java agent, because it seems prudent to have a safety net for cleanup in place.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
