### PR TITLE
Crash handler recursion protection - Fix

### DIFF
--- a/ddprof-lib/src/main/cpp/arguments.cpp
+++ b/ddprof-lib/src/main/cpp/arguments.cpp
@@ -393,7 +393,7 @@ const char *Arguments::expandFilePattern(const char *pattern) {
       } else if (c == '{') {
         char env_key[128];
         const char *p = strchr(pattern, '}');
-        if (p != NULL && p - pattern < sizeof(env_key)) {
+        if (p != NULL && p - pattern < static_cast<int>(sizeof(env_key))) {
           memcpy(env_key, pattern, p - pattern);
           env_key[p - pattern] = 0;
           const char *env_value = getenv(env_key);

--- a/ddprof-lib/src/main/cpp/arguments.h
+++ b/ddprof-lib/src/main/cpp/arguments.h
@@ -175,8 +175,8 @@ public:
         _cstack(CSTACK_DEFAULT),
         _jfr_options(0),
         _context_attributes({}),
-        _lightweight(false),
-        _wallclock_sampler(ASGCT) {}
+        _wallclock_sampler(ASGCT),
+        _lightweight(false) {}
 
   ~Arguments();
 

--- a/ddprof-lib/src/main/cpp/buffers.h
+++ b/ddprof-lib/src/main/cpp/buffers.h
@@ -64,7 +64,7 @@ public:
   void reset() { _offset = 0; }
 
   void put(const char *v, u32 len) {
-    assert(_offset + len < limit());
+    assert(static_cast<int>(_offset + len) < limit());
     memcpy(_data + _offset, v, len);
     _offset += (int)len;
   }

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -40,7 +40,7 @@ static void **_pthread_entry = NULL;
 // pthread_setspecific(). HotSpot puts VMThread into TLS on thread start, and
 // resets on thread end.
 static int pthread_setspecific_hook(pthread_key_t key, const void *value) {
-  if (key != VMThread::key()) {
+  if (key != static_cast<pthread_key_t>(VMThread::key())) {
     return pthread_setspecific(key, value);
   }
   if (pthread_getspecific(key) == value) {

--- a/ddprof-lib/src/main/cpp/event.h
+++ b/ddprof-lib/src/main/cpp/event.h
@@ -42,8 +42,8 @@ public:
   u32 _call_trace_id;
 
   ExecutionEvent()
-      : Event(), _thread_state(ThreadState::RUNNABLE), _weight(1),
-        _execution_mode(ExecutionMode::UNKNOWN), _call_trace_id(0) {}
+      : Event(), _thread_state(ThreadState::RUNNABLE), _execution_mode(ExecutionMode::UNKNOWN),
+        _weight(1), _call_trace_id(0) {}
 };
 
 class AllocEvent : public Event {

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -74,8 +74,8 @@ public:
 class MethodInfo {
 public:
   MethodInfo()
-      : _mark(false), _is_entry(false), _key(0), _modifiers(0), _class(0),
-        _name(0), _sig(0), _line_number_table(nullptr), _type() {}
+      : _mark(false), _is_entry(false), _key(0), _class(0),
+        _name(0), _sig(0), _modifiers(0), _line_number_table(nullptr), _type() {}
 
   bool _mark;
   bool _is_entry;

--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <algorithm>
 #include <random>
 #include <set>
 #include <thread>
@@ -184,7 +185,7 @@ Error LivenessTracker::initialize_table(JNIEnv *jni, int sampling_interval) {
               "not cover full heap.",
               sampling_interval);
   }
-  _table_max_cap = __min(MAX_TRACKING_TABLE_SIZE, required_table_capacity);
+  _table_max_cap = std::min(MAX_TRACKING_TABLE_SIZE, required_table_capacity);
 
   _table_cap = std::max(
       2048,
@@ -277,7 +278,7 @@ Error LivenessTracker::initialize(Arguments &args) {
 
   _table_size = 0;
   _table_cap =
-      __min(2048, _table_max_cap); // with default 512k sampling interval, it's
+      std::min(2048, _table_max_cap); // with default 512k sampling interval, it's
                                    // enough for 1G of heap
   _table = (TrackingEntry *)malloc(sizeof(TrackingEntry) * _table_cap);
 
@@ -367,7 +368,7 @@ retry:
         _table_lock.lock();
 
         // Only increase the size of the table to _table_max_cap elements
-        int newcap = __min(_table_cap * 2, _table_max_cap);
+        int newcap = std::min(_table_cap * 2, _table_max_cap);
         if (_table_cap != newcap) {
           TrackingEntry *tmp = (TrackingEntry *)realloc(
               _table, sizeof(TrackingEntry) * (_table_cap = newcap));

--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -34,6 +34,8 @@
 #include <string.h>
 
 LivenessTracker *const LivenessTracker::_instance = new LivenessTracker();
+constexpr int LivenessTracker::MAX_TRACKING_TABLE_SIZE;
+constexpr int LivenessTracker::MIN_SAMPLING_INTERVAL;
 
 void LivenessTracker::cleanup_table(bool forced) {
   u64 current = loadAcquire(_last_gc_epoch);

--- a/ddprof-lib/src/main/cpp/livenessTracker.h
+++ b/ddprof-lib/src/main/cpp/livenessTracker.h
@@ -44,8 +44,9 @@ class LivenessTracker {
   friend Recording;
 
 private:
-  const static int MAX_TRACKING_TABLE_SIZE = 262144;
-  const static int MIN_SAMPLING_INTERVAL = 524288; // 512kiB
+  // pre-c++17 we should mark these inline(or out of class)
+  inline constexpr static int MAX_TRACKING_TABLE_SIZE = 262144;
+  inline constexpr static int MIN_SAMPLING_INTERVAL = 524288; // 512kiB
 
   bool _initialized;
   bool _enabled;
@@ -88,7 +89,7 @@ public:
 
   LivenessTracker()
       : _initialized(false), _enabled(false), _stored_error(Error::OK),
-        _table_size(0), _table_cap(0), _table(NULL), _table_max_cap(0),
+        _table_size(0), _table_cap(0), _table_max_cap(0), _table(NULL),
         _subsample_ratio(0.1), _record_heap_usage(false), _Class(NULL),
         _Class_getName(0), _gc_epoch(0), _last_gc_epoch(0),
         _used_after_last_gc(0) {}

--- a/ddprof-lib/src/main/cpp/livenessTracker.h
+++ b/ddprof-lib/src/main/cpp/livenessTracker.h
@@ -45,8 +45,8 @@ class LivenessTracker {
 
 private:
   // pre-c++17 we should mark these inline(or out of class)
-  inline constexpr static int MAX_TRACKING_TABLE_SIZE = 262144;
-  inline constexpr static int MIN_SAMPLING_INTERVAL = 524288; // 512kiB
+  constexpr static int MAX_TRACKING_TABLE_SIZE = 262144;
+  constexpr static int MIN_SAMPLING_INTERVAL = 524288; // 512kiB
 
   bool _initialized;
   bool _enabled;

--- a/ddprof-lib/src/main/cpp/objectSampler.h
+++ b/ddprof-lib/src/main/cpp/objectSampler.h
@@ -25,7 +25,6 @@
 #include <time.h>
 
 typedef int (*get_sampling_interval)();
-static int __min(int a, int b) { return a < b ? a : b; }
 
 class ObjectSampler : public Engine {
   friend Recording;

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -945,7 +945,6 @@ bool Profiler::crashHandler(int signo, siginfo_t *siginfo, void *ucontext) {
   if (VM::isHotspot()) {
     // the following checks require vmstructs and therefore HotSpot
 
-    // this check can longjmp to a completely different location - need to call exitCrashHandler() before
     StackWalker::checkFault(thrd);
 
     // Workaround for JDK-8313796. Setting cstack=dwarf also helps

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -161,8 +161,8 @@ private:
 public:
   Profiler()
       : _state(NEW), _class_unload_hook_trap(2),
-        _notify_class_unloaded_func(NULL), _call_trace_storage(),
-        _thread_filter(), _jfr(), _start_time(0), _epoch(0), _timer_id(NULL),
+        _notify_class_unloaded_func(NULL), _thread_filter(), _call_trace_storage(), _jfr(),
+        _start_time(0), _epoch(0), _timer_id(NULL),
         _max_stack_depth(0), _safe_mode(0), _thread_events_state(JVMTI_DISABLE),
         _stubs_lock(), _runtime_stubs("[stubs]"), _native_libs(),
         _call_stub_begin(NULL), _call_stub_end(NULL), _dlopen_entry(NULL),

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -458,7 +458,7 @@ void StackWalker::checkFault(ProfiledThread* thrd) {
   VMThread *vm_thread = VMThread::current();
   if (vm_thread != NULL && sameStack(vm_thread->exception(), &vm_thread)) {
     if (thrd) {
-      thrd->exitCrashHandler();
+      thrd->resetCrashHandler();
     }
     longjmp(*(jmp_buf *)vm_thread->exception(), 1);
   }

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -458,6 +458,7 @@ void StackWalker::checkFault(ProfiledThread* thrd) {
   VMThread *vm_thread = VMThread::current();
   if (vm_thread != NULL && sameStack(vm_thread->exception(), &vm_thread)) {
     if (thrd) {
+      // going to longjmp out of the signal handler, reset the crash handler depth counter
       thrd->resetCrashHandler();
     }
     longjmp(*(jmp_buf *)vm_thread->exception(), 1);

--- a/ddprof-lib/src/main/cpp/thread.h
+++ b/ddprof-lib/src/main/cpp/thread.h
@@ -44,9 +44,8 @@ private:
   u32 _recording_epoch;
 
   ProfiledThread(int buffer_pos, int tid)
-      : ThreadLocalData(), _crash_depth(0), _buffer_pos(buffer_pos), _tid(tid), _cpu_epoch(0),
-        _wall_epoch(0), _pc(0), _call_trace_id(0), _recording_epoch(0),
-        _span_id(0){};
+      : ThreadLocalData(), _pc(0), _span_id(0), _crash_depth(0), _buffer_pos(buffer_pos), _tid(tid), _cpu_epoch(0),
+        _wall_epoch(0), _call_trace_id(0), _recording_epoch(0) {};
 
   void releaseFromBuffer();
 

--- a/ddprof-lib/src/main/cpp/thread.h
+++ b/ddprof-lib/src/main/cpp/thread.h
@@ -103,6 +103,10 @@ public:
     if (_crash_depth > 0) _crash_depth--;
   }
 
+  void resetCrashHandler() {
+    _crash_depth = 0;
+  }
+
   bool isDeepCrashHandler() {
     return _crash_depth > CRASH_HANDLER_NESTING_LIMIT;
   }

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -53,7 +53,6 @@ spotless {
       scalafmt('2.7.5').configFile(configPath + '/enforcement/spotless-scalafmt.conf')
     }
   }
-
   if (project.plugins.hasPlugin('cpp-library') || project.plugins.hasPlugin('cpp-application')) {
     cpp {
       def clangVersion = null
@@ -66,19 +65,22 @@ spotless {
           def versionMatcher = (versionOutput =~ /clang-format version (\d+\.\d+\.\d+.*)/)
           if (versionMatcher) {
             clangVersion = versionMatcher[0][1]  // The version is captured in group 1
-          } else {
-            clangVersion = "11.0.0" // default to 11.0.0
           }
         }
       } catch (Throwable t) {
-        clangVersion = "11.0.0" // no clang-format available; just set the default version
+        throw new GradleException("Clang-format is not available. Please install Clang 11.")
+      }
+
+      // Check if the version is 11.0.0 or higher
+      if (clangVersion && !clangVersion.startsWith("11")) {
+        throw new GradleException("Clang version ${clangVersion} is not supported. Please install Clang 11.")
       }
 
       target 'src/main/cpp/**'
-
       clangFormat(clangVersion).configFile(configPath + '/enforcement/.clang-format')
     }
   }
+
 
   format 'misc', {
     toggleOffOn()


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->
When exiting through the longjmp path, we should reset the depth instead of decrementing.

There were a lot of warnings in the CI. I fixed the most obvious ones.
The PR can be reviewed with separate commits.

**Motivation**:
<!-- What inspired you to submit this pull request? -->
Jaroslav witnessed a crash in the safe access function (meaning we were not preventing the safe access crashes).

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
I have not been able to reproduce as of now.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
