### PR TITLE
Fix J9 JVM thread-bridge

### DIFF
--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "vmStructs.h"
+#include "common.h"
 #include "j9Ext.h"
 #include "safeAccess.h"
 #include "spinLock.h"
@@ -569,11 +570,12 @@ void VMStructs::initThreadBridge(JNIEnv *env) {
   // Get eetop field - a bridge from Java Thread to VMThread
   jclass thread_class = env->GetObjectClass(thread);
   _tid = env->GetFieldID(thread_class, "tid", "J");
-  env->ExceptionClear();
   _eetop = env->GetFieldID(thread_class, "eetop", "J");
-  env->ExceptionClear();
 
   if (_tid == NULL || _eetop == NULL || VM::isOpenJ9()) {
+    // clear any pending exceptions
+    TEST_LOG("J9 thread: tid=%p, eetop=%p", _tid, _eetop);
+    env->ExceptionClear();
     // In JDK 18 and earlier the eetop will be NULL
     // In JDK 19 and later the eetop is an alias to 'threadRef' value
     //  - https://github.com/eclipse-openj9/openj9/blob/ecbfade39c5573ed48e19961708822b5c841b2e7/runtime/oti/vmconstantpool.xml#L239

--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -568,11 +568,15 @@ void VMStructs::initThreadBridge(JNIEnv *env) {
 
   // Get eetop field - a bridge from Java Thread to VMThread
   jclass thread_class = env->GetObjectClass(thread);
-  if ((_tid = env->GetFieldID(thread_class, "tid", "J")) == NULL ||
-      (_eetop = env->GetFieldID(thread_class, "eetop", "J")) == NULL) {
-    // No such field - probably not a HotSpot JVM
-    env->ExceptionClear();
+  _tid = env->GetFieldID(thread_class, "tid", "J");
+  env->ExceptionClear();
+  _eetop = env->GetFieldID(thread_class, "eetop", "J");
+  env->ExceptionClear();
 
+  if (_tid == NULL || _eetop == NULL || VM::isOpenJ9()) {
+    // In JDK 18 and earlier the eetop will be NULL
+    // In JDK 19 and later the eetop is an alias to 'threadRef' value
+    //  - https://github.com/eclipse-openj9/openj9/blob/ecbfade39c5573ed48e19961708822b5c841b2e7/runtime/oti/vmconstantpool.xml#L239
     void *j9thread = J9Ext::j9thread_self();
     if (j9thread != NULL) {
       initTLS(j9thread);


### PR DESCRIPTION
**What does this PR do?**:
It updates the J9 thread-bridge initialization for changes coming in JDK 19

**Motivation**:
While checking for the current state of support for profiling on J9 I realized we were not activating profiler on JDK 21

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-10149]

Unsure? Have a question? Request a review!


[PROF-10149]: https://datadoghq.atlassian.net/browse/PROF-10149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ