### PR TITLE
Deallocate jclass reference promptly

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -133,7 +133,7 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
   jvmtiEnv *jvmti = VM::jvmti();
 
   jvmtiPhase phase;
-  jclass method_class;
+  jclass method_class = nullptr;
   // invariant: these strings must remain null, or be assigned by JVMTI
   char *class_name = nullptr;
   char *method_name = nullptr;
@@ -243,6 +243,10 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
       class_name_id = _classes->lookup("");
       method_name_id = _symbols.lookup("jvmtiError");
       method_sig_id = _symbols.lookup("()L;");
+    }
+
+    if (method_class) {
+      _jni->DeleteLocalRef(method_class);
     }
 
     mi->_class = class_name_id;

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -268,6 +268,7 @@ public:
   Dictionary _symbols;
 
 private:
+  JNIEnv* _jni;
   void fillNativeMethodInfo(MethodInfo *mi, const char *name,
                             const char *lib_name);
   void cutArguments(char *func);
@@ -279,7 +280,7 @@ private:
 public:
   Lookup(Recording *rec, MethodMap *method_map, Dictionary *classes)
       : _rec(rec), _method_map(method_map), _classes(classes), _packages(),
-        _symbols() {}
+        _symbols(), _jni(VM::jni()) {}
 
   MethodInfo *resolveMethod(ASGCT_CallFrame &frame);
   u32 getPackage(const char *class_name);

--- a/ddprof-lib/src/main/cpp/vmEntry.h
+++ b/ddprof-lib/src/main/cpp/vmEntry.h
@@ -124,7 +124,7 @@ public:
 
   static JNIEnv *jni() {
     JNIEnv *jni;
-    return _vm->GetEnv((void **)&jni, JNI_VERSION_1_6) == 0 ? jni : NULL;
+    return _vm && _vm->GetEnv((void**)&jni, JNI_VERSION_1_6) == 0 ? jni : NULL;
   }
 
   static JNIEnv *attachThread(const char *name) {


### PR DESCRIPTION
**What does this PR do?**:
It adds defensive deallocation of jclass references to reduce the chance of crashing due to mismanaged jmethodID in JVM.

**Motivation**:
See https://github.com/async-profiler/async-profiler/pull/981 and https://bugs.openjdk.org/browse/JDK-8268364

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [x] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-10461]

Unsure? Have a question? Request a review!


[PROF-10461]: https://datadoghq.atlassian.net/browse/PROF-10461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ