### PR TITLE
Remove C++17 specific syntax

### DIFF
--- a/ddprof-lib/src/main/cpp/safeAccess.h
+++ b/ddprof-lib/src/main/cpp/safeAccess.h
@@ -73,7 +73,7 @@ public:
     return 0;
   }
 #ifndef __SANITIZE_ADDRESS__
-  constexpr static inline size_t sizeSafeLoadFunc = 16;
+  constexpr static size_t sizeSafeLoadFunc = 16;
 #else
   // asan significantly increases the size of the load function
   // checking disassembled code can help adjust the value


### PR DESCRIPTION
**What does this PR do?**:
It removes C++17 only syntax which breaks one of ours binary builds as we need to support C++11

**Motivation**:
Fixing broken CI pipeline

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-10500]

Unsure? Have a question? Request a review!


[PROF-10500]: https://datadoghq.atlassian.net/browse/PROF-10500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ