### PR TITLE
Fix arguments ownership

### DIFF
--- a/ddprof-lib/src/main/cpp/arguments.h
+++ b/ddprof-lib/src/main/cpp/arguments.h
@@ -179,6 +179,35 @@ class Arguments {
         _lightweight(false) {
     }
 
+    Arguments(Arguments& arguments) :
+        _buf(NULL),
+        _shared(false),
+        _persistent(false),
+        _action(arguments._action),
+        _ring(arguments._ring),
+        _event(arguments._event),
+        _interval(arguments._interval),
+        _cpu(arguments._cpu),
+        _wall(arguments._wall),
+        _wall_collapsing(arguments._wall_collapsing),
+        _wall_threads_per_tick(arguments._wall_threads_per_tick),
+        _memory(arguments._memory),
+        _record_allocations(arguments._record_allocations),
+        _record_liveness(arguments._record_liveness),
+        _record_heap_usage(arguments._record_heap_usage),
+        _jstackdepth(arguments._jstackdepth),
+        _safe_mode(arguments._safe_mode),
+        _file(arguments._file),
+        _log(arguments._log),
+        _loglevel(arguments._loglevel),
+        _unknown_arg(arguments._unknown_arg),
+        _filter(arguments._filter),
+        _cstack(arguments._cstack),
+        _jfr_options(arguments._jfr_options),
+        _context_attributes(arguments._context_attributes),
+        _lightweight(arguments._lightweight) {
+    }
+
     ~Arguments();
 
     void save(Arguments& other);

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1340,7 +1340,7 @@ Error FlightRecorder::start(Arguments& args, bool reset) {
         return Error("Flight Recorder output file is not specified");
     }
     _filename = file;
-    _args = args;
+    _args = new Arguments(args);
 
     if (!TSC::initialized()) {
         TSC::initialize();
@@ -1357,18 +1357,21 @@ Error FlightRecorder::newRecording(bool reset) {
         return Error("Could not open Flight Recorder output file");
     }
 
-    _rec = new Recording(fd, _args);
+    _rec = new Recording(fd, *_args);
     return Error::OK;
 }
 
 void FlightRecorder::stop() {
-    if (_rec != NULL) {
+    if (_rec != nullptr) {
         _rec_lock.lock();
 
         Recording *tmp = _rec;
         // NULL first, deallocate later
         _rec = NULL;
         delete tmp;
+    }
+    if (_args != nullptr) {
+        delete _args;
     }
 }
 

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -274,13 +274,13 @@ class FlightRecorder {
   friend Profiler;
   private:
     std::string _filename;
-    Arguments _args;
+    Arguments* _args;
     Recording* _rec;
 
     Error newRecording(bool reset);
 
   public:
-    FlightRecorder() : _rec(NULL) {}
+    FlightRecorder() : _rec(nullptr), _args(nullptr) {}
     Error start(Arguments& args, bool reset);
     void stop();
     Error dump(const char* filename, const int length);

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1372,11 +1372,12 @@ Error Profiler::restart(Arguments& args) {
     return Error::OK;
 }
 
-void Profiler::shutdown(Arguments& args) {
+void Profiler::shutdown() {
     MutexLocker ml(_state_lock);
 
     // The last chance to dump profile before VM terminates
     if (_state == RUNNING) {
+        Arguments args;
         args._action = ACTION_STOP;
         Error error = run(args);
         if (error) {

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -259,7 +259,7 @@ class Profiler {
     Error run(Arguments& args);
     Error runInternal(Arguments& args, std::ostream& out);
     Error restart(Arguments& args);
-    void shutdown(Arguments& args);
+    void shutdown();
     Error check(Arguments& args);
     Error start(Arguments& args, bool reset);
     Error stop();

--- a/ddprof-lib/src/main/cpp/vmEntry.cpp
+++ b/ddprof-lib/src/main/cpp/vmEntry.cpp
@@ -36,8 +36,6 @@
 const int ARGUMENTS_ERROR = 100;
 const int COMMAND_ERROR = 200;
 
-static Arguments _agent_args(true);
-
 JavaVM* VM::_vm;
 jvmtiEnv* VM::_jvmti = NULL;
 
@@ -388,7 +386,7 @@ void VM::loadAllMethodIDs(jvmtiEnv* jvmti, JNIEnv* jni) {
 }
 
 void JNICALL VM::VMDeath(jvmtiEnv* jvmti, JNIEnv* jni) {
-    Profiler::instance()->shutdown(_agent_args);
+    Profiler::instance()->shutdown();
 }
 
 jvmtiError VM::RedefineClassesHook(jvmtiEnv* jvmti, jint class_count, const jvmtiClassDefinition* class_definitions) {


### PR DESCRIPTION
**What does this PR do?**:
This change means the `Recording` owns the lifecycle of the arguments passed to it, which is done by taking a snapshot. I simplified the stop call made from the `VMDeath` callback to facilitate this.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
