### PR TITLE
Defensive access to JMX for heap usage

### DIFF
--- a/ddprof-lib/src/main/cpp/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/vmStructs.h
@@ -570,12 +570,25 @@ public:
 };
 
 class HeapUsage : VMStructs {
+private:
+  static bool is_jmx_attempted;
+  static bool is_jmx_supported; // default to not-supported
 public:
+
+
   size_t _initSize = -1;
   size_t _used = -1;
   size_t _committed = -1;
   size_t _maxSize = -1;
   size_t _used_at_last_gc = -1;
+
+  static void initJMXUsage(JNIEnv* env);
+
+  static bool isJMXSupported() {
+    initJMXUsage(VM::jni());
+    return is_jmx_supported;
+  }
+
 
   static bool isLastGCUsageSupported() {
     // only supported for JDK 17+
@@ -638,7 +651,7 @@ public:
         usage._maxSize = summary.maxSize();
       }
     }
-    if (usage._maxSize == -1 && _memory_usage_func != NULL && allow_jmx) {
+    if (usage._maxSize == -1 && _memory_usage_func != NULL && allow_jmx && isJMXSupported()) {
       // this path is for non-hotspot JVMs
       // we need to patch the native method binding for JMX GetMemoryUsage to
       // capture the native method pointer first also, it requires JMX and


### PR DESCRIPTION
**What does this PR do?**:
Adds more defensive checks for JMX access for the purpose of initializing Heap usage access

**Motivation**:
When running against jlinked images without JMX the initilization code would crash with SIGSEG


**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-11066]

**Notes**
Tested the locally built artifact with the dd-trace-java agent and it does solve the crash reported in the attached issue.

Unsure? Have a question? Request a review!


[PROF-11066]: https://datadoghq.atlassian.net/browse/PROF-11066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ