### PR TITLE
Properly handle concurrent unloaded mappings

### DIFF
--- a/ddprof-lib/gtest/build.gradle
+++ b/ddprof-lib/gtest/build.gradle
@@ -53,6 +53,28 @@ def buildResourcesTask = tasks.register("buildResources", Exec) {
     outputs.file "${targetDir}/main"
 }
 
+def buildSmallLibTask = tasks.register("buildSmallLib", Exec) {
+    group = 'build'
+    description = "Build the small-lib shared library for the Google Tests"
+
+    onlyIf {
+        hasGtest && !project.hasProperty('skip-native') && os().isLinux()
+    }
+
+    def sourceDir = project(':ddprof-lib').file('src/test/resources/small-lib')
+    def targetDir = project(':ddprof-lib').file('build/test/resources/small-lib')
+
+    commandLine "sh", "-c", """
+        mkdir -p ${targetDir}
+        cd ${sourceDir} && g++ -fPIC -shared -o ${targetDir}/libsmall-lib.so *.cpp
+    """
+
+    inputs.files fileTree(sourceDir) {
+        include '**/*.cpp'
+    }
+    outputs.file "${targetDir}/libsmall-lib.so"
+}
+
 def gtestAll = tasks.register("gtest") {
     onlyIf {
         hasGtest && !project.hasProperty('skip-native')
@@ -179,7 +201,7 @@ tasks.whenTaskAdded { task ->
                         gtestTask.get().dependsOn gtestExecuteTask.get()
                         if (os().isLinux()) {
                             // custom binaries for tests are built only on linux
-                            gtestExecuteTask.get().dependsOn buildResourcesTask
+                            gtestExecuteTask.get().dependsOn(buildResourcesTask, buildSmallLibTask)
                         }
                         gtestAll.get().dependsOn gtestExecuteTask.get()
                     }

--- a/ddprof-lib/src/main/cpp/symbols.h
+++ b/ddprof-lib/src/main/cpp/symbols.h
@@ -29,7 +29,9 @@ class Symbols {
   public:
     static void parseKernelSymbols(CodeCache* cc);
     static void parseLibraries(CodeCacheArray* array, bool kernel_symbols);
-
+    // The clear function is mainly for test purposes
+    // There are internal caches that are not associated to the array
+    static void clearParsingCaches();
     static bool haveKernelSymbols() {
         return _have_kernel_symbols;
     }

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -379,6 +379,11 @@ bool Symbols::_have_kernel_symbols = false;
 static std::set<const void*> _parsed_libraries;
 static std::set<u64> _parsed_inodes;
 
+void Symbols::clearParsingCaches() {
+    _parsed_libraries.clear();
+    _parsed_inodes.clear();
+}
+
 void Symbols::parseKernelSymbols(CodeCache* cc) {
     int fd = open("/proc/kallsyms", O_RDONLY);
 
@@ -425,7 +430,7 @@ static int parseLibrariesCallback(struct dl_phdr_info* info, size_t size, void* 
     if (f == NULL) {
         return 1;
     }
-    
+
     CodeCacheArray* array = (CodeCacheArray*)data;
     const char* image_base = NULL;
     u64 last_inode = 0;

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -27,6 +27,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <link.h>
 #include <linux/limits.h>
 #include "symbols.h"
 #include "symbols_linux.h"
@@ -418,26 +419,14 @@ void Symbols::parseKernelSymbols(CodeCache* cc) {
     fclose(f);
 }
 
-void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
-    MutexLocker ml(_parse_lock);
-
-    if (kernel_symbols && !haveKernelSymbols()) {
-        CodeCache* cc = new CodeCache("[kernel]");
-        parseKernelSymbols(cc);
-
-        if (haveKernelSymbols()) {
-            cc->sort();
-            array->add(cc);
-        } else {
-            delete cc;
-        }
-    }
+static int parseLibrariesCallback(struct dl_phdr_info* info, size_t size, void* data) {
 
     FILE* f = fopen("/proc/self/maps", "r");
     if (f == NULL) {
-        return;
+        return 1;
     }
-
+    
+    CodeCacheArray* array = (CodeCacheArray*)data;
     const char* image_base = NULL;
     u64 last_inode = 0;
     char* str = NULL;
@@ -480,7 +469,7 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
         if (strchr(map.file(), ':') == NULL) {
             u64 inode = u64(map.dev()) << 32 | map.inode();
             if (inode != 0) {
-                // Do not parse the same executable twice, e.g. on Alpine Linux 
+                // Do not parse the same executable twice, e.g. on Alpine Linux
                 if (_parsed_inodes.insert(inode).second) {
                     if (inode == last_inode) {
                         // If last_inode is set, image_base is known to be valid and readable
@@ -504,6 +493,28 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
 
     free(str);
     fclose(f);
+    return 1; // stop at first iteration
+}
+
+void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
+    MutexLocker ml(_parse_lock);
+
+    if (kernel_symbols && !haveKernelSymbols()) {
+        CodeCache* cc = new CodeCache("[kernel]");
+        parseKernelSymbols(cc);
+
+        if (haveKernelSymbols()) {
+            cc->sort();
+            array->add(cc);
+        } else {
+            delete cc;
+        }
+    }
+
+    // In glibc, dl_iterate_phdr() holds dl_load_write_lock, therefore preventing
+    // concurrent loading and unloading of shared libraries.
+    // Without it, we may access memory of a library that is being unloaded.
+    dl_iterate_phdr(parseLibrariesCallback, array);
 }
 
 #endif // __linux__

--- a/ddprof-lib/src/main/cpp/symbols_macos.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_macos.cpp
@@ -135,6 +135,9 @@ Mutex Symbols::_parse_lock;
 bool Symbols::_have_kernel_symbols = false;
 static std::set<const void*> _parsed_libraries;
 
+void Symbols::clearParsingCaches() {
+    _parsed_libraries.clear();
+}
 void Symbols::parseKernelSymbols(CodeCache* cc) {
 }
 

--- a/ddprof-lib/src/test/cpp/elfparser_ut.cpp
+++ b/ddprof-lib/src/test/cpp/elfparser_ut.cpp
@@ -4,9 +4,16 @@
 
 #include "codeCache.h"
 #include "symbols_linux.h"
+#include "log.h"
 
 #include <unistd.h>
 #include <limits.h> // For PATH_MAX
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <cstring>
+#include <chrono>
+#include <thread>
 
 TEST(Elf, readSymTable) {
     char cwd[PATH_MAX - 64];
@@ -21,7 +28,203 @@ TEST(Elf, readSymTable) {
     }
     CodeCache cc("test");
     ElfParser::parseFile(&cc, nullptr, path, false);
-    fprintf(stdout, "CodeCache size: %d\n", cc.count());
 }
+
+class ElfTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Reset global or static state
+        Symbols::clearParsingCaches();
+    }
+
+    void TearDown() override {
+        // probably some free of the array cache to be done
+    }
+
+};
+
+
+// Define an invalid ELF header
+unsigned char invalidElfHeader[64] = {
+    0x7f, 'E', 'L', 'F', // Correct magic number
+    0x01,                // Invalid class (32-bit instead of 64-bit)
+    0x01,                // Invalid data encoding (little-endian)
+    0x01,                // Invalid version (original version of ELF)
+    0,                   // OS/ABI
+    0,                   // ABI version
+    0, 0, 0, 0, 0, 0, 0 // Padding
+    // Rest of the header can be zeroed out
+};
+
+
+TEST_F(ElfTest, invalidElf) {
+    // Create an invalid ELF mapping
+    const size_t headerSize = sizeof(invalidElfHeader);
+    int fd = open("/tmp/invalid_elf", O_RDWR | O_CREAT | O_TRUNC, 0700); // Make the file executable
+    ASSERT_NE(fd, -1) << "Failed to open temporary file";
+
+    // Write the invalid ELF header to the file
+    ssize_t written = write(fd, invalidElfHeader, headerSize);
+    ASSERT_EQ(written, headerSize) << "Failed to write invalid ELF header";
+
+    // Extend the file to a reasonable size
+    ftruncate(fd, 4096);
+
+    // Memory map the file with PROT_EXEC
+    void* addr = mmap(NULL, 4096, PROT_READ | PROT_EXEC, MAP_PRIVATE, fd, 0);
+    ASSERT_NE(addr, MAP_FAILED) << "Failed to memory map the file";
+
+    close(fd);
+
+    // Set up the CodeCacheArray and other required structures
+    CodeCacheArray cc_array;
+
+    // Call the parsing function with the invalid ELF mapping
+    Symbols::parseLibraries(&cc_array, false);
+
+    munmap(addr, 4096);
+    unlink("/tmp/invalid_elf");
+}
+
+// Additional test cases for other invalid ELF scenarios
+TEST_F(ElfTest, nonElfFile) {
+    // Create a non-ELF file mapping
+    const char* nonElfContent = "This is not an ELF file";
+    const size_t contentSize = strlen(nonElfContent) + 1;
+    int fd = open("/tmp/non_elf", O_RDWR | O_CREAT | O_TRUNC, 0700); // Make the file executable
+    ASSERT_NE(fd, -1) << "Failed to open temporary file";
+
+    // Write the non-ELF content to the file
+    ssize_t written = write(fd, nonElfContent, contentSize);
+    ASSERT_EQ(written, contentSize) << "Failed to write non-ELF content";
+
+    // Memory map the file with PROT_EXEC
+    void* addr = mmap(NULL, contentSize, PROT_READ | PROT_EXEC, MAP_PRIVATE, fd, 0);
+    ASSERT_NE(addr, MAP_FAILED) << "Failed to memory map the file";
+
+    close(fd);
+
+    // Set up the CodeCacheArray and other required structures
+    CodeCacheArray cc_array;
+
+    // Call the parsing function with the non-ELF mapping
+    Symbols::parseLibraries(&cc_array, false);
+
+    // we could add checks here, though I am mainly relying on asan to crash
+    // if something is wrong
+    munmap(addr, contentSize);
+    unlink("/tmp/non_elf");
+}
+
+TEST_F(ElfTest, invalidElfSmallMapping) {
+    // Create an invalid ELF mapping
+    const size_t headerSize = sizeof(invalidElfHeader);
+    int fd = open("/tmp/invalid_elf_small", O_RDWR | O_CREAT | O_TRUNC, 0700); // Make the file executable
+    ASSERT_NE(fd, -1) << "Failed to open temporary file";
+
+    // Write the invalid ELF header to the file
+    ssize_t written = write(fd, invalidElfHeader, headerSize);
+    ASSERT_EQ(written, headerSize) << "Failed to write invalid ELF header";
+
+    // Memory map the file with a size smaller than the ELF header
+    void* addr = mmap(NULL, 16, PROT_READ | PROT_EXEC, MAP_PRIVATE, fd, 0); // Map only 16 bytes
+    ASSERT_NE(addr, MAP_FAILED) << "Failed to memory map the file";
+
+    close(fd);
+
+    // Set up the CodeCacheArray and other required structures
+    CodeCacheArray cc_array;
+
+    // Call the parsing function with the small invalid ELF mapping
+    Symbols::parseLibraries(&cc_array, false);
+
+    munmap(addr, 16);
+    unlink("/tmp/invalid_elf_small");
+}
+
+TEST_F(ElfTest, nonElfFileSmallMapping) {
+    // Create a non-ELF file mapping
+    const char* nonElfContent = "Not ELF";
+    const size_t contentSize = strlen(nonElfContent);
+    int fd = open("/tmp/non_elf_small", O_RDWR | O_CREAT | O_TRUNC, 0700); // Make the file executable
+    ASSERT_NE(fd, -1) << "Failed to open temporary file";
+
+    // Write the non-ELF content to the file
+    ssize_t written = write(fd, nonElfContent, contentSize);
+    ASSERT_EQ(written, contentSize) << "Failed to write non-ELF content";
+
+    // Memory map the file with a size smaller than expected
+    void* addr = mmap(NULL, contentSize, PROT_READ | PROT_EXEC, MAP_PRIVATE, fd, 0); // Map only the content size
+    ASSERT_NE(addr, MAP_FAILED) << "Failed to memory map the file";
+
+    close(fd);
+
+    // Set up the CodeCacheArray and other required structures
+    CodeCacheArray cc_array;
+
+    // Call the parsing function with the small non-ELF mapping
+    Symbols::parseLibraries(&cc_array, false);
+    munmap(addr, contentSize);
+    unlink("/tmp/non_elf_small");
+}
+
+class ElfTestParam : public ::testing::TestWithParam<int> {
+protected:
+    void SetUp() override {
+        // Reset global or static state
+        Symbols::clearParsingCaches();
+    }
+
+    void TearDown() override {
+        // probably some free of the array cache to be done
+    }
+};
+
+// This test does not repro 100% of the time.
+// However over a few runs, I get it to reproduce the race condition.
+TEST_P(ElfTestParam, invalidElfSmallMappingAfterUnmap) {
+    // This does not work as expected. There is a follow up to improve logging.
+    Log::open("stderr", "WARN");
+    // Create an invalid ELF mapping (it could be valid for this case, it is not relevant)
+    const size_t headerSize = sizeof(invalidElfHeader);
+    int fd = open("/tmp/invalid_elf_small_unmap", O_RDWR | O_CREAT | O_TRUNC, 0700); // Make the file executable
+    ASSERT_NE(fd, -1) << "Failed to open temporary file";
+    ssize_t written = write(fd, invalidElfHeader, headerSize);
+    ASSERT_EQ(written, headerSize) << "Failed to write invalid ELF header";
+    // Memory map the file
+    void* addr = mmap(NULL, 16, PROT_READ | PROT_EXEC, MAP_PRIVATE, fd, 0); // Map only 16 bytes
+    ASSERT_NE(addr, MAP_FAILED) << "Failed to memory map the file";
+
+    close(fd);
+
+    const char* base = static_cast<const char*>(addr);
+    const char* end = base + 16;
+
+    // Set up the CodeCacheArray and other required structures
+    CodeCacheArray cc_array;
+    int delay = GetParam();
+    fprintf(stderr, "-- Test Delay = %d ms\n", delay);
+    // Create a thread that will unmap the memory after X milliseconds
+    // We need a timing that allows us to read the
+    // mapping, but not loop over them in the parsing function
+    // I was able to reproduce with ~15 ms in asan mode.
+    std::thread unmapper([addr, delay]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+        munmap(addr, 16);
+        unlink("/tmp/invalid_elf_small_unmap");
+    });
+
+    // Call the parsing function in the main thread
+    Symbols::parseLibraries(&cc_array, false);
+
+    // Join the unmapper thread to ensure it has finished
+    unmapper.join();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DelayedUnmapTest,
+    ElfTestParam,
+    ::testing::Range(3, 21) // This will test delays from 5 to 20 milliseconds inclusive
+);
 
 #endif //__linux__

--- a/ddprof-lib/src/test/resources/small-lib/Makefile
+++ b/ddprof-lib/src/test/resources/small-lib/Makefile
@@ -1,0 +1,3 @@
+TARGET_DIR = ../build/test/resources/small-lib
+all:
+	g++ -fPIC -shared -o libsmall-lib.so small_lib.cpp

--- a/ddprof-lib/src/test/resources/small-lib/small_lib.cpp
+++ b/ddprof-lib/src/test/resources/small-lib/small_lib.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+#include "small_lib.h"
+
+extern "C" void hello() {
+    std::cout << "Hello, World from shared library!" << std::endl;
+}

--- a/ddprof-lib/src/test/resources/small-lib/small_lib.h
+++ b/ddprof-lib/src/test/resources/small-lib/small_lib.h
@@ -1,0 +1,5 @@
+#pragma once
+
+extern "C" {
+void hello();
+}


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->

If a mapping is unloaded while we are parsing the mappings we should not be accessing the memory.
@apangin had the idea to use dl_iterate_phdr to take the dl_open lock.

**Motivation**:
<!-- What inspired you to submit this pull request? -->
Customer crash was reported here:
https://github.com/DataDog/dd-trace-java/issues/7372
The full information is only available in the associated Zendesk ticket.

I disassembled to ensure we were crashing in these conditions and was able to reproduce a crash when forcing an unmapping of the mapping being parsed.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->
NA

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
I added a test that tries to reproduce the race condition.
It does not reproduce this 100% of the time.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
