### PR TITLE
Do not attempt to read JavaThread state from non-JavaThread threads

### DIFF
--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -73,7 +73,8 @@ void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext, u64
 
     ExecutionEvent event;
     VMThread* vm_thread = VMThread::current();
-    int raw_thread_state = vm_thread ? vm_thread->state() : 0;
+    bool is_java_thread = vm_thread && VM::jni();
+    int raw_thread_state = vm_thread && is_java_thread ? vm_thread->state() : 0;
     bool is_initialized = raw_thread_state >= 4 && raw_thread_state < 12;
     ThreadState state = ThreadState::UNKNOWN;
     ExecutionMode mode = ExecutionMode::UNKNOWN;
@@ -82,7 +83,7 @@ void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext, u64
         if (os_state != ThreadState::UNKNOWN) {
             state = os_state;
         }
-        mode = VM::jni() != NULL ? convertJvmExecutionState(raw_thread_state) : ExecutionMode::JVM;
+        mode = is_java_thread ? convertJvmExecutionState(raw_thread_state) : ExecutionMode::JVM;
     }
     if (state == ThreadState::UNKNOWN) {
         if (inSyscall(ucontext)) {


### PR DESCRIPTION
**What does this PR do?**:
The wallclock signal handler is trying to read Java thread state from the current thread indiscriminately and this means we might be accessing invalid memory for non-Java threads.
Unfortunately, the only way to test whether we are in a Java or attached Java thread (which can be resolved to jthread and therefore reading its state is valid) is to try and get the JNI environment. And that's what we do here.

**Motivation**:
This issue is flagged by ASAN but it can also lead to very weird thread states reported for non-Java threads.

**Additional Notes**:
Asan CI run showing that this change is fixing the asan report - https://github.com/DataDog/java-profiler/actions/runs/9317890928

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-9838]

Unsure? Have a question? Request a review!


[PROF-9838]: https://datadoghq.atlassian.net/browse/PROF-9838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ