### PR TITLE
add queue type and length to queue events

### DIFF
--- a/ddprof-lib/src/main/cpp/event.h
+++ b/ddprof-lib/src/main/cpp/event.h
@@ -152,6 +152,8 @@ typedef struct QueueTimeEvent {
   u32 _task;
   u32 _scheduler;
   u32 _origin;
+  u32 _queueType;
+  u32 _queueLength;
 } QueueTimeEvent;
 
 #endif // _EVENT_H

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1334,6 +1334,8 @@ void Recording::recordQueueTime(Buffer *buf, int tid, QueueTimeEvent *event) {
   buf->putVar64(event->_origin);
   buf->putVar64(event->_task);
   buf->putVar64(event->_scheduler);
+  buf->putVar64(event->_queueType);
+  buf->putVar64(event->_queueLength);
   writeContext(buf, Contexts::get(tid));
   writeEventSizePrefix(buf, start);
   flushIfNeeded(buf);

--- a/ddprof-lib/src/main/cpp/jfrMetadata.cpp
+++ b/ddprof-lib/src/main/cpp/jfrMetadata.cpp
@@ -186,6 +186,8 @@ void JfrMetadata::initialize(
                   << field("origin", T_THREAD, "Origin Thread", F_CPOOL)
                   << field("task", T_CLASS, "Task", F_CPOOL)
                   << field("scheduler", T_CLASS, "Scheduler", F_CPOOL)
+                  << field("queueType", T_CLASS, "Queue Type", F_CPOOL)
+                  << field("queueLength", T_INT, "Queue Length on Entry")
                   << field("spanId", T_LONG, "Span ID")
                   << field("localRootSpanId", T_LONG, "Local Root Span ID") ||
               contextAttributes)

--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
@@ -442,9 +442,14 @@ public final class JavaProfiler {
      * @param scheduler the name of the thread-pool or executor scheduling the task
      * @param origin the thread the task was submitted on
      */
-    public void recordQueueTime(long startTicks, long endTicks, Class<?> task, Class<?> scheduler,
+    public void recordQueueTime(long startTicks,
+                                long endTicks,
+                                Class<?> task,
+                                Class<?> scheduler,
+                                Class<?> queueType,
+                                int queueLength,
                                 Thread origin) {
-        recordQueueEnd0(startTicks, endTicks, task.getName(), scheduler.getName(), origin);
+        recordQueueEnd0(startTicks, endTicks, task.getName(), scheduler.getName(), origin, queueType.getName(), queueLength);
     }
 
     /**
@@ -578,7 +583,7 @@ public final class JavaProfiler {
 
     private static native void recordSettingEvent0(String name, String value, String unit);
 
-    private static native void recordQueueEnd0(long startTicks, long endTicks, String task, String scheduler, Thread origin);
+    private static native void recordQueueEnd0(long startTicks, long endTicks, String task, String scheduler, Thread origin, String queueType, int queueLength);
 
     private static native long currentTicks0();
 


### PR DESCRIPTION
**What does this PR do?**:
Adds queue type (the class name) and the length (how long the queue was when the task started waiting) to queue time events. This is a breaking change so needs to be coordinated with the corresponding change to dd-trace-java, and needs to be the only change in a release, so we may need to rebase it for a while.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
- [x] JIRA: [PROF-10630]

Unsure? Have a question? Request a review!


[PROF-10630]: https://datadoghq.atlassian.net/browse/PROF-10630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ