### PR TITLE
Add debug option to specify MALLOC_ARENA_MAX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 plugins {
-  id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
+  id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
   id "com.diffplug.spotless" version "6.11.0"
 }
 

--- a/ddprof-lib/src/main/cpp/javaApi.cpp
+++ b/ddprof-lib/src/main/cpp/javaApi.cpp
@@ -254,3 +254,8 @@ extern "C" DLLEXPORT jlong JNICALL
 Java_com_datadoghq_profiler_JavaProfiler_tscFrequency0(JNIEnv* env, jobject unused) {
     return TSC::frequency();
 }
+
+extern "C" DLLEXPORT void JNICALL
+Java_com_datadoghq_profiler_JavaProfiler_mallocArenaMax0(JNIEnv* env, jobject unused, jint maxArenas) {
+    OS::mallocArenaMax(maxArenas);
+}

--- a/ddprof-lib/src/main/cpp/os.h
+++ b/ddprof-lib/src/main/cpp/os.h
@@ -93,6 +93,8 @@ class OS {
     static int fileSize(int fd);
     static int truncateFile(int fd);
     static void freePageCache(int fd, off_t start_offset);
+
+    static void mallocArenaMax(int arena_max);
 };
 
 #endif // _OS_H

--- a/ddprof-lib/src/main/cpp/os_linux.cpp
+++ b/ddprof-lib/src/main/cpp/os_linux.cpp
@@ -35,6 +35,9 @@
 #include <unistd.h>
 #include "os.h"
 
+#ifndef __musl__
+#include <malloc.h>
+#endif
 
 #ifdef __LP64__
 #  define MMAP_SYSCALL __NR_mmap
@@ -358,6 +361,12 @@ int OS::fileSize(int fd) {
 
 void OS::freePageCache(int fd, off_t start_offset) {
     posix_fadvise(fd, start_offset & ~page_mask, 0, POSIX_FADV_DONTNEED);
+}
+
+void OS::mallocArenaMax(int arena_max) {
+#ifndef __musl__
+    mallopt(M_ARENA_MAX, arena_max);
+#endif
 }
 
 #endif // __linux__

--- a/ddprof-lib/src/main/cpp/os_macos.cpp
+++ b/ddprof-lib/src/main/cpp/os_macos.cpp
@@ -342,4 +342,8 @@ void OS::freePageCache(int fd, off_t start_offset) {
     // Not supported on macOS
 }
 
+void OS::mallocArenaMax(int arena_max) {
+    // Not supported on macOS
+}
+
 #endif // __APPLE__

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/context/TagContextTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/context/TagContextTest.java
@@ -68,6 +68,8 @@ public class TagContextTest extends AbstractProfilerTest {
         long sum = 0;
         long[] weights = new long[strings.length];
         for (int i = 0; i < strings.length; i++) {
+            AtomicLong weight = weightsByTagValue.get(strings[i]);
+            assertNotNull(weight, "Weight for " + strings[i] + " not found");
             weights[i] = weightsByTagValue.get(strings[i]).get();
             sum += weights[i];
         }


### PR DESCRIPTION
**What does this PR do?**:
It adds a debug option to specify MALLOC_ARENA_MAX via `mallopt`

**Motivation**:
Make it less error prone to diagnose potential malloc fragmentation issues in customer env (eg. no need to set a separate env variable)

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
