### PR TITLE
Fix GHA on aarch64 runners

### DIFF
--- a/ddprof-lib/src/main/cpp/dwarf.h
+++ b/ddprof-lib/src/main/cpp/dwarf.h
@@ -71,7 +71,7 @@ const int LINKED_FRAME_SIZE = 0;
 
 struct FrameDesc {
   u32 loc;
-  int cfa;
+  u32 cfa;
   int fp_off;
   int pc_off;
 
@@ -106,6 +106,7 @@ private:
   }
 
   u8 get8() { return *_ptr++; }
+
   // We are getting alignment issues when loading the 16-bit value
   // todo: are these relevant and well handled ?
   __attribute__((no_sanitize("undefined"))) u16 get16() {
@@ -159,7 +160,7 @@ private:
   int parseExpression();
 
   void addRecord(u32 loc, u32 cfa_reg, int cfa_off, int fp_off, int pc_off);
-  FrameDesc *addRecordRaw(u32 loc, int cfa, int fp_off, int pc_off);
+  FrameDesc *addRecordRaw(u32 loc, u32 cfa, int fp_off, int pc_off);
 
 public:
   DwarfParser(const char *name, const char *image_base,

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -17,6 +17,8 @@
 #ifdef __linux__
 
 #include "symbols_linux.h"
+
+#include "common.h"
 #include "dwarf.h"
 #include "log.h"
 #include "safeAccess.h"
@@ -492,10 +494,10 @@ static int parseLibrariesCallback(struct dl_phdr_info *info, size_t size,
     }
 
     const char *map_end = map.end();
-    CodeCache *cc = new CodeCache(map.file(), count, false, map_start, map_end);
-
     // Do not try to parse pseudofiles like anon_inode:name, /memfd:name
     if (strchr(map.file(), ':') == NULL) {
+      CodeCache *cc = new CodeCache(map.file(), count, false, map_start, map_end);
+      TEST_LOG("Procesing library: %s", map.file());
       u64 inode = u64(map.dev()) << 32 | map.inode();
       if (inode != 0) {
         // Do not parse the same executable twice, e.g. on Alpine Linux
@@ -516,10 +518,10 @@ static int parseLibrariesCallback(struct dl_phdr_info *info, size_t size,
       } else if (strcmp(map.file(), "[vdso]") == 0) {
         ElfParser::parseProgramHeaders(cc, map_start, map_end, true);
       }
-    }
 
-    cc->sort();
-    array->add(cc);
+      cc->sort();
+      array->add(cc);
+    }
   }
 
   free(str);


### PR DESCRIPTION
**What does this PR do?**:
It fixes the encoding of DWARF CFA values to take negative offsets into account.
It also adds some defensive excludes for Asan on aarch64 because they seem to be false positives, specifically on the GHA aarch64 runners (was not able to reproduce on a different aarch64 box)

**Motivation**:
Make the sanity runs stable again on aarch64

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-11043]

Unsure? Have a question? Request a review!


[PROF-11043]: https://datadoghq.atlassian.net/browse/PROF-11043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ