### PR TITLE
Crash fix - Concurrent unloaded mappings

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -183,7 +183,9 @@ inline u32 Profiler::getLockIndex(int tid) {
 }
 
 void Profiler::updateSymbols(bool kernel_symbols) {
+    Symbols::setupSignalHandlers();
     Symbols::parseLibraries(&_native_libs, kernel_symbols);
+    Symbols::restoreSignalHandlers();
 }
 
 void Profiler::mangle(const char* name, char* buf, size_t size) {

--- a/ddprof-lib/src/main/cpp/safeAccess.h
+++ b/ddprof-lib/src/main/cpp/safeAccess.h
@@ -18,6 +18,7 @@
 #define _SAFEACCESS_H
 
 #include <stdint.h>
+
 #include "arch.h"
 
 
@@ -46,7 +47,14 @@ class SafeAccess {
     }
 
     static uintptr_t skipLoad(uintptr_t pc) {
+#ifndef __SANITIZE_ADDRESS__
         if (pc - (uintptr_t)load < 16) {
+#else
+        // asan significantly increases the size of the load function
+        // checking disassembled code can help adjust the value
+        // gdb --batch -ex 'disas _ZN10SafeAccess4loadEPPv' ./elfparser_ut
+        if (pc - (uintptr_t)load < 132) {
+#endif
 #if defined(__x86_64__)
             return *(u16*)pc == 0x8b48 ? 3 : 0;  // mov rax, [reg]
 #elif defined(__i386__)

--- a/ddprof-lib/src/main/cpp/symbols.h
+++ b/ddprof-lib/src/main/cpp/symbols.h
@@ -27,6 +27,10 @@ class Symbols {
     static bool _have_kernel_symbols;
 
   public:
+    // Ensures we can parse mappings even with concurrent unloading
+    static void setupSignalHandlers();
+    static void restoreSignalHandlers();
+
     static void parseKernelSymbols(CodeCache* cc);
     static void parseLibraries(CodeCacheArray* array, bool kernel_symbols);
     // The clear function is mainly for test purposes

--- a/ddprof-lib/src/main/cpp/symbols_linux.h
+++ b/ddprof-lib/src/main/cpp/symbols_linux.h
@@ -121,17 +121,10 @@ class ElfParser {
     const char* _sections;
     const char* _vaddr_diff;
 
-    ElfParser(CodeCache* cc, const char* base, const void* addr, const char* file_name, size_t length, bool relocate_dyn) {
-        _cc = cc;
-        _base = base;
-        _file_name = file_name;
-        _length = length;
-        _relocate_dyn = relocate_dyn && base != nullptr;
-        _header = (ElfHeader*)addr;
-        _sections = (const char*)addr + _header->e_shoff;
-    }
-
+    ElfParser(CodeCache* cc, const char* base, const void* addr, const char* file_name, size_t length, bool relocate_dyn);
     bool validHeader() {
+        if (!_header) return false;
+        if (!_sections) return false;
         unsigned char* ident = _header->e_ident;
         return ident[0] == 0x7f && ident[1] == 'E' && ident[2] == 'L' && ident[3] == 'F'
             && ident[4] == ELFCLASS_SUPPORTED && ident[5] == ELFDATA2LSB && ident[6] == EV_CURRENT

--- a/ddprof-lib/src/main/cpp/symbols_macos.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_macos.cpp
@@ -142,6 +142,11 @@ void Symbols::clear_parsed_caches() {
 void Symbols::parseKernelSymbols(CodeCache* cc) {
 }
 
+// On macOS, we need to check if there are risks of concurrent unloading
+// for now the signal handlers are not configured 
+void Symbols::setupSignalHandlers() {}
+void Symbols::restoreSignalHandlers() {}
+
 void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
     MutexLocker ml(_parse_lock);
     uint32_t images = _dyld_image_count();


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->
If a mapping is unloaded while we are parsing the mappings we should not be accessing the memory.
This commit adds a function to check that the memory is readable before trying to access the content of the mapping.

**Motivation**:
<!-- What inspired you to submit this pull request? -->
Customer crash was reported here:
https://github.com/DataDog/dd-trace-java/issues/7372
The full information is only available in the associated Zendesk ticket.

I disassembled to ensure we were crashing in these conditions and was able to reproduce a crash when forcing an unmapping of the mapping being parsed.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->
NA

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
I added a test that tries to reproduce the race condition.
It does not reproduce this 100% of the time.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
