### PR TITLE
Fix trivial leak in ThreadFilter

### DIFF
--- a/ddprof-lib/src/main/cpp/threadFilter.cpp
+++ b/ddprof-lib/src/main/cpp/threadFilter.cpp
@@ -43,6 +43,9 @@ ThreadFilter::~ThreadFilter() {
       OS::safeFree(_bitmap[i], BITMAP_SIZE);
     }
   }
+  if (_bitmap) {
+    OS::safeFree(_bitmap, _max_bitmaps * sizeof(u64 *));
+  }
 }
 
 void ThreadFilter::init(const char *filter) {


### PR DESCRIPTION
**What does this PR do?**:
It fixes a trivial leak when the destructor of `ThreadFilter` class did not release the memory allocated for `_bitmaps`.

**Motivation**:
Mostly just a code cleanup - with our current usage the `ThreadFilter` instance will remain active during the whole lifespan of the profiled application so the memory would not really 'leak'. But it is better to have a correct destructor if the usage of `ThreadFilter` would change in the future.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
