### PR TITLE
Downport stack adjustment mode from async-profiler

### DIFF
--- a/ddprof-test/src/test/java/com/datadoghq/profiler/context/TagContextTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/context/TagContextTest.java
@@ -100,7 +100,7 @@ public class TagContextTest extends AbstractProfilerTest {
         Map<String, Long> debugCounters = profiler.getDebugCounters();
         assertFalse(debugCounters.isEmpty());
         assertEquals(1, debugCounters.get("context_storage_pages"));
-        assertEquals(0x10000, debugCounters.get("context_storage_bytes"));
+        assertEquals(0x10000, debugCounters.get("context_storage_bytes"), () -> "invalid context storage: " + debugCounters);
         assertEquals(strings.length, debugCounters.get("dictionary_context_keys"));
         assertEquals(Arrays.stream(strings).mapToInt(s -> s.length() + 1).sum(), debugCounters.get("dictionary_context_keys_bytes"));
         assertBoundedBy(debugCounters.get("dictionary_context_pages"), strings.length, "context storage too many pages");
@@ -154,6 +154,6 @@ public class TagContextTest extends AbstractProfilerTest {
 
     @Override
     protected String getProfilerCommand() {
-        return "wall=~1ms,filter=0";
+        return "wall=1ms,filter=0";
     }
 }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/ObjectSampleDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/ObjectSampleDumpSmokeTest.java
@@ -15,7 +15,7 @@ public class ObjectSampleDumpSmokeTest extends JfrDumpTest {
 
     @Override
     protected String getProfilerCommand() {
-        return "memory=16536:a";
+        return "memory=1024:a";
     }
 
     @RetryingTest(3)


### PR DESCRIPTION
**What does this PR do?**:
Downport stack adjustment mode from async-profiler

**Motivation**:
Allow an experimental mode for recovery of 'unknown_Java` stacks. This mode is not enabled by default because it does 'blind' probing, incrementing SP by pointer size at a time, hoping ASGCT would be able to unwind from that location - which is not really safe and may induce crashes.


**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
