### PR TITLE
Improve robustness of the crash signal handler

### DIFF
--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -20,6 +20,7 @@
 #include "debugSupport.h"
 #include "profiler.h"
 #include "vmStructs.h"
+#include <assert.h>
 #include <stdlib.h>
 #include <sys/syscall.h>
 #include <time.h>
@@ -202,6 +203,7 @@ void CTimer::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
     return;
   int tid = 0;
   ProfiledThread *current = ProfiledThread::current();
+  assert(current == nullptr || !current->isDeepCrashHandler());
   if (current != NULL) {
     current->noteCPUSample(Profiler::instance()->recordingEpoch());
     tid = current->tid();

--- a/ddprof-lib/src/main/cpp/os_linux.cpp
+++ b/ddprof-lib/src/main/cpp/os_linux.cpp
@@ -242,7 +242,7 @@ SigAction OS::replaceSigsegvHandler(SigAction action) {
   sigaction(SIGSEGV, NULL, &sa);
   SigAction old_action = sa.sa_sigaction;
   sa.sa_sigaction = action;
-  sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+  sa.sa_flags = SA_SIGINFO;
   sigaction(SIGSEGV, &sa, NULL);
   return old_action;
 }

--- a/ddprof-lib/src/main/cpp/os_linux.cpp
+++ b/ddprof-lib/src/main/cpp/os_linux.cpp
@@ -242,6 +242,7 @@ SigAction OS::replaceSigsegvHandler(SigAction action) {
   sigaction(SIGSEGV, NULL, &sa);
   SigAction old_action = sa.sa_sigaction;
   sa.sa_sigaction = action;
+  sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
   sigaction(SIGSEGV, &sa, NULL);
   return old_action;
 }

--- a/ddprof-lib/src/main/cpp/os_macos.cpp
+++ b/ddprof-lib/src/main/cpp/os_macos.cpp
@@ -216,6 +216,7 @@ SigAction OS::replaceSigsegvHandler(SigAction action) {
   sigaction(SIGSEGV, NULL, &sa);
   SigAction old_action = sa.sa_sigaction;
   sa.sa_sigaction = action;
+  sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
   sigaction(SIGSEGV, &sa, NULL);
   return old_action;
 }

--- a/ddprof-lib/src/main/cpp/os_macos.cpp
+++ b/ddprof-lib/src/main/cpp/os_macos.cpp
@@ -216,7 +216,7 @@ SigAction OS::replaceSigsegvHandler(SigAction action) {
   sigaction(SIGSEGV, NULL, &sa);
   SigAction old_action = sa.sa_sigaction;
   sa.sa_sigaction = action;
-  sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+  sa.sa_flags = SA_SIGINFO;
   sigaction(SIGSEGV, &sa, NULL);
   return old_action;
 }

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -967,23 +967,6 @@ bool Profiler::crashHandler(int signo, siginfo_t *siginfo, void *ucontext) {
 void Profiler::setupSignalHandlers() {
   // do not re-run the signal setup (run only when VM has not been loaded yet)
   if (VM::java_version() > 0 && !VM::loaded()) {
-    // register alternative stack for sighandlers
-    int ALT_STACK_SIZE = SIGSTKSZ * 4;
-    stack_t ss;
-    memset(&ss, 0, sizeof(ss));
-    ss.ss_sp = malloc(ALT_STACK_SIZE);
-    if (ss.ss_sp == NULL) {
-        perror("malloc");
-        exit(EXIT_FAILURE);
-    }
-    ss.ss_size = ALT_STACK_SIZE;
-    ss.ss_flags = 0;
-
-    if (sigaltstack(&ss, NULL) == -1) {
-        perror("sigaltstack");
-        exit(EXIT_FAILURE);
-    }
-
     // HotSpot and J9 tolerate interposed SIGSEGV/SIGBUS handler; other JVMs
     // probably not
     orig_segvHandler = OS::replaceSigsegvHandler(segvHandler);

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -38,7 +38,6 @@
 #include <algorithm>
 #include <dlfcn.h>
 #include <fstream>
-#include <functional>
 #include <memory>
 #include <set>
 #include <signal.h>
@@ -947,7 +946,7 @@ bool Profiler::crashHandler(int signo, siginfo_t *siginfo, void *ucontext) {
     // the following checks require vmstructs and therefore HotSpot
 
     // this check can longjmp to a completely different location - need to call exitCrashHandler() before
-    StackWalker::checkFault(std::bind(&ProfiledThread::exitCrashHandler, thrd));
+    StackWalker::checkFault(thrd);
 
     // Workaround for JDK-8313796. Setting cstack=dwarf also helps
     if (VMStructs::isInterpretedFrameValidFunc((const void *)pc) &&

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -242,8 +242,6 @@ public:
   CodeBlob *findRuntimeStub(const void *address);
   bool isAddressInCode(const void *pc);
 
-  static void trapHandlerEntry(int signo, siginfo_t *siginfo, void *ucontext);
-  void trapHandler(int signo, siginfo_t *siginfo, void *ucontext);
   static void segvHandler(int signo, siginfo_t *siginfo, void *ucontext);
   static void busHandler(int signo, siginfo_t *siginfo, void *ucontext);
   static void setupSignalHandlers();

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -454,9 +454,12 @@ int StackWalker::walkVM(void *ucontext, ASGCT_CallFrame *frames, int max_depth,
   return depth;
 }
 
-void StackWalker::checkFault() {
+void StackWalker::checkFault(std::function<void()> cleanup) {
   VMThread *vm_thread = VMThread::current();
   if (vm_thread != NULL && sameStack(vm_thread->exception(), &vm_thread)) {
+    if (cleanup) {
+      cleanup();
+    }
     longjmp(*(jmp_buf *)vm_thread->exception(), 1);
   }
 }

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -454,11 +454,11 @@ int StackWalker::walkVM(void *ucontext, ASGCT_CallFrame *frames, int max_depth,
   return depth;
 }
 
-void StackWalker::checkFault(std::function<void()> cleanup) {
+void StackWalker::checkFault(ProfiledThread* thrd) {
   VMThread *vm_thread = VMThread::current();
   if (vm_thread != NULL && sameStack(vm_thread->exception(), &vm_thread)) {
-    if (cleanup) {
-      cleanup();
+    if (thrd) {
+      thrd->exitCrashHandler();
     }
     longjmp(*(jmp_buf *)vm_thread->exception(), 1);
   }

--- a/ddprof-lib/src/main/cpp/stackWalker.h
+++ b/ddprof-lib/src/main/cpp/stackWalker.h
@@ -18,6 +18,7 @@
 #define _STACKWALKER_H
 
 #include "vmEntry.h"
+#include <functional>
 #include <stdint.h>
 
 struct StackContext {
@@ -42,7 +43,7 @@ public:
                     const void *_termination_frame_begin,
                     const void *_termination_frame_end);
 
-  static void checkFault();
+  static void checkFault(std::function<void()> cleanup);
 };
 
 #endif // _STACKWALKER_H

--- a/ddprof-lib/src/main/cpp/stackWalker.h
+++ b/ddprof-lib/src/main/cpp/stackWalker.h
@@ -17,6 +17,7 @@
 #ifndef _STACKWALKER_H
 #define _STACKWALKER_H
 
+#include "thread.h"
 #include "vmEntry.h"
 #include <functional>
 #include <stdint.h>
@@ -43,7 +44,7 @@ public:
                     const void *_termination_frame_begin,
                     const void *_termination_frame_end);
 
-  static void checkFault(std::function<void()> cleanup);
+  static void checkFault(ProfiledThread* thrd);
 };
 
 #endif // _STACKWALKER_H

--- a/ddprof-lib/src/main/cpp/vmEntry.h
+++ b/ddprof-lib/src/main/cpp/vmEntry.h
@@ -122,6 +122,8 @@ public:
 
   static jvmtiEnv *jvmti() { return _jvmti; }
 
+  static bool loaded() { return _jvmti != nullptr; }
+
   static JNIEnv *jni() {
     JNIEnv *jni;
     return _vm->GetEnv((void **)&jni, JNI_VERSION_1_6) == 0 ? jni : NULL;


### PR DESCRIPTION
**What does this PR do?**:
This is an attempt to increase the robustness of the crash signal handler by
- preventing rerunning the signal setup routine (quite unlikely to happen, but just in case)
- using separate stack space for the crash signal handlers to avoid triggering stack overflow
- using TLS guard to prevent recursive crash handling in case the handler itself would cause sigseg
- checking the PC for not being the cause of the original fault - if it is, we can not meaningfully recover and just call the JVM crash handler

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-10605]

Unsure? Have a question? Request a review!


[PROF-10605]: https://datadoghq.atlassian.net/browse/PROF-10605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ