### PR TITLE
Crash handler registration does not work correctly

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -66,6 +66,9 @@ class Profiler {
   friend VM;
 
 private:
+  // signal handlers
+  static volatile bool _signals_initialized;
+
   Mutex _state_lock;
   State _state;
   // class unload hook


### PR DESCRIPTION
**What does this PR do?**:
Fixes the crash handler registration routine by:
- making the java version detection more robust
- guard crash handler setup by JVM being hotspot or J9 instead of relying on Java version
- use a dedicated crash handler initialization flag instead of relying on JVMTI not having been initialized

**Motivation**:
Avoid spurious crashes due to not working safe access mechanism

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-10866]

Unsure? Have a question? Request a review!


[PROF-10866]: https://datadoghq.atlassian.net/browse/PROF-10866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ