### PR TITLE
Fix array decay truncating native thread names

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -932,8 +932,9 @@ void Profiler::updateNativeThreadNames() {
     ThreadList* thread_list = OS::listThreads();
     for (int tid; (tid = thread_list->next()) != -1; ) {
         _thread_info.updateThreadName(tid, [](int tid) -> std::unique_ptr<char[]> {
-            char *name_buf = new char[64];
-            if (OS::threadName(tid, name_buf, sizeof(name_buf))) {
+            const size_t buffer_size = 64;
+            char *name_buf = new char[buffer_size];
+            if (OS::threadName(tid, name_buf, buffer_size)) {
                 return std::unique_ptr<char[]>(name_buf);
             }
             delete[] name_buf;


### PR DESCRIPTION
**What does this PR do?**:
This addresses PROF-9879 by fixing an array decay issue causing truncation of thread names down to pointer size, rather than available buffer size

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->
We could look at changing how we do the ownership / allocation here as well, cc @r1viollet - but this will resolve the issue safely

**How to test the change?**:
I haven't added a test for this- it's a classic C/C++ bug which thankfully couldn't cause any fatal issues. I have reviewed that this change won't cause issues in the MacOS profiler, which uses `pthread_getname_np` rather than `/proc/self/stat`.
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
