### PR TITLE
Update artifact GH actions to V4, V3 to-be-deprecated

### DIFF
--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           ./gradlew scanBuild --no-daemon
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: scan-build-reports
@@ -83,7 +83,7 @@ jobs:
           sed -i "s#target_branch#${HEAD_REF}#g" report-gh.html
           python .github/scripts/python_utils.py cppcheck_cleanup report-gh.html >> comment.html
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: cppcheck-report

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
     if: failure()
     steps:
       - name: Download failed tests artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: failures
           path: ./artifacts

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -67,7 +67,7 @@ jobs:
           export PATH=${JAVA_TEST_HOME}/bin:$PATH
           ./gradlew clean build --no-daemon --parallel --build-cache --no-watch-fs
       - name: Upload Logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: graalvm-${{ matrix.java_version }}-logs
@@ -134,7 +134,7 @@ jobs:
           export PATH=${JAVA_TEST_HOME}/bin:$PATH
           ./gradlew clean build --no-daemon --parallel --build-cache --no-watch-fs
       - name: Upload Logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: graalvm-${{ matrix.java_version }}-logs
@@ -222,7 +222,7 @@ jobs:
             exit 1
           fi
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: reports-linux-glibc-${{ matrix.java_version }}-amd64.zip
@@ -232,17 +232,17 @@ jobs:
             ddprof-test/build/reports/tests
             ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
             ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success()
         with:
           name: glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64
           path: build/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failures
           path: failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: recordings
@@ -325,7 +325,7 @@ jobs:
           fi
           ls -la /tmp
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: reports-linux-glibc-${{ matrix.java_version }}-aarch64.zip
@@ -335,17 +335,17 @@ jobs:
             ddprof-test/build/reports/tests
             ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
             ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success()
         with:
           name: glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
           path: build/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failures
           path: failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: recordings
@@ -419,7 +419,7 @@ jobs:
             exit 1
           fi
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: reports-linux-glibc-j9-${{ matrix.java_version }}-amd64.zip
@@ -429,17 +429,17 @@ jobs:
             ddprof-test/build/reports/tests
             ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
             ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success()
         with:
           name: glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-amd64
           path: build/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failures
           path: failures_glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: recordings
@@ -516,7 +516,7 @@ jobs:
             exit 1
           fi
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: reports-linux-glibc-j9-${{ matrix.java_version }}-aarch64.zip
@@ -526,17 +526,17 @@ jobs:
             ddprof-test/build/reports/tests
             ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
             ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success()
         with:
           name: glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
           path: build/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failures
           path: failures_glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: recordings
@@ -622,7 +622,7 @@ jobs:
             exit 1
           fi
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: reports-linux-oracle-jdk-8.zip
@@ -631,17 +631,17 @@ jobs:
             ddprof-test/build/reports/tests
             ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
             ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success()
         with:
           name: x64-oracle-jdk8-${{ matrix.config }}
           path: build/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failures
           path: failures_glibc-oracle8-${{ matrix.config }}.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: recordings
@@ -742,7 +742,7 @@ jobs:
             exit 1
           fi
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: reports-linux-musl-${{ matrix.java_version }}-amd64.zip
@@ -752,17 +752,17 @@ jobs:
             ddprof-test/build/reports/tests
             ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
             ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success()
         with:
           name: musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64
           path: build/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failures
           path: failures_musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: recordings
@@ -871,7 +871,7 @@ jobs:
             exit 1
           fi
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: reports-linux-zing-jdk-${{ matrix.java_version }}-amd64.zip
@@ -880,17 +880,17 @@ jobs:
             ddprof-test/build/reports/tests/test
             ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
             ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success()
         with:
           name: glibc-zing-${{ matrix.java_version }}-${{ matrix.config }}-amd64
           path: build/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failures
           path: failures_zing-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: recordings
@@ -1001,7 +1001,7 @@ jobs:
             exit 1
           fi
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: reports-linux-zing-jdk-${{ matrix.java_version }}-aarch64.zip
@@ -1010,17 +1010,17 @@ jobs:
             ddprof-test/build/reports/tests/test
             ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
             ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success()
         with:
           name: glibc-zing-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
           path: build/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: failures
           path: failures_zing-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: recordings


### PR DESCRIPTION
**What does this PR do?**:
Bumps our artifact related actions to V4. V3 is [set to be deprecated soon](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) and actions now [automatically fail](https://github.com/DataDog/java-profiler/actions/runs/12813923937/job/35729242500?pr=171) to reflect this.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-11152]

Unsure? Have a question? Request a review!


[PROF-11152]: https://datadoghq.atlassian.net/browse/PROF-11152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ