### PR TITLE
[PROF-10688] Remove a looping allocation when updating threads

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -36,7 +36,6 @@
 #include "vmStructs.h"
 #include "wallClock.h"
 #include <algorithm>
-#include <array>
 #include <dlfcn.h>
 #include <fstream>
 #include <memory>

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -36,6 +36,7 @@
 #include "vmStructs.h"
 #include "wallClock.h"
 #include <algorithm>
+#include <array>
 #include <dlfcn.h>
 #include <fstream>
 #include <memory>
@@ -996,21 +997,21 @@ void Profiler::updateJavaThreadNames() {
 }
 
 void Profiler::updateNativeThreadNames() {
-  ThreadList *thread_list = OS::listThreads();
-  for (int tid; (tid = thread_list->next()) != -1;) {
-    _thread_info.updateThreadName(
-        tid, [](int tid) -> std::unique_ptr<char[]> {
-          const size_t buffer_size = 64;
-          char *name_buf = new char[buffer_size];
-          if (OS::threadName(tid, name_buf, buffer_size)) {
-            return std::unique_ptr<char[]>(name_buf);
-          }
-          delete[] name_buf;
-          return nullptr;
-        });
-  }
+    ThreadList *thread_list = OS::listThreads();
+    constexpr size_t buffer_size = 64;
+    char name_buf[buffer_size];  // Stack-allocated buffer
 
-  delete thread_list;
+    for (int tid; (tid = thread_list->next()) != -1;) {
+        _thread_info.updateThreadName(
+                tid, [&](int tid) -> std::string {
+                    if (OS::threadName(tid, name_buf, buffer_size)) {
+                        return std::string(name_buf, buffer_size);
+                    }
+                    return std::string();
+                });
+    }
+
+    delete thread_list;
 }
 
 Engine *Profiler::selectCpuEngine(Arguments &args) {

--- a/ddprof-lib/src/main/cpp/threadInfo.cpp
+++ b/ddprof-lib/src/main/cpp/threadInfo.cpp
@@ -69,13 +69,12 @@ int ThreadInfo::size() {
 void ThreadInfo::updateThreadName(
         int tid, std::function<std::string(int)> resolver) {
     MutexLocker ml(_ti_lock);
-
-    std::map<int, std::string>::iterator it = _thread_names.lower_bound(tid);
-    if (it == _thread_names.end() || it->first != tid) {
+    auto it = _thread_names.find(tid);
+    if (it == _thread_names.end()) {
+        // Thread ID not found, insert new entry
         std::string name = resolver(tid);
         if (!name.empty()) {
-            _thread_names.insert(it, std::map<int, std::string>::value_type(
-                    tid, std::move(name)));  // Move the string
+            _thread_names.emplace(tid, std::move(name));
         }
     }
 }

--- a/ddprof-lib/src/main/cpp/threadInfo.cpp
+++ b/ddprof-lib/src/main/cpp/threadInfo.cpp
@@ -67,17 +67,17 @@ int ThreadInfo::size() {
 }
 
 void ThreadInfo::updateThreadName(
-    int tid, std::function<std::unique_ptr<char[]>(int)> resolver) {
-  MutexLocker ml(_ti_lock);
+        int tid, std::function<std::string(int)> resolver) {
+    MutexLocker ml(_ti_lock);
 
-  std::map<int, std::string>::iterator it = _thread_names.lower_bound(tid);
-  if (it == _thread_names.end() || it->first != tid) {
-    std::unique_ptr<char[]> namePtr = resolver(tid);
-    if (namePtr.get() != nullptr) {
-      _thread_names.insert(it, std::map<int, std::string>::value_type(
-                                   tid, static_cast<char *>(namePtr.get())));
+    std::map<int, std::string>::iterator it = _thread_names.lower_bound(tid);
+    if (it == _thread_names.end() || it->first != tid) {
+        std::string name = resolver(tid);
+        if (!name.empty()) {
+            _thread_names.insert(it, std::map<int, std::string>::value_type(
+                    tid, std::move(name)));  // Move the string
+        }
     }
-  }
 }
 
 void ThreadInfo::reportCounters() {

--- a/ddprof-lib/src/main/cpp/threadInfo.h
+++ b/ddprof-lib/src/main/cpp/threadInfo.h
@@ -22,8 +22,7 @@ public:
   void set(int tid, const char *name, u64 java_thread_id);
   std::pair<std::shared_ptr<std::string>, u64> get(int tid);
 
-  void updateThreadName(int threadId,
-                        std::function<std::unique_ptr<char[]>(int)> resolver);
+  void updateThreadName(int tid, std::function<std::string(int)> resolver);
 
   int size();
 


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->
Remove a looping allocation when updating threads

**Motivation**:
<!-- What inspired you to submit this pull request? -->
I do not have numbers that would justify that this is important.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->
For long thread names we would still have an allocation in string creation, however we previously had 2 (as we copied the C string to the std::string)

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
