### PR TITLE
cstack=vm support for JDK 23+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             fi
           fi
   check-formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: check-for-pr
     if: needs.check-for-pr.outputs.skip != 'true'
     steps:

--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -411,9 +411,15 @@ void VMStructs::resolveOffsets() {
     _call_stub_return = *_call_stub_return_addr;
   }
 
+  // Since JDK 23, _metadata_offset is relative to _data_offset. See metadata()
+  if (_nmethod_immutable_offset < 0) {
+      _data_offset = 0;
+  }
+
   _has_stack_structs =
       _has_method_structs && _interpreter_frame_bcp_offset != 0 &&
       _code_offset != -1 && _scopes_data_offset != -1 &&
+      _data_offset >= 0 &&
       _scopes_pcs_offset >= 0 &&
       _nmethod_immutable_offset < 0 // TODO: not yet supported
       && _nmethod_metadata_offset >= 0 && _thread_vframe_offset >= 0 &&
@@ -854,8 +860,8 @@ int NMethod::findScopeOffset(const void *pc) {
   }
 
   const int *scopes_pcs = (const int *)at(_scopes_pcs_offset);
-  PcDesc *pcd = (PcDesc *)at(scopes_pcs[0]);
-  PcDesc *pcd_end = (PcDesc *)at(scopes_pcs[1]);
+  PcDesc* pcd = (PcDesc*) immutableDataAt(scopes_pcs[0]);
+  PcDesc* pcd_end = (PcDesc*) immutableDataAt(scopes_pcs[1]);
   int low = 0;
   int high = (pcd_end - pcd) - 1;
 

--- a/ddprof-lib/src/main/cpp/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/vmStructs.h
@@ -329,9 +329,20 @@ public:
 
   short frameCompleteOffset() { return *(short *)at(_frame_complete_offset); }
 
-  // TODO: offset is short on JDK 23+
   void setFrameCompleteOffset(int offset) {
-    *(int *)at(_frame_complete_offset) = offset;
+    if (_nmethod_immutable_offset > 0) {
+      // _frame_complete_offset is short on JDK 23+
+      *(short*) at(_frame_complete_offset) = offset;
+    } else {
+      *(int*) at(_frame_complete_offset) = offset;
+    }
+  }
+
+  const char* immutableDataAt(int offset) {
+    if (_nmethod_immutable_offset > 0) {
+      return *(const char**) at(_nmethod_immutable_offset) + offset;
+    }
+    return at(offset);
   }
 
   const char *code() {
@@ -344,7 +355,7 @@ public:
 
   const char *scopes() {
     if (_scopes_data_offset > 0) {
-      return at(*(int *)at(_scopes_data_offset));
+      return immutableDataAt(*(int*) at(_scopes_data_offset));
     } else {
       return *(const char **)at(-_scopes_data_offset);
     }
@@ -391,6 +402,9 @@ public:
   }
 
   VMMethod **metadata() {
+    if (_data_offset > 0) {
+      return (VMMethod**) at(*(int*) at(_data_offset) + *(unsigned short*) at(_nmethod_metadata_offset));
+    }
     return (VMMethod **)at(*(int *)at(_nmethod_metadata_offset));
   }
 
@@ -663,7 +677,8 @@ public:
 
 class ScopeDesc : VMStructs {
 private:
-  NMethod *_nm;
+  const unsigned char* _scopes;
+  VMMethod** _metadata;
   const unsigned char *_stream;
   int _method_offset;
   int _bci;
@@ -671,10 +686,13 @@ private:
   int readInt();
 
 public:
-  ScopeDesc(NMethod *nm) : _nm(nm) {}
+  ScopeDesc(NMethod *nm) {
+    _scopes = (const unsigned char*)nm->scopes();
+    _metadata = nm->metadata();
+  }
 
   int decode(int offset) {
-    _stream = (const unsigned char *)_nm->scopes() + offset;
+    _stream = _scopes + offset;
     int sender_offset = readInt();
     _method_offset = readInt();
     _bci = readInt() - 1;
@@ -682,7 +700,7 @@ public:
   }
 
   VMMethod *method() {
-    return _method_offset > 0 ? _nm->metadata()[_method_offset - 1] : NULL;
+    return _method_offset > 0 ? _metadata[_method_offset - 1] : NULL;
   }
 
   int bci() { return _bci; }


### PR DESCRIPTION
**What does this PR do?**:
Downstream of [#923: cstack=vm support for JDK 23+](https://github.com/async-profiler/async-profiler/commit/34a9e1354a66a635c7840d08da220c532002c249#diff-9b62e517a445f9a21220d6a3d057c9d85d3d690efea89122f0f49f65fd784d6bR596)

**Motivation**:
Fix vmstructs for JDK 23+

Unsure? Have a question? Request a review!
