### PR TITLE
Cleanup JVMTI sampling implementation

### DIFF
--- a/ddprof-lib/src/main/cpp/arch.h
+++ b/ddprof-lib/src/main/cpp/arch.h
@@ -19,6 +19,12 @@
 
 #include <stddef.h>
 
+#ifdef _LP64
+#  define LP64_ONLY(code) code
+#else // !_LP64
+#  define LP64_ONLY(code)
+#endif // _LP64
+
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;

--- a/ddprof-lib/src/main/cpp/callTraceStorage.cpp
+++ b/ddprof-lib/src/main/cpp/callTraceStorage.cpp
@@ -19,6 +19,8 @@
 #include "os.h"
 #include <string.h>
 
+#define COMMA ,
+
 static const u32 INITIAL_CAPACITY = 65536;
 static const u32 CALL_TRACE_CHUNK = 8 * 1024 * 1024;
 static const u32 OVERFLOW_TRACE_ID = 0x7fffffff;
@@ -81,8 +83,7 @@ public:
   }
 };
 
-CallTrace CallTraceStorage::_overflow_trace = {
-    false, 1, {BCI_ERROR, (jmethodID) "storage_overflow"}};
+CallTrace CallTraceStorage::_overflow_trace = {false, 1, {BCI_ERROR, LP64_ONLY(0 COMMA) (jmethodID)"storage_overflow"}};
 
 CallTraceStorage::CallTraceStorage() : _allocator(CALL_TRACE_CHUNK), _lock(0) {
   _current_table = LongHashTable::allocate(NULL, INITIAL_CAPACITY);

--- a/ddprof-lib/src/main/cpp/livenessTracker.h
+++ b/ddprof-lib/src/main/cpp/livenessTracker.h
@@ -32,8 +32,7 @@ typedef struct TrackingEntry {
   jweak ref;
   AllocEvent alloc;
   double skipped;
-  jint frames_size;
-  jvmtiFrameInfo *frames;
+  u32 call_trace_id;
   jint tid;
   jlong time;
   jlong age;
@@ -100,8 +99,7 @@ public:
 
   Error start(Arguments &args);
   void stop();
-  void track(JNIEnv *env, AllocEvent &event, jint tid, jobject object,
-             int num_frames, jvmtiFrameInfo *frames);
+  void track(JNIEnv *env, AllocEvent &event, jint tid, jobject object, u32 call_trace_id);
   void flush(std::set<int> &tracked_thread_ids);
 
   static void JNICALL GarbageCollectionFinish(jvmtiEnv *jvmti_env);

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -52,8 +52,9 @@ const int RESERVED_FRAMES = 4;
 
 enum EventMask { EM_CPU = 1 << 0, EM_WALL = 1 << 1, EM_ALLOC = 1 << 2 };
 
-struct CallTraceBuffer {
+union CallTraceBuffer {
   ASGCT_CallFrame _asgct_frames[1];
+  jvmtiFrameInfo _jvmti_frames[1];
 };
 
 class FrameName;
@@ -138,12 +139,6 @@ private:
                      int tid, StackContext *java_ctx, bool *truncated);
   int getJavaTraceAsync(void *ucontext, ASGCT_CallFrame *frames, int max_depth,
                         StackContext *java_ctx, bool *truncated);
-  int getJavaTraceJvmti(jvmtiFrameInfo *jvmti_frames, ASGCT_CallFrame *frames,
-                        int start_depth, int max_depth);
-  int getJavaTraceInternal(jvmtiFrameInfo *jvmti_frames,
-                           ASGCT_CallFrame *frames, int max_depth);
-  int convertFrames(jvmtiFrameInfo *jvmti_frames, ASGCT_CallFrame *frames,
-                    int num_frames);
   void fillFrameTypes(ASGCT_CallFrame *frames, int num_frames,
                       NMethod *nmethod);
   void updateThreadName(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread,
@@ -223,9 +218,8 @@ public:
                          ASGCT_CallFrame *frames);
   void recordSample(void *ucontext, u64 weight, int tid, jint event_type,
                     u32 call_trace_id, Event *event);
-  void recordExternalSample(u64 weight, int tid, jvmtiFrameInfo *jvmti_frames,
-                            jint num_jvmti_frames, bool truncated,
-                            jint event_type, Event *event);
+  u32 recordJVMTISample(u64 weight, int tid, jthread thread, jint event_type, Event *event, bool deferred);
+  void recordDeferredSample(int tid, u32 call_trace_id, jint event_type, Event *event);
   void recordExternalSample(u64 weight, int tid, int num_frames,
                             ASGCT_CallFrame *frames, bool truncated,
                             jint event_type, Event *event);

--- a/ddprof-lib/src/main/cpp/vmEntry.h
+++ b/ddprof-lib/src/main/cpp/vmEntry.h
@@ -20,6 +20,7 @@
 
 #include <jvmti.h>
 
+#include "arch.h"
 #include "codeCache.h"
 #include "frame.h"
 
@@ -62,8 +63,11 @@ enum ASGCT_Failure {
 
 typedef struct {
   jint bci;
+  // see https://github.com/async-profiler/async-profiler/pull/1090
+  LP64_ONLY(jint padding;)
   jmethodID method_id;
 } ASGCT_CallFrame;
+
 
 typedef struct {
   JNIEnv *env;

--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -192,18 +192,7 @@ void WallClockJVMTI::timerLoop() {
 
   auto sampleThreads = [&](ThreadEntry& thread_entry, int& num_failures, int& threads_already_exited, int& permission_denied) {
     static jint max_stack_depth = (jint)Profiler::instance()->max_stack_depth();
-    static jvmtiFrameInfo* frame_buffer = new jvmtiFrameInfo[max_stack_depth];
-    static jvmtiEnv* jvmti = VM::jvmti();
 
-    int num_frames = 0;
-    jvmtiError err = jvmti->GetStackTrace(thread_entry.java, 0, max_stack_depth, frame_buffer, &num_frames);
-    if (err != JVMTI_ERROR_NONE) {
-      num_failures++;
-      if (err == JVMTI_ERROR_THREAD_NOT_ALIVE) {
-        threads_already_exited++;
-      }
-      return false;
-    }
     ExecutionEvent event;
     VMThread* vm_thread = thread_entry.native;
     int raw_thread_state = vm_thread->state();
@@ -225,7 +214,7 @@ void WallClockJVMTI::timerLoop() {
     event._execution_mode = mode;
     event._weight =  1;
 
-    Profiler::instance()->recordExternalSample(1, thread_entry.native->osThreadId(), frame_buffer, num_frames, false, BCI_WALL, &event);
+    Profiler::instance()->recordJVMTISample(1, thread_entry.native->osThreadId(), thread_entry.java, BCI_WALL, &event, false);
     return true;
   };
 


### PR DESCRIPTION
**What does this PR do?**:
It cleans up the JVMTI based sampling implementation.

**Motivation**:
Preparation for downporting the vmstructs based stackwalker.

**Additional Notes**:
An added benefit is reduced allocations thanks to reused JVMTI frame buffers.

For the liveness tracking, we stop copying the frames and store the trace in `CallTraceStorage` and persist the trace id instead. The live heap profiler in async-profiler is doing similar thing.


**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-11238]

Unsure? Have a question? Request a review!


[PROF-11238]: https://datadoghq.atlassian.net/browse/PROF-11238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ