### PR TITLE
Trigger 'keep-jmethodids' mode on J9 where supported

### DIFF
--- a/ddprof-lib/src/main/cpp/j9Ext.cpp
+++ b/ddprof-lib/src/main/cpp/j9Ext.cpp
@@ -17,7 +17,7 @@
 #include <string.h>
 #include "j9Ext.h"
 #include "j9ObjectSampler.h"
-#include <string.h>
+#include "os.h"
 
 
 jvmtiEnv* J9Ext::_jvmti;
@@ -69,4 +69,12 @@ bool J9Ext::initialize(jvmtiEnv* jvmti, const void* j9thread_self) {
     }
 
     return _GetOSThreadID != NULL && _GetStackTraceExtended != NULL && _GetAllStackTracesExtended != NULL;
+}
+
+void J9Ext::tryForceKeepJMethodIDs() {
+    // try to force keeping jmethodIDs around by calling ASGCT at least once
+    JitWriteProtection jit(false);
+    ASGCT_CallFrame frames[1];
+    ASGCT_CallTrace trace = {VM::jni(), 0, frames};
+    VM::_asyncGetCallTrace(&trace, 0, nullptr);
 }

--- a/ddprof-lib/src/main/cpp/j9Ext.h
+++ b/ddprof-lib/src/main/cpp/j9Ext.h
@@ -62,6 +62,7 @@ class J9Ext {
     }
 
     static bool initialize(jvmtiEnv* jvmti, const void* j9thread_self);
+    static void tryForceKeepJMethodIDs();
 
     static int GetOSThreadID(jthread thread) {
         jlong thread_id;

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1097,6 +1097,10 @@ Error Profiler::start(Arguments& args, bool reset) {
     // Kernel symbols are useful only for perf_events without --all-user
     updateSymbols(_cpu_engine == &perf_events && (args._ring & RING_KERNEL));
 
+    if (VM::isOpenJ9()) {
+        J9Ext::tryForceKeepJMethodIDs();
+    }
+
     enableEngines();
 
     switchLibraryTrap(_cstack == CSTACK_DWARF);

--- a/ddprof-lib/src/main/cpp/vmEntry.cpp
+++ b/ddprof-lib/src/main/cpp/vmEntry.cpp
@@ -291,6 +291,10 @@ bool VM::init(JavaVM* vm, bool attach) {
             *flag_addr = 1;
         }
     }
+    char* flag_addr = (char*)JVMFlag::find("KeepJNIIDs");
+    if (flag_addr != NULL) {
+        *flag_addr = 1;
+    }
 
     // if the user sets -XX:+UseAdaptiveGCBoundary we will just disable the profiler to avoid the risk of crashing
     // flag was made obsolete (inert) in 15 (see JDK-8228991) and removed in 16 (see JDK-8231560)


### PR DESCRIPTION
**What does this PR do?**:
For J9 it inserts one bogus call to ASGCT to trigger 'keep-jmethodids' mode. Otherwise, accessing stacktraces collected via JVMTI is still prone to crashing due to jmethodids being deallocated.

**Motivation**:
 Make profiling on recent J9 engined more stable.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-10050]

Unsure? Have a question? Request a review!
