### PR TITLE
Default to non-ASGCT samplers on J9

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1043,16 +1043,15 @@ Engine *Profiler::selectWallEngine(Arguments &args) {
     return &noop_engine;
   }
   if (VM::isOpenJ9()) {
-    if (!J9Ext::can_use_ASGCT()) {
+    if (args._wallclock_sampler == JVMTI) {
       if (!J9Ext::is_jvmti_jmethodid_safe()) {
         Log::warn("Safe jmethodID access is not available on this JVM. Using "
                   "wallclock profiler on your own risk.");
       }
       j9_engine.sampleIdleThreads();
       return (Engine *)&j9_engine;
-    } else if (!J9Ext::is_jmethodid_safe()) {
-      Log::warn("Safe jmethodID access is not available on this JVM. Using "
-                "wallclock profiler on your own risk.");
+    } else {
+      return (Engine *)&wall_asgct_engine;
     }
   }
   switch (args._wallclock_sampler) {

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1016,16 +1016,11 @@ Engine *Profiler::selectCpuEngine(Arguments &args) {
     return &noop_engine;
   } else if (args._cpu >= 0 || strcmp(args._event, EVENT_CPU) == 0) {
     if (VM::isOpenJ9()) {
-      if (!J9Ext::can_use_ASGCT()) {
-        if (!J9Ext::is_jvmti_jmethodid_safe()) {
-          Log::warn("Safe jmethodID access is not available on this JVM. Using "
-                    "CPU profiler on your own risk.");
-        }
-        return &j9_engine;
-      } else if (!J9Ext::is_jmethodid_safe()) {
+      if (!J9Ext::is_jvmti_jmethodid_safe()) {
         Log::warn("Safe jmethodID access is not available on this JVM. Using "
                   "CPU profiler on your own risk.");
       }
+      return &j9_engine;
     }
     return !ctimer.check(args)
                ? (Engine *)&ctimer


### PR DESCRIPTION
**What does this PR do?**:
It changes the default behaviour when on J9 the non-ASGCT based samplers will be picked unless otherwise specified.

**Motivation**:
Due to [this OpenJ9 bug](https://github.com/eclipse-openj9/openj9/issues/20577) we are running the risk of getting the profiled application into live-lock when using ASGCT.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-10894]

Unsure? Have a question? Request a review!


[PROF-10894]: https://datadoghq.atlassian.net/browse/PROF-10894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ