### PR TITLE
PROF-10079: jvmti based wallclock sampler

### DIFF
--- a/ddprof-lib/src/main/cpp/arguments.cpp
+++ b/ddprof-lib/src/main/cpp/arguments.cpp
@@ -290,6 +290,18 @@ Error Arguments::parse(const char* args) {
                     }
                 }
 
+            CASE("wallsampler")
+                if (value != NULL) {
+                    switch (value[0]) {
+                        case 'j':
+                            _wallclock_sampler = JVMTI;
+                            break;
+                        case 'a':
+                        default:
+                            _wallclock_sampler = ASGCT;
+                    }
+                }
+
             DEFAULT()
                 if (_unknown_arg == NULL) _unknown_arg = arg;
         }

--- a/ddprof-lib/src/main/cpp/arguments.h
+++ b/ddprof-lib/src/main/cpp/arguments.h
@@ -85,6 +85,11 @@ enum JfrOption {
     JFR_SYNC_OPTS   = NO_SYSTEM_INFO | NO_SYSTEM_PROPS | NO_NATIVE_LIBS | NO_CPU_LOAD
 };
 
+enum WallclockSampler {
+    ASGCT,
+    JVMTI
+};
+
 
 struct Multiplier {
     char symbol;
@@ -134,6 +139,7 @@ class Arguments {
     long _wall;
     bool _wall_collapsing;
     int _wall_threads_per_tick;
+    WallclockSampler _wallclock_sampler;
     long _memory;
     bool _record_allocations;
     bool _record_liveness;
@@ -178,7 +184,8 @@ class Arguments {
         _cstack(CSTACK_DEFAULT),
         _jfr_options(0),
         _context_attributes({}),
-        _lightweight(false) {
+        _lightweight(false),
+        _wallclock_sampler(ASGCT){
     }
 
     ~Arguments();

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -37,6 +37,7 @@
 #include "vmEntry.h"
 #include "objectSampler.h"
 #include "thread.h"
+#include <vector>
 
 // avoid linking against newer symbols here for wide compatibility
 #ifdef __GLIBC__
@@ -112,6 +113,9 @@ class Profiler {
     int _max_stack_depth;
     int _safe_mode;
     CStack _cstack;
+
+    Mutex _jthread_mutex;
+    map<int, jthread> _jthreads;
 
     volatile jvmtiEventMode _thread_events_state;
 
@@ -272,6 +276,7 @@ class Profiler {
 
     static int registerThread(int tid);
     static void unregisterThread(int tid);
+    void getThreads(const vector<int>& tids, std::vector<jthread>& threads);
 
     // CompiledMethodLoad is also needed to enable DebugNonSafepoints info by default
     static void JNICALL CompiledMethodLoad(jvmtiEnv* jvmti, jmethodID method,

--- a/ddprof-lib/src/main/cpp/reservoir_sampler.h
+++ b/ddprof-lib/src/main/cpp/reservoir_sampler.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 Datadog
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RESERVOIR_SAMPLER_H
+#define RESERVOIR_SAMPLER_H
+
+#include <math.h>
+#include <random>
+#include <vector>
+
+
+template <class T>
+class ReservoirSampler {
+private:
+    const int size;
+    std::mt19937 generator;
+    std::uniform_real_distribution<double> uniform;
+    std::uniform_int_distribution<int> random_index;
+    std::vector<T> reservoir;
+
+public:
+    ReservoirSampler(const int size) :
+        size(size),
+        generator((std::random_device())()),
+        uniform(1e-16, 1.0),
+        random_index(0, size - 1) {
+        reservoir.reserve(size);
+    }
+
+    std::vector<T>& sample(const std::vector<T> &input) {
+        reservoir.clear();
+        for (int i = 0; i < size && i < input.size(); i++) {
+            reservoir.push_back(input[i]);
+        }
+        double weight = exp(log(uniform(generator)) / size);
+        int target = size + (int) (log(uniform(generator)) / log(1 - weight));
+        while (target < input.size()) {
+            reservoir[random_index(generator)] = input[target];
+            weight *= exp(log(uniform(generator)) / size);
+            target += (int) (log(uniform(generator)) / log(1 - weight));
+        }
+        return reservoir;
+    }
+};
+
+#endif //RESERVOIR_SAMPLER_H

--- a/ddprof-lib/src/main/cpp/threadState.h
+++ b/ddprof-lib/src/main/cpp/threadState.h
@@ -16,6 +16,30 @@ enum class ThreadState : int {
     SYSCALL = 9                       // does not originate in the JVM, used when the current frame is known to be a syscall
 };
 
+static ThreadState convertJvmtiThreadState(int state) {
+    switch (state & 0xFFFF) {
+        case JVMTI_THREAD_STATE_ALIVE:
+            return ThreadState::NEW;
+        case JVMTI_THREAD_STATE_TERMINATED:
+            return ThreadState::TERMINATED;
+        case JVMTI_THREAD_STATE_RUNNABLE:
+            return ThreadState::RUNNABLE;
+        case JVMTI_THREAD_STATE_BLOCKED_ON_MONITOR_ENTER:
+            return ThreadState::MONITOR_WAIT;
+        case JVMTI_THREAD_STATE_WAITING:
+        case JVMTI_THREAD_STATE_WAITING_INDEFINITELY:
+        case JVMTI_THREAD_STATE_WAITING_WITH_TIMEOUT:
+        case JVMTI_THREAD_STATE_PARKED:
+            return ThreadState::CONDVAR_WAIT;
+        case JVMTI_THREAD_STATE_SLEEPING:
+            return ThreadState::SLEEPING;
+        case JVMTI_THREAD_STATE_IN_OBJECT_WAIT:
+            return ThreadState::OBJECT_WAIT;
+        default:
+            return ThreadState::UNKNOWN;
+    }
+}
+
 
 enum class ExecutionMode : int {
     UNKNOWN = 0,
@@ -43,6 +67,10 @@ static ExecutionMode convertJvmExecutionState(int state) {
         default:
             return ExecutionMode::UNKNOWN;
     }
+}
+
+static ExecutionMode getExecutionModeFromJvmtiThreadState(int state) {
+    return (state & 0x400000) == 0x400000 ? ExecutionMode::NATIVE : ExecutionMode::JAVA;
 }
 
 #endif //JAVA_PROFILER_LIBRARY_THREAD_STATE_H

--- a/ddprof-lib/src/main/cpp/wallClock_jvmti.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock_jvmti.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <math.h>
+#include <random>
+#include "debugSupport.h"
+#include "wallClock_jvmti.h"
+#include "profiler.h"
+#include "stackFrame.h"
+#include "context.h"
+#include "log.h"
+#include "thread.h"
+#include "tsc.h"
+#include "vmStructs.h"
+#include "reservoir_sampler.h"
+#include <jvmti.h>
+
+std::atomic<bool> JvmtiWallClockSampler::_enabled{false};
+
+Error JvmtiWallClockSampler::start(Arguments &args) {
+    int interval = args._event != NULL ? args._interval : args._wall;
+    if (interval < 0) {
+        return Error("interval must be positive");
+    }
+    _interval = interval ? interval : DEFAULT_WALL_INTERVAL;
+
+    _reservoir_size =
+            args._wall_threads_per_tick ?
+            args._wall_threads_per_tick :
+            DEFAULT_WALL_THREADS_PER_TICK;
+
+    _running = true;
+
+    if (pthread_create(&_thread, NULL, threadEntry, this) != 0) {
+        return Error("Unable to create timer thread");
+    }
+
+    return Error::OK;
+}
+
+void JvmtiWallClockSampler::stop() {
+    _running.store(false);
+    // the thread join ensures we wait for the thread to finish before returning (and possibly removing the object)
+    pthread_kill(_thread, WAKEUP_SIGNAL);
+    int res = pthread_join(_thread, NULL);
+    if(res != 0) {
+        Log::warn("Unable to join WallClock thread on stop %d", res);
+    }
+}
+
+void JvmtiWallClockSampler::timerLoop() {
+    ThreadFilter* thread_filter = Profiler::instance()->threadFilter();
+    if (!_enabled.load(std::memory_order_acquire) || !thread_filter->enabled()) {
+        return;
+    }
+    JNIEnv* jni = VM::attachThread("datadog-wallclock-sampler");
+    jvmtiEnv* jvmti = VM::jvmti();
+    const int max_frames = Profiler::instance()->max_stack_depth();
+    jvmtiFrameInfo* frames = frames = new jvmtiFrameInfo[max_frames];
+    std::vector<int> tids;
+    tids.reserve(_reservoir_size);
+    std::vector<jthread> javaThreads;
+    javaThreads.reserve(_reservoir_size);
+    ReservoirSampler<int> reservoir(_reservoir_size);
+    int self = OS::threadId();
+    u64 counter = 0;
+
+
+    while (_running.load(std::memory_order_relaxed)) {
+        int numFailures = 0;
+        int threadsAlreadyExited = 0;
+        std::vector<int> sample = reservoir.sample(tids);
+        Profiler::instance()->getThreads(sample, javaThreads);
+        for (int i = 0; i < sample.size(); i++) {
+            int tid = sample[i];
+            jthread javaThread = javaThreads[i];
+            if (javaThread != nullptr) {
+                jint depth;
+                jint error = jvmti->GetStackTrace(javaThread, 0, max_frames, frames, &depth);
+                if (error == 0 && depth > 0) {
+                    ExecutionEvent event;
+                    event._execution_mode = ExecutionMode::JAVA;
+                    event._thread_state = ThreadState::UNKNOWN;
+                    jint state;
+                    if (jvmti->GetThreadState(javaThread, &state) == 0) {
+                        event._thread_state = convertJvmtiThreadState(state);
+                        event._execution_mode = getExecutionModeFromJvmtiThreadState(state);
+                    }
+                    Profiler::instance()->recordExternalSample(0, tid, frames, depth, false, BCI_WALL, &event);
+                }
+            } else {
+                threadsAlreadyExited++;
+            }
+        }
+        tids.clear();
+        OS::sleep(_interval);
+    }
+    VM::detachThread();
+}

--- a/ddprof-lib/src/main/cpp/wallClock_jvmti.h
+++ b/ddprof-lib/src/main/cpp/wallClock_jvmti.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Andrei Pangin
+ * Copyright 2024 Datadog
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef _WALLCLOCK_H
-#define _WALLCLOCK_H
+#ifndef _WALLCLOCK_JVMTI_H
+#define _WALLCLOCK_JVMTI_H
 
 #include <atomic>
 #include <climits>
@@ -25,11 +25,10 @@
 #include "os.h"
 #include "threadState.h"
 
-class WallClock : public Engine {
+class JvmtiWallClockSampler : public Engine {
   private:
     static std::atomic<bool> _enabled;
 
-    bool _collapsing;
     long _interval;
 
     // Maximum number of threads sampled in one iteration. This limit serves as a throttle
@@ -44,18 +43,12 @@ class WallClock : public Engine {
     void timerLoop();
 
     static void* threadEntry(void* wall_clock) {
-        ((WallClock*)wall_clock)->timerLoop();
+        ((JvmtiWallClockSampler*)wall_clock)->timerLoop();
         return NULL;
     }
 
-    static bool inSyscall(void* ucontext);
-
-    static void sharedSignalHandler(int signo, siginfo_t* siginfo, void* ucontext);
-    void signalHandler(int signo, siginfo_t* siginfo, void* ucontext, u64 last_sample);
-
   public:
-    WallClock() :
-        _collapsing(false),
+    JvmtiWallClockSampler() :
         _interval(LONG_MAX),
         _reservoir_size(0),
         _running(false),
@@ -66,7 +59,7 @@ class WallClock : public Engine {
     }
 
     const char* name() {
-        return "WallClock - AsyncGetCallTrace";
+        return "WallClock - JVMTI";
     }
 
     long interval() const {
@@ -81,4 +74,4 @@ class WallClock : public Engine {
     }
 };
 
-#endif // _WALLCLOCK_H
+#endif // _WALLCLOCK_JVMTI_H

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContendedWallclockSamplesTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContendedWallclockSamplesTest.java
@@ -4,7 +4,6 @@ import com.datadoghq.profiler.AbstractProfilerTest;
 import com.datadoghq.profiler.Platform;
 import com.datadoghq.profiler.context.ContextExecutor;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.RetryingTest;
 import org.openjdk.jmc.common.item.IItem;
 import org.openjdk.jmc.common.item.IItemIterable;

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/JvmtiBasedContextWallClockTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/JvmtiBasedContextWallClockTest.java
@@ -1,0 +1,9 @@
+package com.datadoghq.profiler.wallclock;
+
+public class JvmtiBasedContextWallClockTest extends ContextWallClockTest {
+
+    @Override
+    protected String getProfilerCommand() {
+        return super.getProfilerCommand() + ";wallsampler=jvmti";
+    }
+}

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/JvmtiBasedWallclockThreadFilterTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/JvmtiBasedWallclockThreadFilterTest.java
@@ -1,0 +1,9 @@
+package com.datadoghq.profiler.wallclock;
+
+public class JvmtiBasedWallclockThreadFilterTest extends WallclockThreadFilterTest {
+
+    @Override
+    protected String getProfilerCommand() {
+        return super.getProfilerCommand() + ";wallsampler=jvmti";
+    }
+}

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/MegamorphicCallTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/MegamorphicCallTest.java
@@ -3,7 +3,6 @@ package com.datadoghq.profiler.wallclock;
 import com.datadoghq.profiler.AbstractProfilerTest;
 import com.datadoghq.profiler.Platform;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.RetryingTest;
 import org.openjdk.jmc.common.item.IItem;
 import org.openjdk.jmc.common.item.IItemCollection;

--- a/gradle/configurations.gradle
+++ b/gradle/configurations.gradle
@@ -58,7 +58,7 @@ def locateLibasan() {
 }
 
 def locateLibtsan() {
-    return locateLibrary('libtsan')
+  return locateLibrary('libtsan')
 }
 
 ext.libasan = locateLibasan()
@@ -116,7 +116,7 @@ def commonLinuxCompilerArgs = [
   "-DCOUNTERS"
 ]
 
-def commonLinuxLinkerArgs = ["-ldl", "-Wl,-z,defs", "--verbose", "-lpthread", "-lm", "-lrt", "-v"]
+def commonLinuxLinkerArgs = ["-ldl", "-Wl,-z,defs", "--verbose", "-lpthread", "-lm", "-lrt"]
 
 def commonMacosCompilerArgs = commonLinuxCompilerArgs + ["-D_XOPEN_SOURCE", "-D_DARWIN_C_SOURCE"]
 
@@ -206,7 +206,8 @@ addBuildConfiguration 'release', 'linux', 'x64',
     "-static-libstdc++",
     "-static-libgcc",
     "-Wl,--exclude-libs,ALL",
-    "-Wl,--gc-sections"
+    "-Wl,--gc-sections",
+    "-v"
   ]
 addBuildConfiguration 'debug', 'linux', 'x64',
   ['-O0', '-g', '-DDEBUG'] + commonLinuxCompilerArgs,


### PR DESCRIPTION
**What does this PR do?**:
Introduces a new wallclock sampler not based on signals, which uses JVMTI APIs instead.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
