### PR TITLE
Change property name in README to reflect existing Gradle infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ Once prerequisites have been installed simple as `./gradlew assembleAll`. The re
 
 
 ### Consuming the artifact
-For dd-trace-java you just need to set the `java.profiler.jar` project property.
-Eg. you can run the gradle build like this - ./gradlew clean -Pjava.profiler.jar=file://<path-to-artifact.jar> :dd-java-agent:shadowJar` - which will result in a custom `dd-java-agent.jar` build containing your test version of Java profiler.
+For dd-trace-java you just need to set the `ddprof.jar` project property.
+Eg. you can run the gradle build like this - ./gradlew clean -Pddprof.jar=file://<path-to-artifact.jar> :dd-java-agent:shadowJar` - which will result in a custom `dd-java-agent.jar` build containing your test version of Java profiler.


### PR DESCRIPTION
**What does this PR do?**:
Updates the README

**Motivation**:
See https://github.com/DataDog/dd-trace-java/issues/7407, for PROF-10347

**Additional Notes**:
This does not attempt to address potential deficits within `dd-trace-java`'s Gradle infra, this only fixes the discrepancy in our profiler shadowing instructions

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
