### PR TITLE
Add a fail-safe when we encounter double-exit from crash handler

### DIFF
--- a/ddprof-lib/src/main/cpp/thread.h
+++ b/ddprof-lib/src/main/cpp/thread.h
@@ -99,7 +99,8 @@ public:
 
   // needs to be called when the crash handler exits
   void exitCrashHandler() {
-    _crash_depth--;
+    // failsafe check - do not attempt to decrement if there are no crash handlers on stack
+    if (_crash_depth > 0) _crash_depth--;
   }
 
   bool isDeepCrashHandler() {


### PR DESCRIPTION
**What does this PR do?**:
Adds a fail-safe when we encounter double-exit from crash handler. 

**Motivation**:
This seems to happen sometimes in relation to longjmp. Since the crash signal handler is using depth tracking to avoid stack overflow, having this depth corrupted by double-exit may cause not intercepting and sigsegs at all. 
This was witnessed in CI when cca. 1 in 4 runs quite reliable crashed in `SafeAccess::load` call. 

With this particular patch applied no crash is observed in a series of 7 subsequent runs so this all looks like a valid hypothesis.

**Additional Notes**:
If a crash in `SafeAccess::load` is observed even with this patch applied then the safest course of action is to revert this PR and then #134 

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-10605]

Unsure? Have a question? Request a review!


[PROF-10605]: https://datadoghq.atlassian.net/browse/PROF-10605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ