### PR TITLE
Add safeguard for J9-specific jmethodid unloading behaviour (version-dependent)

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -150,7 +150,7 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
     bool entry = false;
     if (VMMethod::check_jmethodID(method) &&
         jvmti->GetMethodDeclaringClass(method, &method_class) == 0 &&
-        jvmti->GetClassSignature(method_class, &class_name, NULL) == 0 &&
+        ((!VM::isOpenJ9() || method_class != reinterpret_cast<jclass>(-1)) && jvmti->GetClassSignature(method_class, &class_name, NULL) == 0) &&
         jvmti->GetMethodName(method, &method_name, &method_sig, NULL) == 0) {
 
       if (first_time) {

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -150,6 +150,13 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
     bool entry = false;
     if (VMMethod::check_jmethodID(method) &&
         jvmti->GetMethodDeclaringClass(method, &method_class) == 0 &&
+        // On some older versions of J9, the JVMTI call to GetMethodDeclaringClass will return OK = 0, but when a
+        // classloader is unloaded they free all JNIIDs. This means that anyone holding on to a jmethodID is
+        // pointing to corrupt data and the behaviour is undefined.
+        // The behaviour is adjusted so that when asgct() is used or if `-XX:+KeepJNIIDs` is specified,
+        // when a classloader is unloaded, the jmethodIDs are not freed, but instead marked as -1.
+        // The nested check below is to mitigate these crashes.
+        // In more recent versions, the condition above will short-circuit safely.
         ((!VM::isOpenJ9() || method_class != reinterpret_cast<jclass>(-1)) && jvmti->GetClassSignature(method_class, &class_name, NULL) == 0) &&
         jvmti->GetMethodName(method, &method_name, &method_sig, NULL) == 0) {
 


### PR DESCRIPTION
**What does this PR do?**:
Adds a safeguard to prevent crashes on certain versions of J9 for which we don't have certain API compliance guarantees assumed to be present by async-profiler / java-profiler.

**Motivation**:
Incident 32141

**Additional Notes**:
See incident channel and private Slack for further details, (private) customer info and correspondence informed this change.

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-11094]

Unsure? Have a question? Request a review!


[PROF-11094]: https://datadoghq.atlassian.net/browse/PROF-11094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ