### PR TITLE
Add sanity test for Java version retrieval in native code

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -46,6 +46,16 @@ jobs:
           export LIBC=glibc
           export JAVA_TEST_HOME=$(pwd)/test_jdk
           export SANITIZER=${{ matrix.config }}
+          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
+              split($2, v, "[._]");
+              if (v[1] == "1") {
+              # Java 8 or older: Include major, minor, and update
+              printf "%s.%s.%s\n", v[2], v[3], v[4]
+            } else {
+              # Java 9 or newer: Major, minor, and patch
+              printf "%s.%s.%s\n", v[1], v[2], v[3]
+            }
+          }')
           ./gradlew :ddprof-test:test${{ matrix.config }}  
           if [ $? -ne 0 ]; then 
             echo "glibc-${{ matrix.java_version }}-${{ matrix.config }}" >> failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}.txt
@@ -109,6 +119,16 @@ jobs:
           export JAVA_HOME=$JAVA_HOME
           export PATH=$JAVA_HOME/bin:$PATH
           export SANITIZER=${{ matrix.config }}
+          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
+              split($2, v, "[._]");
+              if (v[1] == "1") {
+              # Java 8 or older: Include major, minor, and update
+              printf "%s.%s.%s\n", v[2], v[3], v[4]
+            } else {
+              # Java 9 or newer: Major, minor, and patch
+              printf "%s.%s.%s\n", v[1], v[2], v[3]
+            }
+          }')
           ./gradlew :ddprof-test:test${{ matrix.config }}
           if [ $? -ne 0 ]; then 
             echo "ubuntu-jdk-${{ matrix.java_version }}-${{ matrix.config }}" >> failures_ubuntu-jdk-${{ matrix.java_version }}-${{ matrix.config }}.txt
@@ -169,6 +189,16 @@ jobs:
           export TEST_CONFIGURATION=glibc/${{ matrix.java_version }}
           export LIBC=glibc
           export SANITIZER=${{ matrix.config }}
+          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
+              split($2, v, "[._]");
+              if (v[1] == "1") {
+              # Java 8 or older: Include major, minor, and update
+              printf "%s.%s.%s\n", v[2], v[3], v[4]
+            } else {
+              # Java 9 or newer: Major, minor, and patch
+              printf "%s.%s.%s\n", v[1], v[2], v[3]
+            }
+          }')
           chmod a+x gradlew
           ./gradlew :ddprof-test:test${{ matrix.config }}
           if [ $? -ne 0 ]; then 
@@ -233,6 +263,16 @@ jobs:
           export JAVA_HOME=$JAVA_HOME
           export PATH=$JAVA_HOME/bin:$PATH
           export SANITIZER=${{ matrix.config }}
+          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
+              split($2, v, "[._]");
+              if (v[1] == "1") {
+              # Java 8 or older: Include major, minor, and update
+              printf "%s.%s.%s\n", v[2], v[3], v[4]
+            } else {
+              # Java 9 or newer: Major, minor, and patch
+              printf "%s.%s.%s\n", v[1], v[2], v[3]
+            }
+          }')
           ./gradlew :ddprof-test:test${{ matrix.config }}
           if [ $? -ne 0 ]; then 
             echo "glibc-oracle8-${{ matrix.config }}" >> failures_glibc-oracle8-${{ matrix.config }}.txt
@@ -295,6 +335,16 @@ jobs:
           export LIBC=musl
           export JAVA_TEST_HOME=$(pwd)/test_jdk
           export SANITIZER=${{ matrix.config }}
+          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
+              split($2, v, "[._]");
+              if (v[1] == "1") {
+              # Java 8 or older: Include major, minor, and update
+              printf "%s.%s.%s\n", v[2], v[3], v[4]
+            } else {
+              # Java 9 or newer: Major, minor, and patch
+              printf "%s.%s.%s\n", v[1], v[2], v[3]
+            }
+          }')
           ./gradlew :ddprof-test:test${{ matrix.config }}
           if [ $? -ne 0 ]; then 
             echo "musl-${{ matrix.java_version }}-${{ matrix.config }}" >> failures_musl-${{ matrix.java_version }}-${{ matrix.config }}.txt
@@ -380,6 +430,16 @@ jobs:
           export JAVA_HOME=$JAVA_HOME
           export PATH=$JAVA_HOME/bin:$PATH
           export SANITIZER=${{ matrix.config }}
+          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
+              split($2, v, "[._]");
+              if (v[1] == "1") {
+              # Java 8 or older: Include major, minor, and update
+              printf "%s.%s.%s\n", v[2], v[3], v[4]
+            } else {
+              # Java 9 or newer: Major, minor, and patch
+              printf "%s.%s.%s\n", v[1], v[2], v[3]
+            }
+          }')
           ./gradlew :ddprof-test:test${{ matrix.config }}
           if [ $? -ne 0 ]; then 
             echo "glibc-zing-${{ matrix.java_version }}-${{ matrix.config }}" >> failures_zing-${{ matrix.java_version }}-${{ matrix.config }}.txt

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/JVMAccessTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/JVMAccessTest.java
@@ -57,6 +57,47 @@ public class JVMAccessTest {
     }
 
     @Test
+    void jvmVersionTest() throws Exception {
+        String config = System.getProperty("ddprof_test.config");
+        assumeTrue("debug".equals(config));
+
+        String javaVersion = System.getenv("JAVA_VERSION");
+        assumeTrue(javaVersion != null);
+
+        String javaHome = System.getenv("JAVA_TEST_HOME");
+        if (javaHome == null) {
+            javaHome = System.getenv("JAVA_HOME");
+        }
+        if (javaHome == null) {
+            javaHome = System.getProperty("java.home");
+        }
+        assertNotNull(javaHome);
+
+        File outFile = Files.createTempFile("jvmaccess", ".out").toFile();
+        outFile.deleteOnExit();
+        File errFile = Files.createTempFile("jvmaccess", ".err").toFile();
+        errFile.deleteOnExit();
+
+        ProcessBuilder pb = new ProcessBuilder(javaHome + "/bin/java", "-cp", System.getProperty("java.class.path"), ExternalLauncher.class.getName(), "library");
+        pb.redirectOutput(outFile);
+        pb.redirectError(errFile);
+        Process p = pb.start();
+        int val = p.waitFor();
+        assertEquals(0, val);
+
+        String foundVersion = null;
+        for (String line : Files.readAllLines(outFile.toPath())) {
+            System.err.println(line);
+            if (line.contains("[TEST::INFO] jvm_version#")) {
+                foundVersion = line.split("#")[1];
+                break;
+            }
+        }
+        assertNotNull(foundVersion, "java version not found in logs");
+        assertEquals(javaVersion, foundVersion, "invalid java version");
+    }
+
+    @Test
     void testGetFlag() {
         JVMAccess.Flags flags = JVMAccess.getInstance().flags();
         // non-existent flag


### PR DESCRIPTION
**What does this PR do?**:
Adds a sanity test for the Java version retrieval in the JVMTI agent/library

**Motivation**:
We want to have the version retrieval covered because it is used for conditionally enabling some parts of the profiler to avoid problems and crashes.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-10876]

Unsure? Have a question? Request a review!


[PROF-10876]: https://datadoghq.atlassian.net/browse/PROF-10876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ