### PR TITLE
Do not use vmstructs to recover from crash on J9

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -866,15 +866,18 @@ bool Profiler::crashHandler(int signo, siginfo_t* siginfo, void* ucontext) {
         return true;
     }
 
-    StackWalker::checkFault();
-
-    // Workaround for JDK-8313796. Setting cstack=dwarf also helps
-    if (VMStructs::isInterpretedFrameValidFunc((const void*)pc) && frame.skipFaultInstruction()) {
+    if (WX_MEMORY && Trap::isFaultInstruction(pc)) {
         return true;
     }
 
-    if (WX_MEMORY && Trap::isFaultInstruction(pc)) {
-        return true;
+    if (VM::isHotspot()) {
+        // the following checks require vmstructs and therefore HotSpot
+        StackWalker::checkFault();
+
+        // Workaround for JDK-8313796. Setting cstack=dwarf also helps
+        if (VMStructs::isInterpretedFrameValidFunc((const void*)pc) && frame.skipFaultInstruction()) {
+            return true;
+        }
     }
 
     return false;


### PR DESCRIPTION
**What does this PR do?**:
It skips the checks requiring vmstructs on J9

**Motivation**:
vmstructs are not available on J9. Using them means accessing memory referenced via the default offset values (mostly -1) which can give very 'interesting' results.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
