### PR TITLE
Downstream aarch64 related fixes

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -12,11 +12,11 @@ permissions:
   actions: read
 
 jobs:
-  test-linux-glibc:
+  test-linux-glibc-amd64:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ 8u412+9, 11.0.23+12, 17.0.11+12, 21.0.3+12, 22.0.1+12 ]
+        java_version: [ 8u432+7, 11.0.25+11, 17.0.13+12, 21.0.5+11, 23.0.1+13 ]
         config: ${{ fromJson(inputs.configuration) }}
     runs-on: ubuntu-latest
     timeout-minutes: 180
@@ -42,7 +42,7 @@ jobs:
 
           set +e
           export TEST_COMMIT=${{ github.sha }}
-          export TEST_CONFIGURATION=glibc/${{ matrix.java_version }}
+          export TEST_CONFIGURATION=glibc/${{ matrix.java_version }}-amd64
           export LIBC=glibc
           export JAVA_TEST_HOME=$(pwd)/test_jdk
           export SANITIZER=${{ matrix.config }}
@@ -56,17 +56,18 @@ jobs:
               printf "%s.%s.%s\n", v[1], v[2], v[3]
             }
           }')
-          ./gradlew :ddprof-test:test${{ matrix.config }}  
-          if [ $? -ne 0 ]; then 
-            echo "glibc-${{ matrix.java_version }}-${{ matrix.config }}" >> failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}.txt
+          ./gradlew :ddprof-test:test${{ matrix.config }}
+          if [ $? -ne 0 ]; then
+            echo "glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64" >> failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
             exit 1
           fi
       - name: Upload logs
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: reports-linux-glibc-${{ matrix.java_version }}.zip
+          name: reports-linux-glibc-${{ matrix.java_version }}-amd64.zip
           path: |
+            /tmp/hs_err*
             ddprof-test/hs_err_*
             ddprof-test/build/reports/tests
             ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
@@ -74,21 +75,23 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: success()
         with:
-          name: x64-glibc-${{ matrix.java_version }}-${{ matrix.config }}
+          name: glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64
           path: build/
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: failures
-          path: failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}.txt
+          path: failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
 
-  test-ubuntu-jdk:
+  test-linux-glibc-aarch64:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ '11.0.23-librca', '17.0.11-librca', '21.0.3-librca', '22.0.1-librca' ]
+        java_version: [ 8u432+7, 11.0.25+11, 17.0.13+12, 21.0.5+11, 23.0.1+13 ]
         config: ${{ fromJson(inputs.configuration) }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: ARM LINUX SHARED
+      labels: arm-4core-linux
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@v3
@@ -97,49 +100,39 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: "11"
-      - name: Prepare OS
+      - name: Setup OS
         run: |
-          sudo apt-get update
-          sudo apt-get install -y curl zip unzip libgtest-dev libgmock-dev
+          sudo apt update -y
+          sudo apt remove -y g++
+          sudo apt autoremove -y
+          sudo apt install -y curl zip unzip clang make build-essential
       - name: Prepare JDK ${{ matrix.java_version }}
         run: |
-          curl -s "https://get.sdkman.io" | bash
-          source "$HOME/.sdkman/bin/sdkman-init.sh"
-          echo 'n' | sdk install java ${{ matrix.java_version }}
+          wget -nv https://download.bell-sw.com/java/${{ matrix.java_version }}/bellsoft-jdk${{ matrix.java_version }}-linux-aarch64.tar.gz -O jdk.tar.gz
+          tar xzf *.tar.gz
+          find . -type d -name 'jdk*' -maxdepth 1| xargs -I {} mv {} test_jdk
       - name: Test
         run: |
           sudo sysctl vm.mmap_rnd_bits=28
-          source "$HOME/.sdkman/bin/sdkman-init.sh"
-          
+
           set +e
           export TEST_COMMIT=${{ github.sha }}
-          export TEST_CONFIGURATION=glibc/${{ matrix.java_version }}
+          export TEST_CONFIGURATION=glibc/${{ matrix.java_version }}-aarch64
           export LIBC=glibc
-          export JAVA_TEST_HOME=${SDKMAN_DIR}/candidates/java/${{ matrix.java_version }}
-          export JAVA_HOME=$JAVA_HOME
-          export PATH=$JAVA_HOME/bin:$PATH
+          export JAVA_TEST_HOME=$(pwd)/test_jdk
           export SANITIZER=${{ matrix.config }}
-          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
-              split($2, v, "[._]");
-              if (v[1] == "1") {
-              # Java 8 or older: Include major, minor, and update
-              printf "%s.%s.%s\n", v[2], v[3], v[4]
-            } else {
-              # Java 9 or newer: Major, minor, and patch
-              printf "%s.%s.%s\n", v[1], v[2], v[3]
-            }
-          }')
           ./gradlew :ddprof-test:test${{ matrix.config }}
-          if [ $? -ne 0 ]; then 
-            echo "ubuntu-jdk-${{ matrix.java_version }}-${{ matrix.config }}" >> failures_ubuntu-jdk-${{ matrix.java_version }}-${{ matrix.config }}.txt
+          if [ $? -ne 0 ]; then
+            echo "glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64" >> failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
             exit 1
           fi
       - name: Upload logs
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: reports-linux-ubuntu-jdk-${{ matrix.java_version }}.zip
+          name: reports-linux-glibc-${{ matrix.java_version }}-aarch64.zip
           path: |
+            /tmp/hs_err*
             ddprof-test/hs_err_*
             ddprof-test/build/reports/tests
             ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
@@ -147,15 +140,15 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: success()
         with:
-          name: x64-ubuntu-jdk-${{ matrix.java_version }}-${{ matrix.config }}
+          name: glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
           path: build/
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: failures
-          path: failures_ubuntu-jdk-${{ matrix.java_version }}-${{ matrix.config }}.txt
+          path: failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
 
-  test-linux-glibc-j9:
+  test-linux-glibc-j9-amd64:
     strategy:
       fail-fast: false
       matrix:
@@ -201,16 +194,17 @@ jobs:
           }')
           chmod a+x gradlew
           ./gradlew :ddprof-test:test${{ matrix.config }}
-          if [ $? -ne 0 ]; then 
-            echo "glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}" >> failures_glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}.txt
+          if [ $? -ne 0 ]; then
+            echo "glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-amd64" >> failures_glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
             exit 1
           fi
       - name: Upload logs
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: reports-linux-glibc-j9-${{ matrix.java_version }}.zip
+          name: reports-linux-glibc-j9-${{ matrix.java_version }}-amd64.zip
           path: |
+            /tmp/javacore*
             ddprof-test/javacore*
             ddprof-test/build/reports/tests
             ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
@@ -218,13 +212,88 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: success()
         with:
-          name: x64-glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}
+          name: glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-amd64
           path: build/
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: failures
-          path: failures_glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}.txt
+          path: failures_glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
+
+  test-linux-glibc-j9-aarch64:
+    strategy:
+      fail-fast: false
+      matrix:
+        java_version: [ 8, 11, 17 ]
+        config: ${{ fromJson(inputs.configuration) }}
+    runs-on:
+      group: ARM LINUX SHARED
+      labels: arm-4core-linux
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup OS
+        run: |
+          sudo apt update -y
+          sudo apt remove -y g++
+          sudo apt autoremove -y
+          sudo apt install -y curl zip unzip clang make build-essential
+      - name: Prepare test JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt-openj9'
+          java-version: "${{ matrix.java_version }}"
+      - name: Store JAVA_TEST_HOME
+        run: JAVA_PATH=$(which java) && echo "JAVA_TEST_HOME=${JAVA_PATH/\/bin\/java/\/}" >> $GITHUB_ENV
+      - name: Prepare build JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt-openj9'
+          java-version: "11"
+      - name: Test
+        run: |
+          set +e
+          export TEST_COMMIT=${{ github.sha }}
+          export TEST_CONFIGURATION=glibc/${{ matrix.java_version }}
+          export LIBC=glibc
+          export SANITIZER=${{ matrix.config }}
+          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
+              split($2, v, "[._]");
+              if (v[1] == "1") {
+              # Java 8 or older: Include major, minor, and update
+              printf "%s.%s.%s\n", v[2], v[3], v[4]
+            } else {
+              # Java 9 or newer: Major, minor, and patch
+              printf "%s.%s.%s\n", v[1], v[2], v[3]
+            }
+          }')
+          chmod a+x gradlew
+          ./gradlew :ddprof-test:test${{ matrix.config }}
+          if [ $? -ne 0 ]; then
+            echo "glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-aarch64" >> failures_glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
+            exit 1
+          fi
+      - name: Upload logs
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: reports-linux-glibc-j9-${{ matrix.java_version }}-aarch64.zip
+          path: |
+            /tmp/javacore*
+            ddprof-test/javacore*
+            ddprof-test/build/reports/tests
+            ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
+            ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
+      - uses: actions/upload-artifact@v3
+        if: success()
+        with:
+          name: glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
+          path: build/
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: failures
+          path: failures_glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
 
   test-linux-glibc-oracle8:
     strategy:
@@ -274,7 +343,7 @@ jobs:
             }
           }')
           ./gradlew :ddprof-test:test${{ matrix.config }}
-          if [ $? -ne 0 ]; then 
+          if [ $? -ne 0 ]; then
             echo "glibc-oracle8-${{ matrix.config }}" >> failures_glibc-oracle8-${{ matrix.config }}.txt
             exit 1
           fi
@@ -299,11 +368,11 @@ jobs:
           name: failures
           path: failures_glibc-oracle8-${{ matrix.config }}.txt
 
-  test-linux-musl:
+  test-linux-musl-amd64:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ 8u412+9, 11.0.23+12, 17.0.11+12, 21.0.3+12, 22.0.1+12 ]
+        java_version: [ 8u432+7, 11.0.25+11, 17.0.13+12, 21.0.5+11, 23.0.1+13 ]
         config: ${{ fromJson(inputs.configuration) }}
     runs-on: ubuntu-latest
     timeout-minutes: 180
@@ -317,7 +386,7 @@ jobs:
         run: apk update && apk add curl moreutils wget hexdump linux-headers bash make g++ clang git cppcheck jq cmake gtest-dev gmock >/dev/null
       - name: Prepare build JDK
         run: |
-          wget -nv https://download.bell-sw.com/java/11.0.18+10/bellsoft-jdk11.0.18+10-linux-x64-musl.tar.gz -O jdk.tar.gz
+          wget -nv https://download.bell-sw.com/java/11.0.25+11/bellsoft-jdk11.0.25+11-linux-x64-musl.tar.gz -O jdk.tar.gz
           tar xzf *.tar.gz
           find . -type d -name 'jdk*' -maxdepth 1 | xargs -I {} mv {} build_jdk
       - name: Prepare JDK ${{ matrix.java_version }}
@@ -346,16 +415,17 @@ jobs:
             }
           }')
           ./gradlew :ddprof-test:test${{ matrix.config }}
-          if [ $? -ne 0 ]; then 
-            echo "musl-${{ matrix.java_version }}-${{ matrix.config }}" >> failures_musl-${{ matrix.java_version }}-${{ matrix.config }}.txt
+          if [ $? -ne 0 ]; then
+            echo "musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64" >> failures_musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
             exit 1
           fi
       - name: Upload logs
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: reports-linux-musl-${{ matrix.java_version }}.zip
+          name: reports-linux-musl-${{ matrix.java_version }}-amd64.zip
           path: |
+            /tmp/hs_err*
             ddprof-test/hs_err_*
             ddprof-test/build/reports/tests
             ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
@@ -363,15 +433,15 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: success()
         with:
-          name: x64-musl-${{ matrix.java_version }}-${{ matrix.config }}
+          name: musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64
           path: build/
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: failures
-          path: failures_musl-${{ matrix.java_version }}-${{ matrix.config }}.txt
+          path: failures_musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
 
-  test-linux-glibc-zing:
+  test-linux-glibc-zing-amd64:
     strategy:
       fail-fast: false
       matrix:
@@ -441,15 +511,15 @@ jobs:
             }
           }')
           ./gradlew :ddprof-test:test${{ matrix.config }}
-          if [ $? -ne 0 ]; then 
-            echo "glibc-zing-${{ matrix.java_version }}-${{ matrix.config }}" >> failures_zing-${{ matrix.java_version }}-${{ matrix.config }}.txt
+          if [ $? -ne 0 ]; then
+            echo "glibc-zing-${{ matrix.java_version }}-${{ matrix.config }}-amd64" >> failures_zing-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
             exit 1
           fi
       - name: Upload logs
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: reports-linux-zing-jdk-${{ matrix.java_version }}.zip
+          name: reports-linux-zing-jdk-${{ matrix.java_version }}-amd64.zip
           path: |
             ddprof-test/hs_err_*
             ddprof-test/build/reports/tests/test
@@ -458,10 +528,107 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: success()
         with:
-          name: x64-glibc-zing-${{ matrix.java_version }}-${{ matrix.config }}
+          name: glibc-zing-${{ matrix.java_version }}-${{ matrix.config }}-amd64
           path: build/
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: failures
-          path: failures_zing-${{ matrix.java_version }}-${{ matrix.config }}.txt
+          path: failures_zing-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
+
+  test-linux-glibc-zing-aarch64:
+    strategy:
+      fail-fast: false
+      matrix:
+        java_version: [ 8, 11, 17, 21 ]
+        config: ${{ fromJson(inputs.configuration) }}
+    runs-on:
+      group: ARM LINUX SHARED
+      labels: arm-4core-linux
+    timeout-minutes: 180
+
+    steps:
+      - name: Set config output
+        id: set_config
+        run: echo "::set-output name=config::${{ matrix.config }}"
+      - uses: actions/checkout@v3
+        if: steps.set_config.outputs.config == 'release' || steps.set_config.outputs.config == 'debug'
+      - name: Setup OS
+        run: |
+          sudo apt update -y
+          sudo apt remove -y g++
+          sudo apt autoremove -y
+          sudo apt install -y curl zip unzip clang make build-essential
+      - name: Prepare build JDK
+        if: steps.set_config.outputs.config == 'release' || steps.set_config.outputs.config == 'debug'
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: "11"
+      - name: Prepare JDK ${{ matrix.java_version }}
+        if: steps.set_config.outputs.config == 'release' || steps.set_config.outputs.config == 'debug'
+        run: |
+          sudo apt-get -y update && sudo apt-get -y install curl g++-9 gcc-9
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9
+          sudo update-alternatives --set gcc /usr/bin/gcc-9
+          set -eux
+          sudo mkdir -p /usr/lib/jvm/zing
+          if [ "${{ matrix.java_version }}" = "8" ]; then
+            # jdk1.8.0_432
+            curl -L --fail "https://cdn.azul.com/zing-zvm/ZVM24.10.0.0/zing24.10.0.0-4-jdk8.0.431-linux_aarch64.tar.gz" | sudo tar -xvzf - -C /usr/lib/jvm/zing --strip-components 1
+          elif [ "${{ matrix.java_version }}" = "11" ]; then
+            # jdk 11.0.24
+            curl -L --fail "https://cdn.azul.com/zing-zvm/ZVM24.10.0.0/zing24.10.0.0-4-jdk11.0.24.0.101-linux_aarch64.tar.gz" | sudo tar -xvzf - -C /usr/lib/jvm/zing --strip-components 1
+          elif [ "${{ matrix.java_version }}" = "17" ]; then
+            # jdk 17.0.12
+            curl -L --fail "https://cdn.azul.com/zing-zvm/ZVM24.10.0.0/zing24.10.0.0-4-jdk17.0.12.0.101-linux_aarch64.tar.gz" | sudo tar -xvzf - -C /usr/lib/jvm/zing --strip-components 1
+          elif [ "${{ matrix.java_version }}" = "21" ]; then
+            # jdk 21.0.4
+            curl -L --fail "https://cdn.azul.com/zing-zvm/ZVM24.10.0.0/zing24.10.0.0-4-jdk21.0.4.0.101-linux_aarch64.tar.gz" | sudo tar -xvzf - -C /usr/lib/jvm/zing --strip-components 1
+          fi
+      - name: Test
+        if: steps.set_config.outputs.config == 'release' || steps.set_config.outputs.config == 'debug'
+        run: |
+          set +e
+          export TEST_COMMIT=${{ github.sha }}
+          export TEST_CONFIGURATION=glibc/${{ matrix.java_version }}
+          export LIBC=glibc
+          export JAVA_TEST_HOME=/usr/lib/jvm/zing
+          export JAVA_HOME=$JAVA_HOME
+          export PATH=$JAVA_HOME/bin:$PATH
+          export SANITIZER=${{ matrix.config }}
+          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
+              split($2, v, "[._]");
+              if (v[1] == "1") {
+              # Java 8 or older: Include major, minor, and update
+              printf "%s.%s.%s\n", v[2], v[3], v[4]
+            } else {
+              # Java 9 or newer: Major, minor, and patch
+              printf "%s.%s.%s\n", v[1], v[2], v[3]
+            }
+          }')
+          ./gradlew :ddprof-test:test${{ matrix.config }}
+          if [ $? -ne 0 ]; then
+            echo "glibc-zing-${{ matrix.java_version }}-${{ matrix.config }}-aarch64" >> failures_zing-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
+            exit 1
+          fi
+      - name: Upload logs
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: reports-linux-zing-jdk-${{ matrix.java_version }}-aarch64.zip
+          path: |
+            ddprof-test/hs_err_*
+            ddprof-test/build/reports/tests/test
+            ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
+            ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
+      - uses: actions/upload-artifact@v3
+        if: success()
+        with:
+          name: glibc-zing-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
+          path: build/
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: failures
+          path: failures_zing-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt

--- a/ddprof-lib/src/main/cpp/libraries.cpp
+++ b/ddprof-lib/src/main/cpp/libraries.cpp
@@ -5,8 +5,6 @@
 #include "vmEntry.h"
 #include "vmStructs.h"
 
-Libraries* Libraries::_instance = new Libraries();
-
 void Libraries::mangle(const char *name, char *buf, size_t size) {
   char *buf_end = buf + size;
   strcpy(buf, "_ZN");

--- a/ddprof-lib/src/main/cpp/libraries.h
+++ b/ddprof-lib/src/main/cpp/libraries.h
@@ -5,8 +5,6 @@
 
 class Libraries {
  private:
-  static Libraries * _instance;
-
   CodeCacheArray _native_libs;
   CodeCache _runtime_stubs;
 
@@ -21,7 +19,14 @@ class Libraries {
   CodeCache *findLibraryByName(const char *lib_name);
   CodeCache *findLibraryByAddress(const void *address);
 
-  static Libraries *instance() { return _instance; }
+  static Libraries *instance() {
+    static Libraries instance;
+    return &instance;
+  }
+
+  // Delete copy constructor and assignment operator to prevent copies
+  Libraries(const Libraries&) = delete;
+  Libraries& operator=(const Libraries&) = delete;
 };
 
 #endif // _LIBRARIES_H

--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -33,7 +33,6 @@
 #include <jni.h>
 #include <string.h>
 
-LivenessTracker *const LivenessTracker::_instance = new LivenessTracker();
 constexpr int LivenessTracker::MAX_TRACKING_TABLE_SIZE;
 constexpr int LivenessTracker::MIN_SAMPLING_INTERVAL;
 

--- a/ddprof-lib/src/main/cpp/livenessTracker.h
+++ b/ddprof-lib/src/main/cpp/livenessTracker.h
@@ -82,10 +82,14 @@ private:
 
   jlong getMaxMemory(JNIEnv *env);
 
-  static LivenessTracker *const _instance;
-
 public:
-  static LivenessTracker *instance() { return _instance; }
+  static LivenessTracker *instance() {
+    static LivenessTracker instance;
+    return &instance;
+  }
+  // Delete copy constructor and assignment operator to prevent copies
+  LivenessTracker(const LivenessTracker&) = delete;
+  LivenessTracker& operator=(const LivenessTracker&) = delete;
 
   LivenessTracker()
       : _initialized(false), _enabled(false), _stored_error(Error::OK),

--- a/ddprof-lib/src/main/cpp/stackFrame.h
+++ b/ddprof-lib/src/main/cpp/stackFrame.h
@@ -74,6 +74,7 @@ public:
   bool unwindStub(instruction_t *entry, const char *name, uintptr_t &pc,
                   uintptr_t &sp, uintptr_t &fp);
   bool unwindCompiled(NMethod *nm, uintptr_t &pc, uintptr_t &sp, uintptr_t &fp);
+  bool unwindAtomicStub(const void*& pc);
 
   void adjustSP(const void *entry, const void *pc, uintptr_t &sp);
 

--- a/ddprof-lib/src/main/cpp/stackFrame.h
+++ b/ddprof-lib/src/main/cpp/stackFrame.h
@@ -75,7 +75,7 @@ public:
                   uintptr_t &sp, uintptr_t &fp);
   bool unwindCompiled(NMethod *nm, uintptr_t &pc, uintptr_t &sp, uintptr_t &fp);
 
-  void adjustCompiled(NMethod *nm, const void *pc, uintptr_t &sp);
+  void adjustSP(const void *entry, const void *pc, uintptr_t &sp);
 
   bool skipFaultInstruction();
 

--- a/ddprof-lib/src/main/cpp/stackFrame_aarch64.cpp
+++ b/ddprof-lib/src/main/cpp/stackFrame_aarch64.cpp
@@ -136,9 +136,8 @@ bool StackFrame::unwindCompiled(NMethod *nm, uintptr_t &pc, uintptr_t &sp,
   return true;
 }
 
-void StackFrame::adjustCompiled(NMethod *nm, const void *pc, uintptr_t &sp) {
+void StackFrame::adjustSP(const void *entry, const void *pc, uintptr_t &sp) {
   instruction_t *ip = (instruction_t *)pc;
-  instruction_t *entry = (instruction_t *)nm->entry();
   if (ip > entry && (ip[-1] == 0xa9bf27ff ||
                      (ip[-1] == 0xd63f0100 && ip[-2] == 0xa9bf27ff))) {
     // When calling a leaf native from Java, JVM puts a dummy frame link onto

--- a/ddprof-lib/src/main/cpp/stackFrame_aarch64.cpp
+++ b/ddprof-lib/src/main/cpp/stackFrame_aarch64.cpp
@@ -136,6 +136,19 @@ bool StackFrame::unwindCompiled(NMethod *nm, uintptr_t &pc, uintptr_t &sp,
   return true;
 }
 
+bool StackFrame::unwindAtomicStub(const void*& pc) {
+  // VM threads may call generated atomic stubs, which are not normally walkable
+  const void* lr = (const void*)link();
+  if (VMStructs::libjvm()->contains(lr)) {
+    NMethod* nm = CodeHeap::findNMethod(pc);
+    if (nm != NULL && strncmp(nm->name(), "Stub", 4) == 0) {
+      pc = lr;
+      return true;
+    }
+  }
+  return false;
+}
+
 void StackFrame::adjustSP(const void *entry, const void *pc, uintptr_t &sp) {
   instruction_t *ip = (instruction_t *)pc;
   if (ip > entry && (ip[-1] == 0xa9bf27ff ||

--- a/ddprof-lib/src/main/cpp/stackFrame_arm.cpp
+++ b/ddprof-lib/src/main/cpp/stackFrame_arm.cpp
@@ -112,6 +112,11 @@ void StackFrame::adjustSP(const void *entry, const void *pc, uintptr_t &sp) {
   // Not needed
 }
 
+bool StackFrame::unwindAtomicStub(const void*& pc) {
+  // Not needed
+  return false;
+}
+
 bool StackFrame::skipFaultInstruction() { return false; }
 
 bool StackFrame::checkInterruptedSyscall() {

--- a/ddprof-lib/src/main/cpp/stackFrame_arm.cpp
+++ b/ddprof-lib/src/main/cpp/stackFrame_arm.cpp
@@ -108,7 +108,7 @@ bool StackFrame::unwindCompiled(NMethod *nm, uintptr_t &pc, uintptr_t &sp,
   return true;
 }
 
-void StackFrame::adjustCompiled(NMethod *nm, const void *pc, uintptr_t &sp) {
+void StackFrame::adjustSP(const void *entry, const void *pc, uintptr_t &sp) {
   // Not needed
 }
 

--- a/ddprof-lib/src/main/cpp/stackFrame_i386.cpp
+++ b/ddprof-lib/src/main/cpp/stackFrame_i386.cpp
@@ -115,7 +115,7 @@ bool StackFrame::unwindCompiled(NMethod *nm, uintptr_t &pc, uintptr_t &sp,
   return false;
 }
 
-void StackFrame::adjustCompiled(NMethod *nm, const void *pc, uintptr_t &sp) {
+void StackFrame::adjustSP(const void *entry, const void *pc, uintptr_t &sp) {
   // Not needed
 }
 

--- a/ddprof-lib/src/main/cpp/stackFrame_i386.cpp
+++ b/ddprof-lib/src/main/cpp/stackFrame_i386.cpp
@@ -119,6 +119,11 @@ void StackFrame::adjustSP(const void *entry, const void *pc, uintptr_t &sp) {
   // Not needed
 }
 
+bool StackFrame::unwindAtomicStub(const void*& pc) {
+  // Not needed
+  return false;
+}
+
 bool StackFrame::skipFaultInstruction() { return false; }
 
 bool StackFrame::checkInterruptedSyscall() {

--- a/ddprof-lib/src/main/cpp/stackFrame_ppc64.cpp
+++ b/ddprof-lib/src/main/cpp/stackFrame_ppc64.cpp
@@ -147,6 +147,11 @@ void StackFrame::adjustSP(const void *entry, const void *pc, uintptr_t &sp) {
   // Not needed
 }
 
+bool StackFrame::unwindAtomicStub(const void*& pc) {
+  // Not needed
+  return false;
+}
+
 bool StackFrame::skipFaultInstruction() { return false; }
 
 bool StackFrame::checkInterruptedSyscall() {

--- a/ddprof-lib/src/main/cpp/stackFrame_ppc64.cpp
+++ b/ddprof-lib/src/main/cpp/stackFrame_ppc64.cpp
@@ -143,7 +143,7 @@ bool StackFrame::unwindCompiled(NMethod *nm, uintptr_t &pc, uintptr_t &sp,
   return true;
 }
 
-void StackFrame::adjustCompiled(NMethod *nm, const void *pc, uintptr_t &sp) {
+void StackFrame::adjustSP(const void *entry, const void *pc, uintptr_t &sp) {
   // Not needed
 }
 

--- a/ddprof-lib/src/main/cpp/stackFrame_x64.cpp
+++ b/ddprof-lib/src/main/cpp/stackFrame_x64.cpp
@@ -145,6 +145,11 @@ void StackFrame::adjustSP(const void *entry, const void *pc, uintptr_t &sp) {
   // Not needed
 }
 
+bool StackFrame::unwindAtomicStub(const void*& pc) {
+  // Not needed
+  return false;
+}
+
 // Skip failed MOV instruction by writing 0 to destination register
 bool StackFrame::skipFaultInstruction() {
   unsigned int insn = *(unsigned int *)pc();

--- a/ddprof-lib/src/main/cpp/stackFrame_x64.cpp
+++ b/ddprof-lib/src/main/cpp/stackFrame_x64.cpp
@@ -141,7 +141,7 @@ bool StackFrame::unwindCompiled(NMethod *nm, uintptr_t &pc, uintptr_t &sp,
   return false;
 }
 
-void StackFrame::adjustCompiled(NMethod *nm, const void *pc, uintptr_t &sp) {
+void StackFrame::adjustSP(const void *entry, const void *pc, uintptr_t &sp) {
   // Not needed
 }
 

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -155,6 +155,8 @@ int StackWalker::walkDwarf(void *ucontext, const void **callchain,
       break;
     }
     if (CodeHeap::contains(pc)) {
+      const void* page_start = (const void*)((uintptr_t)pc & ~0xfffUL);
+      frame.adjustSP(page_start, pc, sp);
       java_ctx->set(pc, sp, fp);
       break;
     }
@@ -302,7 +304,7 @@ int StackWalker::walkVM(void *ucontext, ASGCT_CallFrame *frames, int max_depth,
 
           // Handle situations when sp is temporarily changed in the compiled
           // code
-          frame.adjustCompiled(nm, pc, sp);
+          frame.adjustSP(nm->entry(), pc, sp);
 
           sp += nm->frameSize() * sizeof(void *);
           fp = ((uintptr_t *)sp)[-FRAME_PC_SLOT - 1];

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -71,6 +71,7 @@ int StackWalker::walkFP(void *ucontext, const void **callchain, int max_depth,
   uintptr_t sp;
   uintptr_t bottom = (uintptr_t)&sp + MAX_WALK_SIZE;
 
+  StackFrame frame(ucontext);
   if (ucontext == NULL) {
     pc = __builtin_return_address(0);
     fp = (uintptr_t)__builtin_frame_address(1);
@@ -92,7 +93,7 @@ int StackWalker::walkFP(void *ucontext, const void **callchain, int max_depth,
       *truncated = true;
       break;
     }
-    if (CodeHeap::contains(pc)) {
+    if (CodeHeap::contains(pc) && !(depth == 0 && frame.unwindAtomicStub(pc))) {
       java_ctx->set(pc, sp, fp);
       break;
     }
@@ -154,7 +155,7 @@ int StackWalker::walkDwarf(void *ucontext, const void **callchain,
       *truncated = true;
       break;
     }
-    if (CodeHeap::contains(pc)) {
+    if (CodeHeap::contains(pc) && !(depth == 0 && frame.unwindAtomicStub(pc))) {
       const void* page_start = (const void*)((uintptr_t)pc & ~0xfffUL);
       frame.adjustSP(page_start, pc, sp);
       java_ctx->set(pc, sp, fp);

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/AbstractProfilerTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/AbstractProfilerTest.java
@@ -142,9 +142,12 @@ public abstract class AbstractProfilerTest {
     return true;
   }
 
+  protected void withTestAssumptions() {}
+
   @BeforeEach
   public void setupProfiler() throws Exception {
     Assumptions.assumeTrue(isPlatformSupported());
+    withTestAssumptions();
 
     jfrDump = Files.createTempFile(Paths.get("/tmp"), getClass().getName() + UUID.randomUUID(), ".jfr");
     profiler = JavaProfiler.getInstance();

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/VMStructsBasedCpuTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/VMStructsBasedCpuTest.java
@@ -2,6 +2,7 @@ package com.datadoghq.profiler.cpu;
 
 import com.datadoghq.profiler.AbstractProfilerTest;
 import com.datadoghq.profiler.Platform;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jmc.common.item.IItem;
 import org.openjdk.jmc.common.item.IItemCollection;
@@ -19,7 +20,15 @@ public class VMStructsBasedCpuTest extends AbstractProfilerTest {
     private ProfiledCode profiledCode;
 
     @Override
+    protected void withTestAssumptions() {
+        // vmstructs based stackwalking will throw ISE on Java 23
+        Assumptions.assumeFalse(Platform.isJavaVersionAtLeast(23));
+    }
+
+    @Override
     protected void before() {
+        // vmstructs based stackwalking will throw ISE on Java 23
+        Assumptions.assumeFalse(Platform.isJavaVersionAtLeast(23));
         profiledCode = new ProfiledCode(profiler);
     }
 


### PR DESCRIPTION
**What does this PR do?**:
It downstreams two aarch64 related fixes

**Motivation**:
Improving the aarch64 profiling stability

**Additional Notes**:
Additional aarch64 GHA runners were added. This also required some minor adjustments in the code to avoid crashes on those aarch64 runners (these things are most probably setup specific as I could not reproduce the problems on an aarch64 ec2 instance)

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-10874]

Unsure? Have a question? Request a review!


[PROF-10874]: https://datadoghq.atlassian.net/browse/PROF-10874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ