### PR TITLE
VMStructs: Undefined behaviour fix

### DIFF
--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -808,17 +808,22 @@ int NMethod::findScopeOffset(const void *pc) {
 }
 
 int ScopeDesc::readInt() {
-  unsigned char c = *_stream++;
-  unsigned int n = c - _unsigned5_base;
-  if (c >= 192) {
-    for (int shift = 6;; shift += 6) {
-      c = *_stream++;
-      n += (c - _unsigned5_base) << shift;
-      if (c < 192 || shift >= 24)
-        break;
+    unsigned char c = *_stream++;
+    if (c < _unsigned5_base) {
+        return 0;
     }
-  }
-  return n;
+    unsigned int n = c - _unsigned5_base;
+    if (c >= 192) {
+        for (int shift = 6; ; shift += 6) {
+            c = *_stream++;
+            if (c < _unsigned5_base) {
+                break;
+            }
+            n += (c - _unsigned5_base) << shift;
+            if (c < 192 || shift >= 24) break;
+        }
+    }
+    return n;
 }
 
 bool VMStructs::isSafeToWalk(uintptr_t pc) {


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->

Avoid shifting a negative value
This was raised by asan nightly runs

**Motivation**:
<!-- What inspired you to submit this pull request? -->
```
> Task :ddprof-test:testClasses
ddprof-lib/src/main/cpp/vmStructs.cpp:816:34: runtime error: left shift of negative value -1
    #0 0x7f6f6bd20631 in ScopeDesc::readInt()
    #1 0x7f6f6bce54a6 in ScopeDesc::decode(int)
    #2 0x7f6f6bce7fb0 in StackWalker::walkVM(void*, ASGCT_CallFrame*, int, void const*, void const*)
```

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
