### PR TITLE
Split java version to 'java version' and 'hotspot version'

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -703,7 +703,7 @@ void Recording::writeRecordingInfo(Buffer *buf) {
   buf->putUtf8("java-profiler " PROFILER_VERSION);
   buf->putUtf8("java-profiler.jfr");
   buf->putVar64(MAX_JLONG);
-  if (VM::java_version() >= 14) {
+  if (VM::hotspot_version() >= 14) {
     buf->put8(0);
   }
   buf->put8(0);

--- a/ddprof-lib/src/main/cpp/jfrMetadata.cpp
+++ b/ddprof-lib/src/main/cpp/jfrMetadata.cpp
@@ -214,7 +214,7 @@ void JfrMetadata::initialize(
               << field("destination", T_STRING, "Destination")
               << field("maxAge", T_LONG, "Max Age", F_DURATION_MILLIS)
               << field("flushInterval", T_LONG, "Flush Interval",
-                       F_DURATION_MILLIS, VM::java_version() >= 14)
+                       F_DURATION_MILLIS, VM::hotspot_version() >= 14)
               << field("maxSize", T_LONG, "Max Size", F_BYTES)
               << field("recordingStart", T_LONG, "Start Time", F_TIME_MILLIS)
               << field("recordingDuration", T_LONG, "Recording Duration",

--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -242,7 +242,7 @@ Error LivenessTracker::initialize(Arguments &args) {
   }
   _initialized = true;
 
-  if (VM::java_version() < 11) {
+  if (VM::hotspot_version() < 11) {
     Log::warn("Liveness tracking requires Java 11+");
     // disable liveness tracking
     _table_max_cap = 0;

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1194,7 +1194,7 @@ Error Profiler::start(Arguments &args, bool reset) {
   }
 
   _safe_mode = args._safe_mode;
-  if (VM::java_version() < 8 || VM::isZing()) {
+  if (VM::hotspot_version() < 8 || VM::isZing()) {
     _safe_mode |= GC_TRACES | LAST_JAVA_PC;
   }
 

--- a/ddprof-lib/src/main/cpp/vmEntry.h
+++ b/ddprof-lib/src/main/cpp/vmEntry.h
@@ -87,6 +87,17 @@ typedef struct {
   jvmtiError(JNICALL *RetransformClasses)(jvmtiEnv *, jint, const jclass *);
 } JVMTIFunctions;
 
+typedef struct {
+  int major;
+  int update;
+} JavaFullVersion;
+
+class JavaVersionAccess {
+ public:
+   static JavaFullVersion get_java_version(char* prop_value);
+   static int get_hotspot_version(char* prop_value);
+};
+
 class VM {
 private:
   static JavaVM *_vm;
@@ -94,6 +105,7 @@ private:
 
   static int _java_version;
   static int _java_update_version;
+  static int _hotspot_version;
   static bool _openj9;
   static bool _hotspot;
   static bool _zing;
@@ -144,7 +156,7 @@ public:
 
   static int java_version() { return _java_version; }
 
-  static int hotspot_version() { return isHotspot() ? _java_version : -1; }
+  static int hotspot_version() { return isHotspot() ? _hotspot_version : -1; }
 
   static int java_update_version() { return _java_update_version; }
 

--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -493,7 +493,7 @@ const void *VMStructs::findHeapUsageFunc() {
         return _libjvm->findSymbol("_ZN15G1CollectedHeap12memory_usageEv");
       } else if (isFlagTrue("UseShenandoahGC")) {
         return _libjvm->findSymbol("_ZN14ShenandoahHeap12memory_usageEv");
-      } else if (isFlagTrue("UseZGC") && VM::java_version() < 21) {
+      } else if (isFlagTrue("UseZGC") && VM::hotspot_version() < 21) {
         // acessing this method in JDK 21 (generational ZGC) wil cause SIGSEGV
         return _libjvm->findSymbol("_ZN14ZCollectedHeap12memory_usageEv");
       }
@@ -506,7 +506,7 @@ void VMStructs::initJvmFunctions() {
   _get_stack_trace = (GetStackTraceFunc)_libjvm->findSymbolByPrefix(
       "_ZN8JvmtiEnv13GetStackTraceEP10JavaThreadiiP");
 
-  if (VM::java_version() == 8) {
+  if (VM::hotspot_version() == 8) {
     _lock_func = (LockFunc)_libjvm->findSymbol(
         "_ZN7Monitor28lock_without_safepoint_checkEv");
     _unlock_func = (LockFunc)_libjvm->findSymbol("_ZN7Monitor6unlockEv");
@@ -589,7 +589,7 @@ void VMStructs::initThreadBridge(JNIEnv *env) {
 void VMStructs::initLogging(JNIEnv *env) {
   // Workaround for JDK-8238460
   // Can not be used for OpenJ9 because it will crash the VM
-  if (VM::java_version() >= 15 && !VM::isOpenJ9()) {
+  if (VM::java_version() >= 15 && VM::hotspot_version() >= 15 && !VM::isOpenJ9()) {
     VMManagement *management = VM::management();
     if (management != NULL) {
       jstring vm_log_str = env->NewStringUTF("VM.log list");

--- a/ddprof-lib/src/test/cpp/ddprof_ut.cpp
+++ b/ddprof-lib/src/test/cpp/ddprof_ut.cpp
@@ -9,6 +9,7 @@
     #include "threadFilter.h"
     #include "threadInfo.h"
     #include "threadLocalData.h"
+    #include "vmEntry.h"
     #include <vector>
 
     ssize_t callback(char* ptr, int len) {
@@ -191,6 +192,47 @@
             EXPECT_TRUE(first.acquired());
         }
         EXPECT_FALSE(data.is_unwinding_Java());
+    }
+
+    TEST(JavaVersionAccess, testJavaVersionAccess_hs_8) {
+        char runtime_prop_value_1[] = "1.8.0_292";
+        char vm_prop_value_1[] = "25.292-b10";
+        char runtime_prop_value_2[] = "8.0.292";
+        char vm_prop_value_2[] = "25.292-b10";
+
+        JavaFullVersion java_version1 = JavaVersionAccess::get_java_version(runtime_prop_value_1);
+        int hs_version1 = JavaVersionAccess::get_hotspot_version(vm_prop_value_1);
+        EXPECT_EQ(8, java_version1.major);
+        EXPECT_EQ(292, java_version1.update);
+        EXPECT_EQ(8, hs_version1);
+
+        JavaFullVersion java_version2 = JavaVersionAccess::get_java_version(runtime_prop_value_2);
+        int hs_version2 = JavaVersionAccess::get_hotspot_version(vm_prop_value_2);
+        EXPECT_EQ(8, java_version2.major);
+        EXPECT_EQ(292, java_version2.update);
+        EXPECT_EQ(8, hs_version2);
+    }
+
+    TEST(JavaVersionAccess, testJavaVersionAccess_hs_11) {
+        char runtime_prop_value_1[] = "11.0.25";
+        char vm_prop_value_1[] = "11.0.25+10";
+
+        JavaFullVersion java_version1 = JavaVersionAccess::get_java_version(runtime_prop_value_1);
+        int hs_version1 = JavaVersionAccess::get_hotspot_version(vm_prop_value_1);
+        EXPECT_EQ(11, java_version1.major);
+        EXPECT_EQ(25, java_version1.update);
+        EXPECT_EQ(11, hs_version1);
+    }
+
+    TEST(JavaVersionAccess, testJavaVersionAccess_hs_default) {
+        char runtime_prop_value_1[] = "3.11.25x_10";
+        char vm_prop_value_1[] = "3.11.25x_10";
+
+        JavaFullVersion java_version1 = JavaVersionAccess::get_java_version(runtime_prop_value_1);
+        int hs_version1 = JavaVersionAccess::get_hotspot_version(vm_prop_value_1);
+        EXPECT_EQ(9, java_version1.major);
+        EXPECT_EQ(25, java_version1.update);
+        EXPECT_EQ(9, hs_version1);
     }
 
     int main(int argc, char **argv) {


### PR DESCRIPTION
**What does this PR do?**:
It fixes the java and hotspot version retrieval. It splits the version in Java version and Hotspot version (if available) - yes, there still might be distributions allowing combination of different levels of Java and Hotspot.

**Motivation**:
Reported issue #136 

**How to test the change?**:
Added UT GTests

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-10797]

Unsure? Have a question? Request a review!


[PROF-10797]: https://datadoghq.atlassian.net/browse/PROF-10797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ