### PR TITLE
Restructure CI workflow and improve JDK caching

### DIFF
--- a/.github/actions/extract_versions/action.yml
+++ b/.github/actions/extract_versions/action.yml
@@ -1,5 +1,6 @@
 name: Extract Java and Gradle Versions
 description: Versions are reported in JAVA_VERSION and GRADLE_VERSION environment variables
+
 runs:
   using: "composite"
   steps:
@@ -7,9 +8,21 @@ runs:
       id: extract_versions
       shell: bash
       run: |
+        set +e
+
         # Extract Java version
-        java_version="${{ matrix.java_version }}"
-        echo "JAVA_VERSION=${java_version%%+*}" >> $GITHUB_ENV
+        ${{ env.JAVA_TEST_HOME }}/bin/java -version
+        JAVA_VERSION=$(${{ env.JAVA_TEST_HOME }}/bin/java -version 2>&1 | awk -F '"' '/version/ {
+              split($2, v, "[._]");
+              if (v[1] == "1") {
+              # Java 8 or older: Include major, minor, and update
+              printf "%s.%s.%s\n", v[2], v[3], v[4]
+            } else {
+              # Java 9 or newer: Major, minor, and patch
+              printf "%s.%s.%s\n", v[1], v[2], v[3]
+            }
+          }')
+        echo "JAVA_VERSION=${JAVA_VERSION}" >> $GITHUB_ENV
 
         # Extract Gradle version from gradle-wrapper.properties
         gradle_version=$(grep 'distributionUrl' gradle/wrapper/gradle-wrapper.properties | cut -d'=' -f2)

--- a/.github/actions/setup_cached_java/action.yml
+++ b/.github/actions/setup_cached_java/action.yml
@@ -1,0 +1,74 @@
+name: "Setup test Java environment"
+description: "Setup Java environment for testing"
+
+inputs:
+  version:
+    description: "The test JDK version to install"
+    required: true
+    default: "11"
+  arch:
+    description: "The architecture"
+    required: true
+    default: "amd64"
+
+runs:
+    using: composite
+    steps:
+      - name: Infer Build JDK
+        shell: bash
+        id: infer_build_jdk
+        run: |
+          echo "Infering JDK 11 [${{ inputs.arch }}]"
+          if [[ ${{ inputs.arch }} =~ "-musl" ]]; then
+            echo "build_jdk=jdk11-librca" >> $GITHUB_OUTPUT
+          else
+            echo "build_jdk=jdk11" >> $GITHUB_OUTPUT
+          fi
+      - name: Cache Build JDK [${{ inputs.arch }}]
+        id: cache_build_jdk
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            jdks/${{ steps.infer_build_jdk.outputs.build_jdk }}
+          key: ${{ steps.infer_build_jdk.outputs.build_jdk }}-${{ inputs.arch }}--${{ hashFiles('.github/workflows/cache_java.yml', '.github/scripts/java_setup.sh') }}
+          restore-keys: |
+            ${{ steps.infer_build_jdk.outputs.build_jdk }}-${{ inputs.arch }}--
+      - name: Cache JDK ${{ inputs.version }} [${{ inputs.arch }}]
+        id: cache_jdk
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            jdks/jdk${{ inputs.version }}
+          key: jdk${{ inputs.version }}-${{ inputs.arch }}--${{ hashFiles('.github/workflows/cache_java.yml', '.github/scripts/java_setup.sh') }}
+          restore-keys: |
+            jdk${{ inputs.version }}-${{ inputs.arch }}--
+      - name: JDK cache miss
+        if: steps.cache_jdk.outputs.cache-hit != 'true' || steps.cache_build_jdk.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          # well, the cache-hit is not alway set to 'true', even when cache is hit (but it is not freshly recreated, whatever that means)
+          if [ ! -d "jdks/jdk${{ inputs.version }}" ]; then
+            OWNER=${{ github.repository_owner }}
+            REPO=${{ github.event.repository.name }}
+            BRANCH=${{ github.ref_name }}
+            WORKFLOW="cache_java.yml"
+    
+            URL="https://github.com/$OWNER/$REPO/actions/workflows/$WORKFLOW"
+              
+            echo "### ⚠️ JDK Cache Miss Detected" >> $GITHUB_STEP_SUMMARY
+            echo "🛠️ [Click here and select ${BRANCH} branch to manually refresh the cache](<$URL>)" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+      - name: Setup Environment
+        shell: bash
+        run: |
+          chmod a+rx -R jdks
+          echo "Setting up JDK ${{ inputs.version }} [${{ inputs.arch }}]"
+          JAVA_HOME=$(pwd)/jdks/${{ steps.infer_build_jdk.outputs.build_jdk }}
+          JAVA_TEST_HOME=$(pwd)/jdks/jdk${{ inputs.version }}
+          PATH=$JAVA_HOME/bin:$PATH
+          echo "JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
+          echo "JAVA_TEST_HOME=$JAVA_TEST_HOME" >> $GITHUB_ENV
+          echo "PATH=$JAVA_HOME/bin:$PATH" >> $GITHUB_ENV
+          
+          ldd $JAVA_HOME/bin/java

--- a/.github/scripts/java_setup.sh
+++ b/.github/scripts/java_setup.sh
@@ -1,14 +1,76 @@
 #!/usr/bin/env bash
 
 function prepareJdk() {
-  local jdk_distro=$1
-  local target_path=$2
+  local variant=$1
+  local arch=$2
+  local version=${variant%%-*}
+  local qualifier=${variant#*-}
 
-  if [ -e "$target_path/bin/java" ]; then
-    echo "JDK $jdk_distro already installed at $jdk_path"
+  local target_path="${GITHUB_WORKSPACE}/${JDKS_DIR}/jdk${variant}"
+
+  mkdir -p ${target_path}
+
+  if [[ ${qualifier} == "librca" ]] && [[ "${arch}" =~ "-musl" ]]; then
+    URL_VAR="JAVA_${version}_MUSL_URL"
+    URL="${!URL_VAR}"
+    if [[ -z "${URL}" ]]; then
+      echo "Musl/Liberica JDK URL not found for ${arch}/${variant}"
+      exit 1
+    fi
+    curl -L --fail "${URL}" | tar -xvzf - -C ${target_path} --strip-components 1
     return
   fi
 
-  echo 'n' | sdk install java ${jdk_distro}
-  ln -s ~/.sdkman/candidates/java/${jdk_distro} ${target_path}
+  if [[ ${qualifier} == "orcl" ]]; then
+    if [[ ${version} == "8" ]]; then
+      mkdir -p "${target_path}"
+      curl -L --fail "${JAVA_8_ORACLE_URL}" | sudo tar -xvzf - -C ${target_path} --strip-components 1
+      return
+    else
+      echo "Oracle JDK 8 only!"
+      exit 1
+    fi
+  fi
+
+  if [[ ${qualifier} == "zing" ]]; then
+    URL_VAR="JAVA_${version}_ZING_URL"
+    if [[ "${arch}" == "aarch64" ]]; then
+      URL_VAR="JAVA_${version}_ZING_AARCH64_URL"
+    fi
+
+    URL="${!URL_VAR}"
+    if [[ -z "${URL}" ]]; then
+      echo "Zing JDK URL not found for ${variant}"
+      exit 1
+    fi
+    curl -L --fail "${URL}" | sudo tar -xvzf - -C ${target_path} --strip-components 1
+    if [[ "${arch}" != "aarch64" ]]; then
+      # rename the bundled libstdc++.so to avoid conflicts with the system one
+      sudo mv ${target_path}/etc/libc++/libstdc++.so.6 ${target_path}/etc/libc++/libstdc++.so.6.bak
+    fi
+    return
+  fi
+
+  # below the installation of the SDKMAN-managed JDK
+  source ~/.sdkman/bin/sdkman-init.sh
+
+  local suffix="tem"
+  local versionVar="JAVA_${version}_VERSION"
+  if [[ "${qualifier}" == "j9" ]]; then
+    suffix="sem"
+    versionVar="JAVA_${version}_J9_VERSION"
+  elif [[ "${qualifier}" == "graal" ]]; then
+    suffix="graal"
+    versionVar="JAVA_${version}_GRAAL_VERSION"
+  fi
+
+  local distro_base
+  distro_base="${!versionVar}"
+  local jdk_distro="${distro_base}-${suffix}"
+
+  echo 'n' | sdk install java ${jdk_distro} > /dev/null
+
+  rm -rf ${target_path}
+  mkdir -p "$(dirname ${target_path})"
+  mv ${SDKMAN_DIR}/candidates/java/${jdk_distro} ${target_path}
 }

--- a/.github/scripts/prepare_reports.sh
+++ b/.github/scripts/prepare_reports.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+mkdir -p reports
+cp /tmp/hs_err* reports/ || true
+cp ddprof-test/build/hs_err* reports/ || true
+cp -r ddprof-lib/build/tmp reports/native_build || true
+cp -r ddprof-test/build/reports/tests reports/tests || true
+cp -r /tmp/recordings reports/recordings || true
+find ddprof-lib/build -name 'libjavaProfiler.*' -exec cp {} reports/ \; || true

--- a/.github/workflows/cache_java.yml
+++ b/.github/workflows/cache_java.yml
@@ -1,174 +1,292 @@
 name: Cache Java Distributions
 
 on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/cache_java.yml'
+      - '.github/scripts/java_setup.sh'
+  schedule:
+    # Runs every day at 03:00 UTC every 4 days
+    # This should keep the caches fresh and not expiring after 7 days
+    - cron: '0 3 */4 * *'
   workflow_dispatch:
+  workflow_call:
 
 env:
   JDKS_DIR: jdks
-  JAVA_BUILD_VERSION: 11.0.26-tem
   JAVA_8_VERSION: 8.0.442
+  JAVA_8_J9_VERSION: 8.0.432
   JAVA_11_VERSION: 11.0.26
+  JAVA_11_J9_VERSION: 11.0.25
   JAVA_17_VERSION: 17.0.14
+  JAVA_17_J9_VERSION: 17.0.13
   JAVA_21_VERSION: 21.0.6
+  JAVA_21_J9_VERSION: 21.0.5
   JAVA_23_VERSION: 23.0.2
 
-  GRAAL_17_VERSION: 17.0.12
-  GRAAL_21_VERSION: 21.0.6
-  GRAAL_23_VERSION: 23.0.2
+  JAVA_17_GRAAL_VERSION: 17.0.12
+  JAVA_21_GRAAL_VERSION: 21.0.6
+  JAVA_23_GRAAL_VERSION: 23.0.2
+
+  # https://gist.github.com/wavezhang/ba8425f24a968ec9b2a8619d7c2d86a6?permalink_comment_id=4444663#gistcomment-4444663
+  # jdk1.8.0_361
+  JAVA_8_ORACLE_URL: "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=247926_0ae14417abb444ebb02b9815e2103550"
+
+  JAVA_8_ZING_URL         : "https://cdn.azul.com/zing-zvm/ZVM23.05.0.0/zing23.05.0.0-2-jdk8.0.372-linux_x64.tar.gz"
+  JAVA_8_ZING_AARCH64_URL : "https://cdn.azul.com/zing-zvm/ZVM24.10.0.0/zing24.10.0.0-4-jdk8.0.431-linux_aarch64.tar.gz"
+  JAVA_11_ZING_URL        : "https://cdn.azul.com/zing-zvm/ZVM23.05.0.0/zing23.05.0.0-2-jdk11.0.19-linux_x64.tar.gz"
+  JAVA_11_ZING_AARCH64_URL: "https://cdn.azul.com/zing-zvm/ZVM24.10.0.0/zing24.10.0.0-4-jdk11.0.24.0.101-linux_aarch64.tar.gz"
+  JAVA_17_ZING_URL        : "https://cdn.azul.com/zing-zvm/ZVM23.05.0.0/zing23.05.0.0-2-jdk17.0.7-linux_x64.tar.gz"
+  JAVA_17_ZING_AARCH64_URL: "https://cdn.azul.com/zing-zvm/ZVM24.10.0.0/zing24.10.0.0-4-jdk17.0.12.0.101-linux_aarch64.tar.gz"
+  JAVA_21_ZING_URL        : "https://cdn.azul.com/zing-zvm/ZVM23.10.0.0/zing23.10.0.0-3-jdk21.0.1-linux_x64.tar.gz"
+  JAVA_21_ZING_AARCH64_URL: "https://cdn.azul.com/zing-zvm/ZVM24.10.0.0/zing24.10.0.0-4-jdk21.0.4.0.101-linux_aarch64.tar.gz"
+
+  JAVA_8_MUSL_URL : "https://download.bell-sw.com/java/8u442+7/bellsoft-jdk8u442+7-linux-x64-musl-lite.tar.gz"
+  JAVA_11_MUSL_URL: "https://download.bell-sw.com/java/11.0.26+9/bellsoft-jdk11.0.26+9-linux-x64-musl-lite.tar.gz"
+  JAVA_17_MUSL_URL: "https://download.bell-sw.com/java/17.0.14+10/bellsoft-jdk17.0.14+10-linux-x64-musl-lite.tar.gz"
+  JAVA_21_MUSL_URL: "https://download.bell-sw.com/java/21.0.6+10/bellsoft-jdk21.0.6+10-linux-x64-musl-lite.tar.gz"
+  JAVA_23_MUSL_URL: "https://download.bell-sw.com/java/23.0.2+9/bellsoft-jdk23.0.2+9-linux-x64-musl-lite.tar.gz"
 
 permissions:
   contents: read
   actions: read
 
 jobs:
-  cache-amd64:
+  setup-sdkman-amd64:
     runs-on: ubuntu-latest
+    outputs:
+      sdkman_path: ${{ steps.export-path.outputs.sdkman_path }}
+    steps:
+      - name: Cache SDKMan! AMD64
+        uses: actions/cache@v4
+        with:
+          path: sdkman
+          key: sdkman-amd64-${{ github.run_id }}
+          restore-keys: |
+            sdkman-amd64-
+      - name: Check if SDKMAN! is Already Installed
+        id: check-sdkman
+        run: |
+          if [ -e "${GITHUB_WORKSPACE}/sdkman/bin/sdkman-init.sh" ]; then
+            echo "SDKMAN! already installed at ${GITHUB_WORKSPACE}/sdkman."
+            echo "skip_install=true" >> $GITHUB_ENV
+          else
+            echo "SDKMAN! not found, proceeding with installation."
+            echo "skip_install=false" >> $GITHUB_ENV
+          fi
+          echo "SDKMAN_DIR=${GITHUB_WORKSPACE}/sdkman" >> $GITHUB_ENV
+      - name: Setup OS
+        if: env.skip_install == 'false'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y curl zip unzip
+      - name: Install SDKMAN!
+        if: env.skip_install == 'false'
+        run: |
+          curl -s "https://get.sdkman.io" | bash
+      - name: Upload SDKMAN! as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdkman-installation-amd64
+          path: ${{ env.SDKMAN_DIR }}
+
+  setup-sdkman-aarch64:
+    runs-on:
+      group: ARM LINUX SHARED
+      labels: arm-4core-linux
+    outputs:
+      sdkman_path: ${{ steps.export-path.outputs.sdkman_path }}
+    steps:
+      - name: Cache SDKMan! AARCH64
+        uses: actions/cache@v4
+        with:
+          path: sdkman
+          key: sdkman-aarch64-${{ github.run_id }}
+          restore-keys: |
+            sdkman-aarch64-
+      - name: Check if SDKMAN! is Already Installed
+        id: check-sdkman
+        run: |
+          if [ -e "${GITHUB_WORKSPACE}/sdkman/bin/sdkman-init.sh" ]; then
+            echo "SDKMAN! already installed at ${GITHUB_WORKSPACE}/sdkman."
+            echo "skip_install=true" >> $GITHUB_ENV
+          else
+            echo "SDKMAN! not found, proceeding with installation."
+            echo "skip_install=false" >> $GITHUB_ENV
+          fi
+          echo "SDKMAN_DIR=${GITHUB_WORKSPACE}/sdkman" >> $GITHUB_ENV
+      - name: Setup OS
+        if: env.skip_install == 'false'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y curl zip unzip
+      - name: Install SDKMAN!
+        if: env.skip_install == 'false'
+        run: |
+          curl -s "https://get.sdkman.io" | bash
+      - name: Upload SDKMAN! as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdkman-installation-aarch64
+          path: ${{ env.SDKMAN_DIR }}
+
+  cache-amd64:
+    needs: setup-sdkman-amd64
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        java_variant: [ "8", "8-orcl", "8-zing", "8-j9", "11", "11-zing", "11-j9", "17", "17-zing", "17-j9", "17-graal", "21", "21-j9", "21-zing", "21-graal", "23", "23-graal" ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Try restore cache JDK ${{ matrix.java_variant }}
+        id: cache-jdk
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ env.JDKS_DIR }}/jdk${{ matrix.java_variant }}
+          key: jdk${{matrix.java_variant }}-amd64--${{ hashFiles('.github/workflows/cache_java.yml', '.github/scripts/java_setup.sh') }}
+      - name: Is JDK cached?
+        id: check-cache
+        run: |
+          if [ -d "jdks" ]; then
+            echo "cache-hit=true" >> $GITHUB_OUTPUT
+          else
+            echo "cache-hit=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Setup OS
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y curl zip unzip
+      - name: Download SDKMAN! from Artifact
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: sdkman-installation-amd64
+          path: sdkman
+
+      - name: Install JDK ${{ matrix.java_variant }}
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        run: |
+          mv $GITHUB_WORKSPACE/sdkman ~/.sdkman
+          mkdir -p ~/.sdkman/ext # Create ext directory; it is empty and not uploaded
+          mkdir -p ~/.sdkman/tmp # Create tmp directory; it is empty and not uploaded
+          
+          source .github/scripts/java_setup.sh
+
+          prepareJdk ${{ matrix.java_variant }} amd64
+
+      - name: Save JDK ${{ matrix.java_variant }} cache
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ env.JDKS_DIR }}/jdk${{ matrix.java_variant }}
+          key: jdk${{matrix.java_variant }}-amd64--${{ hashFiles('.github/workflows/cache_java.yml', '.github/scripts/java_setup.sh') }}
+
+  cache-amd64-musl:
+    runs-on: ubuntu-latest
+    container:
+      image: "alpine:3.14"
+      options: --cpus 2
+    strategy:
+      fail-fast: true
+      matrix:
+        java_variant: [ "8-librca", "11-librca", "17-librca", "21-librca", "23-librca" ]
     steps:
       - uses: actions/checkout@v3
       - name: Setup OS
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y curl zip unzip
-          mkdir jdks
-      - name: Install SDKMAN
+          # This needs to be done early because alpine does not have bash and tar is also iffy
+          apk update && apk add curl zip unzip bash tar
+      - name: Cache JDK ${{ matrix.java_variant }}
+        id: cache-jdk
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ env.JDKS_DIR }}/jdk${{ matrix.java_variant }}
+          key: jdk${{matrix.java_variant }}-amd64-musl--${{ hashFiles('.github/workflows/cache_java.yml') }}
+
+      - name: Is JDK cached?
+        id: check-cache
         run: |
-          curl -s "https://get.sdkman.io" | bash
-          source ~/.sdkman/bin/sdkman-init.sh
-      - name: Cache Build JDK [amd64]
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.JDKS_DIR }}/jdk
-          key: jdk-amd64-${{ github.run_id }}
-          restore-keys: |
-            jdk-amd64-
-      - name: Cache JDK 8
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.JDKS_DIR }}/jdk8
-          key: jdk8-amd64-${{ github.run_id }}
-          restore-keys: |
-            jdk8-amd64-
-      - name: Cache JDK 11
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.JDKS_DIR }}/jdk11
-          key: jdk11-amd64-${{ github.run_id }}
-          restore-keys: |
-            jdk11-amd64-
-      - name: Cache JDK 17
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.JDKS_DIR }}/jdk17
-          key: jdk17-amd64-${{ github.run_id }}
-          restore-keys: |
-            jdk17-amd64-
-      - name: Cache JDK 21
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.JDKS_DIR }}/jdk21
-          key: jdk21-amd64-${{ github.run_id }}
-          restore-keys: |
-            jdk21-amd64-
-      - name: Cache JDK 23
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.JDKS_DIR }}/jdk23
-          key: jdk23-amd64-${{ github.run_id }}
-          restore-keys: |
-            jdk23-amd64-
+          if [ -d "jdks" ]; then
+            echo "cache-hit=true" >> $GITHUB_OUTPUT
+          else
+            echo "cache-hit=false" >> $GITHUB_OUTPUT
+          fi
 
-      - name: Cache JDK 8 (J9)
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.JDKS_DIR }}/jdk8-j9
-          key: jdk8-j9-amd64-${{ github.run_id }}
-          restore-keys: |
-            jdk8-j9-amd64-
-      - name: Cache JDK 11 (J9)
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.JDKS_DIR }}/jdk11-j9
-          key: jdk11-j9-amd64-${{ github.run_id }}
-          restore-keys: |
-            jdk11-j9-amd64-
-      - name: Cache JDK 17 (J9)
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.JDKS_DIR }}/jdk17-j9
-          key: jdk17-j9-amd64-${{ github.run_id }}
-          restore-keys: |
-            jdk17-j9-amd64-
-      - name: Cache JDK 21 (J9)
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.JDKS_DIR }}/jdk21-j9
-          key: jdk21-j9-amd64-${{ github.run_id }}
-          restore-keys: |
-            jdk21-j9-amd64-
-      - name: Cache JDK 23 (J9)
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.JDKS_DIR }}/jdk23-j9
-          key: jdk23-j9-amd64-${{ github.run_id }}
-          restore-keys: |
-            jdk23-j9-amd64-
-
-      - name: Cache JDK 17 (GraalVM)
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.JDKS_DIR }}/jdk17-graal
-          key: jdk17-graal-amd64-${{ github.run_id }}
-          restore-keys: |
-            jdk17-graal-amd64-
-      - name: Cache JDK 21 (GraalVM)
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.JDKS_DIR }}/jdk21-graal
-          key: jdk21-graal-amd64-${{ github.run_id }}
-          restore-keys: |
-            jdk21-graal-amd64-
-      - name: Cache JDK 23 (GraalVM)
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.JDKS_DIR }}/jdk23-graal
-          key: jdk23-graal-amd64-${{ github.run_id }}
-          restore-keys: |
-            jdk23-graal-amd64-          
-
-      - name: Install JDKs
+      - name: Install JDK ${{ matrix.java_variant }}
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        shell: bash
         run: |
           source .github/scripts/java_setup.sh
-          
-          prepareJdk ${{ env.JAVA_BUILD_VERSION }}-tem ${{ env.JDKS_DIR }}/jdk
 
-          prepareJdk ${{ env.JAVA_8_VERSION }}-tem ${{ env.JDKS_DIR }}/jdk8
-          prepareJdk ${{ env.JAVA_8_VERSION }}-sem ${{ env.JDKS_DIR }}/jdk8-j9
+          prepareJdk ${{ matrix.java_variant }} amd64-musl
+
+      - name: Save JDK ${{ matrix.java_variant }} cache
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ env.JDKS_DIR }}/jdk${{ matrix.java_variant }}
+          key: jdk${{matrix.java_variant }}-amd64-musl--${{ hashFiles('.github/workflows/cache_java.yml') }}
+
+  cache-aarch64:
+    needs: setup-sdkman-aarch64
+    runs-on:
+      group: ARM LINUX SHARED
+      labels: arm-4core-linux
+    strategy:
+      fail-fast: true
+      matrix:
+        java_variant: [ "8", "8-zing", "8-j9", "11", "11-zing", "11-j9", "17", "17-zing", "17-j9", "17-graal", "21", "21-j9", "21-zing", "21-graal", "23", "23-graal" ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache JDK ${{ matrix.java_variant }}
+        id: cache-jdk
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ env.JDKS_DIR }}/jdk${{ matrix.java_variant }}
+          key: jdk${{matrix.java_variant }}-aarch64--${{ hashFiles('.github/workflows/cache_java.yml') }}
+      - name: Is JDK cached?
+        id: check-cache
+        run: |
+          if [ -d "jdks" ]; then
+            echo "cache-hit=true" >> $GITHUB_OUTPUT
+          else
+            echo "cache-hit=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Setup OS
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y curl zip unzip
+      - name: Download SDKMAN! from Artifact
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: sdkman-installation-aarch64
+          path: sdkman
+      - name: Install JDK ${{ matrix.java_variant }}
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        run: |
+          mv $GITHUB_WORKSPACE/sdkman ~/.sdkman
+          mkdir -p ~/.sdkman/ext # Create ext directory; it is empty and not uploaded
+          mkdir -p ~/.sdkman/tmp # Create tmp directory; it is empty and not uploaded
           
-          prepareJdk ${{ env.JAVA_11_VERSION }}-tem ${{ env.JDKS_DIR }}/jdk11
-          prepareJdk ${{ env.JAVA_11_VERSION }}-sem ${{ env.JDKS_DIR }}/jdk11-j9
-          
-          prepareJdk ${{ env.JAVA_17_VERSION }}-tem ${{ env.JDKS_DIR }}/jdk17
-          prepareJdk ${{ env.JAVA_17_VERSION }}-sem ${{ env.JDKS_DIR }}/jdk17-j9
-          prepareJdk ${{ env.GRAAL_17_VERSION }}-graal ${{ env.JDKS_DIR }}/jdk17-graal
-          
-          prepareJdk ${{ env.JAVA_21_VERSION }}-tem ${{ env.JDKS_DIR }}/jdk21
-          prepareJdk ${{ env.JAVA_21_VERSION }}-sem ${{ env.JDKS_DIR }}/jdk21-j9
-          prepareJdk ${{ env.GRAAL_21_VERSION }}-graal ${{ env.JDKS_DIR }}/jdk21-graal
-          
-          prepareJdk ${{ env.JAVA_23_VERSION }}-tem ${{ env.JDKS_DIR }}/jdk23
-          prepareJdk ${{ env.JAVA_23_VERSION }}-sem ${{ env.JDKS_DIR }}/jdk23-j9
-          prepareJdk ${{ env.GRAAL_23_VERSION }}-graal ${{ env.JDKS_DIR }}/jdk23-graal
+          source .github/scripts/java_setup.sh
+
+          prepareJdk ${{ matrix.java_variant }} aarch64
+
+      - name: Save JDK ${{ matrix.java_variant }} cache
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ env.JDKS_DIR }}/jdk${{ matrix.java_variant }}
+          key: jdk${{matrix.java_variant }}-aarch64--${{ hashFiles('.github/workflows/cache_java.yml') }}

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -12,154 +12,32 @@ permissions:
   actions: read
 
 jobs:
-  test-linux-glibc-graalvm-amd64:
-    strategy:
-      fail-fast: false
-      matrix:
-        java_version: [ 17.0.9, 21.0.2, 23.0.1 ]
-        config: ${{ fromJson(inputs.configuration) }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup OS
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl zip unzip libgtest-dev libgmock-dev
-      - name: Cache Gradle Wrapper Binaries
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper/dists
-          key: gradle-wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-wrapper-${{ runner.os }}-
-      - name: Cache Gradle User Home
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: gradle-caches-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-caches-${{ runner.os }}-
-      - name: Extract Java Major Version
-        run: echo "JAVA_MAJOR_VERSION=$(echo ${{ matrix.java_version }} | cut -d '.' -f 1)" >> $GITHUB_ENV
-      - name: Cache GraalVM JDK ${{ matrix.java_version }} [amd64]
-        uses: actions/cache@v3
-        with:
-          path: |
-            graalvm_${{ matrix.java_version }}_jdk
-          key: graalvm-${{ matrix.java_version }}-amd64-${{ github.run_id }}
-          restore-keys: |
-            graalvm-${{ matrix.java_version }}-amd64-
-      - name: Prepare GraalVM JDK ${{ matrix.java_version }}
-        run: |
-          GRAALVM_JDK_DIR="graalvm_${{ matrix.java_version }}_jdk"
-          if [ ! -e ${GRAALVM_JDK_DIR}/bin/java ]; then
-            wget -nv https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${{ matrix.java_version }}/graalvm-community-jdk-${{ matrix.java_version }}_linux-x64_bin.tar.gz -O graalvm.tar.gz
-            mkdir -p ${GRAALVM_JDK_DIR}
-            tar -xzf graalvm.tar.gz --strip-components=1 -C ${GRAALVM_JDK_DIR}
-          fi
-          ls -la ${GRAALVM_JDK_DIR}
-      - name: Test
-        run: |
-          export TEST_COMMIT=${{ github.sha }}
-          export TEST_CONFIGURATION=glibc/graalvm/${{ matrix.java_version }}-amd64
-          export JAVA_TEST_HOME=$(pwd)/graalvm_${{ matrix.java_version }}_jdk
-          export PATH=${JAVA_TEST_HOME}/bin:$PATH
-          ./gradlew clean build --no-daemon --parallel --build-cache --no-watch-fs
-      - name: Upload Logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: graalvm-${{ matrix.java_version }}-logs-amd64
-          path: |
-            build/reports/tests/
-            build/tmp/
-
-  test-linux-glibc-graalvm-aarch64:
-    strategy:
-      fail-fast: false
-      matrix:
-        java_version: [ 17.0.9, 21.0.2, 23.0.1 ]
-        config: ${{ fromJson(inputs.configuration) }}
-    runs-on:
-      group: ARM LINUX SHARED
-      labels: arm-4core-linux
-    timeout-minutes: 180
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup OS
-        run: |
-          sudo apt update -y
-          sudo apt remove -y g++
-          sudo apt autoremove -y
-          sudo apt install -y curl zip unzip clang make build-essential
-      - name: Cache Gradle Wrapper Binaries
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper/dists
-          key: gradle-wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-wrapper-${{ runner.os }}-
-      - name: Cache Gradle User Home
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: gradle-caches-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-caches-${{ runner.os }}-
-      - name: Extract Java Major Version
-        run: echo "JAVA_MAJOR_VERSION=$(echo ${{ matrix.java_version }} | cut -d '.' -f 1)" >> $GITHUB_ENV
-      - name: Cache GraalVM JDK ${{ matrix.java_version }} [arm64]
-        uses: actions/cache@v3
-        with:
-          path: |
-            graalvm_${{ matrix.java_version }}_jdk
-          key: graalvm-${{ matrix.java_version }}-arm64-${{ github.run_id }}
-          restore-keys: |
-            graalvm-${{ matrix.java_version }}-arm64-
-      - name: Prepare GraalVM JDK ${{ matrix.java_version }}
-        run: |
-          GRAALVM_JDK_DIR="graalvm_${{ matrix.java_version }}_jdk"
-          if [ ! -e ${GRAALVM_JDK_DIR}/bin/java ]; then
-            wget -nv https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${{ matrix.java_version }}/graalvm-community-jdk-${{ matrix.java_version }}_linux-aarch64_bin.tar.gz -O graalvm.tar.gz
-            mkdir -p ${GRAALVM_JDK_DIR}
-            tar -xzf graalvm.tar.gz --strip-components=1 -C ${GRAALVM_JDK_DIR}
-          fi
-          ls -la ${GRAALVM_JDK_DIR}
-      - name: Test
-        run: |
-          export TEST_COMMIT=${{ github.sha }}
-          export TEST_CONFIGURATION=glibc/graalvm/${{ matrix.java_version }}-arm64
-          export JAVA_TEST_HOME=$(pwd)/graalvm_${{ matrix.java_version }}_jdk
-          export PATH=${JAVA_TEST_HOME}/bin:$PATH
-          ./gradlew clean build --no-daemon --parallel --build-cache --no-watch-fs
-      - name: Upload Logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: graalvm-${{ matrix.java_version }}-logs-aarch64
-          path: |
-            build/reports/tests/
-            build/tmp/
-
+  cache-jdks:
+    # This job is used to cache the JDKs for the test jobs
+    uses: ./.github/workflows/cache_java.yml
   test-linux-glibc-amd64:
+    needs: cache-jdks
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ 8u432+7, 11.0.25+11, 17.0.13+12, 21.0.5+11, 23.0.1+13 ]
+        java_version: [ "8", "8-orcl", "8-j9", "8-zing", "11", "11-j9", "11-zing", "17", "17-j9", "17-zing", "17-graal", "21", "21-zing", "21-graal", "23", "23-graal" ]
         config: ${{ fromJson(inputs.configuration) }}
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
+      - name: Set enabled flag
+        id: set_enabled
+        run: |
+          echo "enabled=true" >> $GITHUB_OUTPUT
+          if [[ "${{ matrix.java_version }}" =~ -zing ]]; then
+            if [[ "${{ matrix.config }}" != "release" ]] && [[ "${{ matrix.config }}" != "debug" ]]; then
+              echo "enabled=false" >> $GITHUB_OUTPUT
+            fi
+          fi
       - uses: actions/checkout@v3
-      - name: Prepare build JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: "11"
-      - name: Extract Versions
-        uses: ./.github/actions/extract_versions
+        if: steps.set_enabled.outputs.enabled == 'true'
       - name: Cache Gradle Wrapper Binaries
+        if: steps.set_enabled.outputs.enabled == 'true'
         uses: actions/cache@v4
         with:
           path: ~/.gradle/wrapper/dists
@@ -167,504 +45,89 @@ jobs:
           restore-keys: |
             gradle-wrapper-${{ runner.os }}-
       - name: Cache Gradle User Home
+        if: steps.set_enabled.outputs.enabled == 'true'
         uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: gradle-caches-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-caches-${{ runner.os }}-
+      - name: Setup cached JDK
+        id: cache-jdk
+        if: steps.set_enabled.outputs.enabled == 'true'
+        uses: ./.github/actions/setup_cached_java
+        with:
+          version: ${{ matrix.java_version }}
+          arch: 'amd64'
       - name: Setup OS
+        if: steps.set_enabled.outputs.enabled == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y curl zip unzip libgtest-dev libgmock-dev
-      - name: Cache JDK ${{ env.JAVA_VERSION }} [amd64]
-        uses: actions/cache@v3
-        with:
-          path: |
-            test_${{ env.JAVA_VERSION }}_jdk
-          key: ${{ env.JAVA_VERSION }}-amd64-${{ github.run_id }}
-          restore-keys: |
-            ${{ env.JAVA_VERSION }}-amd64-
-      - name: Prepare JDK ${{ env.JAVA_VERSION }}
-        run: |
-          TEST_JDK_DIR="test_${{ env.JAVA_VERSION }}_jdk"
-          if [ ! -e ${TEST_JDK_DIR}/bin/java ]; then
-            wget -nv https://download.bell-sw.com/java/${{ matrix.java_version }}/bellsoft-jdk${{ matrix.java_version }}-linux-amd64.tar.gz -O jdk.tar.gz
-            tar xzf *.tar.gz
-            find . -type d -name 'jdk*' -maxdepth 1| xargs -I {} mv {} ${TEST_JDK_DIR}
+          if [[ ${{ matrix.java_version }} =~ "-zing" ]]; then
+            sudo apt-get install -y g++-9 gcc-9
+            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9
+            sudo update-alternatives --set gcc /usr/bin/gcc-9
           fi
+      - name: Extract Versions
+        if: steps.set_enabled.outputs.enabled == 'true'
+        uses: ./.github/actions/extract_versions
       - name: Test
+        if: steps.set_enabled.outputs.enabled == 'true'
         run: |
           sudo sysctl vm.mmap_rnd_bits=28
 
           set +e
           export KEEP_JFRS=true
           export TEST_COMMIT=${{ github.sha }}
-          export TEST_CONFIGURATION=glibc/${{ matrix.java_version }}-amd64
+          export TEST_CONFIGURATION=glibc/${{ matrix.java_version }}-${{ matrix.config }}-amd64
           export LIBC=glibc
-          export JAVA_TEST_HOME=$(pwd)/test_${{ env.JAVA_VERSION }}_jdk
           export SANITIZER=${{ matrix.config }}
-          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
-              split($2, v, "[._]");
-              if (v[1] == "1") {
-              # Java 8 or older: Include major, minor, and update
-              printf "%s.%s.%s\n", v[2], v[3], v[4]
-            } else {
-              # Java 9 or newer: Major, minor, and patch
-              printf "%s.%s.%s\n", v[1], v[2], v[3]
-            }
-          }')
+
           ./gradlew -PkeepJFRs :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs
           EXIT_CODE=$?
-          rm -rf $JAVA_TEST_HOME
+
           if [ $EXIT_CODE -ne 0 ]; then
             echo "glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64" >> failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
             exit 1
           fi
-      - name: Upload logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: reports-linux-glibc-${{ matrix.java_version }}-amd64.zip
-          path: |
-            /tmp/hs_err*
-            ddprof-test/hs_err_*
-            ddprof-test/build/reports/tests
-            ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
-            ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
       - uses: actions/upload-artifact@v4
         if: success()
         with:
-          name: glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64
+          name: test-linux-glibc-amd64 (${{ matrix.java_version }}, ${{ matrix.config }})] (build)
           path: build/
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: failures
+          name: failures-glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64
           path: failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
+      - name: Prepare reports
+        if: failure()
+        run: |
+          .github/scripts/prepare_reports.sh
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: recordings
-          path: /tmp/recordings
-
-  test-linux-glibc-aarch64:
-    strategy:
-      fail-fast: false
-      matrix:
-        java_version: [ 8u432+7, 11.0.25+11, 17.0.13+12, 21.0.5+11, 23.0.1+13 ]
-        config: ${{ fromJson(inputs.configuration) }}
-    runs-on:
-      group: ARM LINUX SHARED
-      labels: arm-4core-linux
-    timeout-minutes: 180
-    steps:
-      - uses: actions/checkout@v3
-      - name: Prepare build JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: "11"
-      - name: Setup OS
-        run: |
-          sudo apt update -y
-          sudo apt remove -y g++
-          sudo apt autoremove -y
-          sudo apt install -y curl zip unzip clang make build-essential
-      - name: Extract Versions
-        uses: ./.github/actions/extract_versions
-      - name: Cache Gradle Wrapper Binaries
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper/dists
-          key: gradle-wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-wrapper-${{ runner.os }}-
-      - name: Cache Gradle User Home
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: gradle-caches-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-caches-${{ runner.os }}-
-      - name: Cache JDK ${{ env.JAVA_VERSION }} [aarch64]
-        uses: actions/cache@v3
-        with:
-          path: |
-            test_${{ env.JAVA_VERSION }}_jdk
-          key: ${{ env.JAVA_VERSION }}-aarch64-${{ github.run_id }}
-          restore-keys: |
-            ${{ env.JAVA_VERSION }}-aarch64-
-      - name: Prepare JDK ${{ matrix.java_version }}
-        run: |
-          TEST_JDK_DIR="test_${{ env.JAVA_VERSION }}_jdk"
-          if [ ! -e ${TEST_JDK_DIR}/bin/java ]; then
-            wget -nv https://download.bell-sw.com/java/${{ matrix.java_version }}/bellsoft-jdk${{ matrix.java_version }}-linux-aarch64.tar.gz -O jdk.tar.gz
-            tar xzf *.tar.gz
-            find . -type d -name 'jdk*' -maxdepth 1| xargs -I {} mv {} ${TEST_JDK_DIR}
-          
-            ls -la ${TEST_JDK_DIR}
-          fi
-      - name: Test
-        run: |
-          sudo sysctl vm.mmap_rnd_bits=28
-
-          set +e
-          export KEEP_JFRS=true
-          export TEST_COMMIT=${{ github.sha }}
-          export TEST_CONFIGURATION=glibc/${{ matrix.java_version }}-aarch64
-          export LIBC=glibc
-          export JAVA_TEST_HOME=$(pwd)/test_${{ env.JAVA_VERSION }}_jdk
-          export SANITIZER=${{ matrix.config }}
-          ./gradlew -PkeepJFRs :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs
-          EXIT_CODE=$?
-          rm -rf $JAVA_TEST_HOME
-          if [ $EXIT_CODE -ne 0 ]; then
-            echo "glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64" >> failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
-            exit 1
-          fi
-          ls -la /tmp
-      - name: Upload logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: reports-linux-glibc-${{ matrix.java_version }}-aarch64.zip
-          path: |
-            /tmp/hs_err*
-            ddprof-test/hs_err_*
-            ddprof-test/build/reports/tests
-            ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
-            ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
-      - uses: actions/upload-artifact@v4
-        if: success()
-        with:
-          name: glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
-          path: build/
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: failures
-          path: failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: recordings
-          path: /tmp/recordings
-
-  test-linux-glibc-j9-amd64:
-    strategy:
-      fail-fast: false
-      matrix:
-        java_version: [ 8, 11, 17 ]
-        config: ${{ fromJson(inputs.configuration) }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup OS
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl zip unzip libgtest-dev libgmock-dev
-#          sudo sysctl vm.mmap_rnd_bits=28
-      - name: Cache Gradle Wrapper Binaries
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper/dists
-          key: gradle-wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-wrapper-${{ runner.os }}-
-      - name: Cache Gradle User Home
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: gradle-caches-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-caches-${{ runner.os }}-
-      - name: Prepare test JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt-openj9'
-          java-version: "${{ matrix.java_version }}"
-      - name: Store JAVA_TEST_HOME
-        run: JAVA_PATH=$(which java) && echo "JAVA_TEST_HOME=${JAVA_PATH/\/bin\/java/\/}" >> $GITHUB_ENV
-      - name: Prepare build JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt-openj9'
-          java-version: "11"
-      - name: Test
-        run: |
-          set +e
-          export KEEP_JFRS=true
-          export TEST_COMMIT=${{ github.sha }}
-          export TEST_CONFIGURATION=glibc/j9/${{ matrix.java_version }}-amd64
-          export LIBC=glibc
-          export SANITIZER=${{ matrix.config }}
-          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
-              split($2, v, "[._]");
-              if (v[1] == "1") {
-              # Java 8 or older: Include major, minor, and update
-              printf "%s.%s.%s\n", v[2], v[3], v[4]
-            } else {
-              # Java 9 or newer: Major, minor, and patch
-              printf "%s.%s.%s\n", v[1], v[2], v[3]
-            }
-          }')
-          chmod a+x gradlew
-          ./gradlew -PkeepJFRs :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs
-          EXIT_CODE=$?
-          rm -rf $JAVA_TEST_HOME
-          if [ $EXIT_CODE -ne 0 ]; then
-            echo "glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-amd64" >> failures_glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
-            exit 1
-          fi
-      - name: Upload logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: reports-linux-glibc-j9-${{ matrix.java_version }}-amd64.zip
-          path: |
-            /tmp/javacore*
-            ddprof-test/javacore*
-            ddprof-test/build/reports/tests
-            ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
-            ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
-      - uses: actions/upload-artifact@v4
-        if: success()
-        with:
-          name: glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-amd64
-          path: build/
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: failures
-          path: failures_glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: recordings
-          path: /tmp/recordings
-
-  test-linux-glibc-j9-aarch64:
-    strategy:
-      fail-fast: false
-      matrix:
-        java_version: [ 8, 11, 17 ]
-        config: ${{ fromJson(inputs.configuration) }}
-    runs-on:
-      group: ARM LINUX SHARED
-      labels: arm-4core-linux
-    timeout-minutes: 180
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup OS
-        run: |
-          sudo apt update -y
-          sudo apt remove -y g++
-          sudo apt autoremove -y
-          sudo apt install -y curl zip unzip clang make build-essential
-      - name: Cache Gradle Wrapper Binaries
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper/dists
-          key: gradle-wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-wrapper-${{ runner.os }}-
-      - name: Cache Gradle User Home
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: gradle-caches-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-caches-${{ runner.os }}-
-      - name: Prepare test JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt-openj9'
-          java-version: "${{ matrix.java_version }}"
-      - name: Store JAVA_TEST_HOME
-        run: JAVA_PATH=$(which java) && echo "JAVA_TEST_HOME=${JAVA_PATH/\/bin\/java/\/}" >> $GITHUB_ENV
-      - name: Prepare build JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt-openj9'
-          java-version: "11"
-      - name: Test
-        run: |
-          set +e
-          export KEEP_JFRS=true
-          export TEST_COMMIT=${{ github.sha }}
-          export TEST_CONFIGURATION=glibc/j9/${{ matrix.java_version }}-aarch64
-          export LIBC=glibc
-          export SANITIZER=${{ matrix.config }}
-          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
-              split($2, v, "[._]");
-              if (v[1] == "1") {
-              # Java 8 or older: Include major, minor, and update
-              printf "%s.%s.%s\n", v[2], v[3], v[4]
-            } else {
-              # Java 9 or newer: Major, minor, and patch
-              printf "%s.%s.%s\n", v[1], v[2], v[3]
-            }
-          }')
-          chmod a+x gradlew
-          ./gradlew -PkeepJFRs :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs
-          EXIT_CODE=$?
-          rm -rf $JAVA_TEST_HOME
-          if [ $EXIT_CODE -ne 0 ]; then
-            echo "glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-aarch64" >> failures_glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
-            exit 1
-          fi
-      - name: Upload logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: reports-linux-glibc-j9-${{ matrix.java_version }}-aarch64.zip
-          path: |
-            /tmp/javacore*
-            ddprof-test/javacore*
-            ddprof-test/build/reports/tests
-            ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
-            ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
-      - uses: actions/upload-artifact@v4
-        if: success()
-        with:
-          name: glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
-          path: build/
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: failures
-          path: failures_glibc-j9-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: recordings
-          path: /tmp/recordings
-
-  test-linux-glibc-oracle8:
-    strategy:
-      fail-fast: false
-      matrix:
-        config: ${{ fromJson(inputs.configuration) }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup OS
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl zip unzip libgtest-dev libgmock-dev
-      - name: Cache Gradle Wrapper Binaries
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper/dists
-          key: gradle-wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-wrapper-${{ runner.os }}-
-      - name: Cache Gradle User Home
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: gradle-caches-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-caches-${{ runner.os }}-
-      - name: Prepare build JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: "11"
-      - name: Cache JDK Oracle JDK 8
-        uses: actions/cache@v3
-        with:
-          path: |
-            /usr/lib/jvm/oracle8
-          key: oracle-jdk8-${{ github.run_id }}
-          restore-keys: |
-              oracle-jdk8-
-      - name: Prepare JDK ${{ matrix.java_version }}
-        run: |
-          sudo sysctl vm.mmap_rnd_bits=28
-          set -eux;
-          if [ ! -e /usr/lib/jvm/oracle8/bin/java ]; then
-            sudo mkdir -p /usr/lib/jvm/oracle8;
-            # https://gist.github.com/wavezhang/ba8425f24a968ec9b2a8619d7c2d86a6?permalink_comment_id=4444663#gistcomment-4444663
-            # jdk1.8.0_361
-            curl -L --fail "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=247926_0ae14417abb444ebb02b9815e2103550" | sudo tar -xvzf - -C /usr/lib/jvm/oracle8 --strip-components 1
-          fi
-          uname -r
-      - name: Test
-        run: |
-          set +e
-          export KEEP_JFRS=true
-          export TEST_COMMIT=${{ github.sha }}
-          export TEST_CONFIGURATION=glibc/oracle/8-amd64
-          export LIBC=glibc
-          export JAVA_TEST_HOME=/usr/lib/jvm/oracle8
-          export JAVA_HOME=$JAVA_HOME
-          export PATH=$JAVA_HOME/bin:$PATH
-          export SANITIZER=${{ matrix.config }}
-          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
-              split($2, v, "[._]");
-              if (v[1] == "1") {
-              # Java 8 or older: Include major, minor, and update
-              printf "%s.%s.%s\n", v[2], v[3], v[4]
-            } else {
-              # Java 9 or newer: Major, minor, and patch
-              printf "%s.%s.%s\n", v[1], v[2], v[3]
-            }
-          }')
-          ./gradlew -PkeepJFRs :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs
-          EXIT_CODE=$?
-          rm -rf $JAVA_TEST_HOME
-          if [ $EXIT_CODE -ne 0 ]; then
-            echo "glibc-oracle8-${{ matrix.config }}" >> failures_glibc-oracle8-${{ matrix.config }}.txt
-            exit 1
-          fi
-      - name: Upload logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: reports-linux-oracle-jdk-8.zip
-          path: |
-            ddprof-test/hs_err_*
-            ddprof-test/build/reports/tests
-            ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
-            ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
-      - uses: actions/upload-artifact@v4
-        if: success()
-        with:
-          name: x64-oracle-jdk8-${{ matrix.config }}
-          path: build/
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: failures
-          path: failures_glibc-oracle8-${{ matrix.config }}.txt
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: recordings
-          path: /tmp/recordings
+          name: test-linux-glibc-amd64 (${{ matrix.java_version }}, ${{ matrix.config }}) (reports)
+          path: reports
 
   test-linux-musl-amd64:
+    needs: cache-jdks
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ 8u432+7, 11.0.25+11, 17.0.13+12, 21.0.5+11, 23.0.1+13 ]
+        java_version: [ "8-librca", "11-librca", "17-librca", "21-librca", "23-librca" ]
         config: ${{ fromJson(inputs.configuration) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 180
-
     container:
       image: "alpine:3.14"
-      options: --cpus 2
+      options: --cpus 4 --workdir /github/workspace -v /home/runner/work/_temp:/home/runner/work/_temp
+    timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v3
       - name: Setup OS
-        run: apk update && apk add curl moreutils wget hexdump linux-headers bash make g++ clang git cppcheck jq cmake gtest-dev gmock tar >/dev/null
-      - name: Extract Versions
-        uses: ./.github/actions/extract_versions
+        run: |
+          apk update && apk add curl moreutils wget hexdump linux-headers bash make g++ clang git cppcheck jq cmake gtest-dev gmock tar >/dev/null
+      - uses: actions/checkout@v3
       - name: Cache Gradle Wrapper Binaries
         uses: actions/cache@v4
         with:
@@ -679,51 +142,27 @@ jobs:
           key: gradle-caches-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-caches-${{ runner.os }}-
-      - name: Cache JDK 11.0.25 [amd64-musl]
-        uses: actions/cache@v3
+      - name: Setup cached JDK
+        id: cache-jdk
+        uses: ./.github/actions/setup_cached_java
         with:
-          path: |
-            test_11.0.25_jdk
-          key: 11.0.25-amd64-musl-${{ github.run_id }}
-          restore-keys: |
-            11.0.25-amd64-musl-
-      - name: Cache JDK ${{ env.JAVA_VERSION }} [amd64-musl]
-        uses: actions/cache@v3
-        with:
-          path: |
-            test_${{ env.JAVA_VERSION }}_jdk
-          key: ${{ env.JAVA_VERSION }}-amd64-musl-${{ github.run_id }}
-          restore-keys: |
-            ${{ env.JAVA_VERSION }}-amd64-musl-
-
-      - name: Prepare JDK 11.0.25
-        run: |
-          TEST_JDK_DIR="test_11.0.25_jdk"
-          if [ ! -e ${TEST_JDK_DIR}/bin/java ]; then
-            wget -nv https://download.bell-sw.com/java/11.0.25+11/bellsoft-jdk11.0.25+11-linux-x64-musl.tar.gz -O jdk.tar.gz
-            tar xzf *.tar.gz
-            find . -type d -name 'jdk*' -maxdepth 1| xargs -I {} mv {} ${TEST_JDK_DIR}
-          fi
-      - name: Prepare JDK ${{ env.JAVA_VERSION }}
-        run: |
-          TEST_JDK_DIR="test_${{ env.JAVA_VERSION }}_jdk"
-          if [ ! -e ${TEST_JDK_DIR}/bin/java ]; then
-            wget -nv https://download.bell-sw.com/java/${{ matrix.java_version }}/bellsoft-jdk${{ matrix.java_version }}-linux-x64-musl.tar.gz -O jdk.tar.gz
-            tar xzf *.tar.gz
-            find . -type d -name 'jdk*' -maxdepth 1| xargs -I {} mv {} ${TEST_JDK_DIR}
-          fi
+          version: ${{ matrix.java_version }}
+          arch: 'amd64-musl'
+      - name: Extract Versions
+        uses: ./.github/actions/extract_versions
       - name: Test
         run: |
           set +e
+          
           export KEEP_JFRS=true
-          export JAVA_HOME=$(pwd)/test_11.0.25_jdk
-          export PATH=$JAVA_HOME/bin:$PATH
           export TEST_COMMIT=${{ github.sha }}
-          export TEST_CONFIGURATION=musl/${{ matrix.java_version }}-amd64
+          export TEST_CONFIGURATION=musl/${{ matrix.java_version }}-${{ matrix.config }}-amd64
+          # make sure the job knows it is running on musl
           export LIBC=musl
-          export JAVA_TEST_HOME=$(pwd)/test_${{ env.JAVA_VERSION }}_jdk
           export SANITIZER=${{ matrix.config }}
-          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
+          
+          # due to env hell in GHA containers, we need to re-do the logic from Etract Versions here
+          JAVA_VERSION=$(${{ env.JAVA_TEST_HOME }}/bin/java -version 2>&1 | awk -F '"' '/version/ {
               split($2, v, "[._]");
               if (v[1] == "1") {
               # Java 8 or older: Include major, minor, and update
@@ -733,193 +172,60 @@ jobs:
               printf "%s.%s.%s\n", v[1], v[2], v[3]
             }
           }')
+          export JAVA_VERSION
+
           ./gradlew -PkeepJFRs :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs
           EXIT_CODE=$?
-          rm -rf $JAVA_TEST_HOME
-          rm -rf $JAVA_HOME
+
           if [ $EXIT_CODE -ne 0 ]; then
             echo "musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64" >> failures_musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
             exit 1
           fi
-      - name: Upload logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: reports-linux-musl-${{ matrix.java_version }}-amd64.zip
-          path: |
-            /tmp/hs_err*
-            ddprof-test/hs_err_*
-            ddprof-test/build/reports/tests
-            ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
-            ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
       - uses: actions/upload-artifact@v4
         if: success()
         with:
-          name: musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64
+          name: test-linux-musl-amd64 (${{ matrix.java_version }}, ${{ matrix.config }})] (build)
           path: build/
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: failures
+          name: failures-musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64
           path: failures_musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
+      - name: Prepare reports
+        if: failure()
+        run: |
+          .github/scripts/prepare_reports.sh
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: recordings
-          path: /tmp/recordings
+          name: test-linux-musl-amd64 (${{ matrix.java_version }}, ${{ matrix.config }}) (reports)
+          path: reports
 
-  test-linux-glibc-zing-amd64:
+  test-linux-glibc-aarch64:
+    needs: cache-jdks
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ 8, 11, 17, 21 ]
-        config: ${{ fromJson(inputs.configuration) }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
-
-    steps:
-      - name: Set config output
-        id: set_config
-        run: echo "::set-output name=config::${{ matrix.config }}"
-      - uses: actions/checkout@v3
-        if: steps.set_config.outputs.config == 'release' || steps.set_config.outputs.config == 'debug'
-      - name: Setup OS
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl zip unzip libgtest-dev libgmock-dev
-      - name: Cache Gradle Wrapper Binaries
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper/dists
-          key: gradle-wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-wrapper-${{ runner.os }}-
-      - name: Cache Gradle User Home
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: gradle-caches-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-caches-${{ runner.os }}-
-      - name: Prepare build JDK
-        if: steps.set_config.outputs.config == 'release' || steps.set_config.outputs.config == 'debug'
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: "11"
-      - name: Cache JDK ${{ matrix.java_version }} [amd64-zing]
-        uses: actions/cache@v3
-        with:
-          path: |
-            test_${{ matrix.java_version }}_jdk
-          key: ${{ matrix.java_version }}-amd64-zing-${{ github.run_id }}
-          restore-keys: |
-            ${{ matrix.java_version }}-amd64-zing-
-      - name: Prepare JDK ${{ matrix.java_version }}
-        if: steps.set_config.outputs.config == 'release' || steps.set_config.outputs.config == 'debug'
-        run: |
-          sudo apt-get -y update && sudo apt-get -y install curl g++-9 gcc-9
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9
-          sudo update-alternatives --set gcc /usr/bin/gcc-9
-          TEST_JDK_DIR=test_${{ matrix.java_version }}_jdk
-          if [ ! -e ${TEST_JDK_DIR}/bin/java ]; then
-            set -eux
-            mkdir -p ${TEST_JDK_DIR}
-            if [ "${{ matrix.java_version }}" = "8" ]; then
-              # jdk1.8.0_372
-              curl -L --fail "https://cdn.azul.com/zing-zvm/ZVM23.05.0.0/zing23.05.0.0-2-jdk8.0.372-linux_x64.tar.gz" | sudo tar -xvzf - -C ${TEST_JDK_DIR} --strip-components 1
-            elif [ "${{ matrix.java_version }}" = "11" ]; then
-              # jdk 11.0.19
-              curl -L --fail "https://cdn.azul.com/zing-zvm/ZVM23.05.0.0/zing23.05.0.0-2-jdk11.0.19-linux_x64.tar.gz" | sudo tar -xvzf - -C ${TEST_JDK_DIR} --strip-components 1
-            elif [ "${{ matrix.java_version }}" = "17" ]; then
-              # jdk 17.0.7
-              curl -L --fail "https://cdn.azul.com/zing-zvm/ZVM23.05.0.0/zing23.05.0.0-2-jdk17.0.7-linux_x64.tar.gz" | sudo tar -xvzf - -C ${TEST_JDK_DIR} --strip-components 1
-            elif [ "${{ matrix.java_version }}" = "21" ]; then
-              # jdk 21.0.2
-              curl -L --fail "https://cdn.azul.com/zing-zvm/ZVM23.10.0.0/zing23.10.0.0-3-jdk21.0.1-linux_x64.tar.gz" | sudo tar -xvzf - -C ${TEST_JDK_DIR} --strip-components 1
-            fi
-            # rename the bundled libstdc++.so to avoid conflicts with the system one
-            sudo mv ${TEST_JDK_DIR}/etc/libc++/libstdc++.so.6 ${TEST_JDK_DIR}/etc/libc++/libstdc++.so.6.bak
-          fi
-      - name: Test
-        if: steps.set_config.outputs.config == 'release' || steps.set_config.outputs.config == 'debug'
-        run: |
-          set +e
-          export KEEP_JFRS=true
-          export TEST_COMMIT=${{ github.sha }}
-          export TEST_CONFIGURATION=glibc/zing/${{ matrix.java_version }}-amd64
-          export LIBC=glibc
-          export JAVA_TEST_HOME=$(pwd)/test_${{ matrix.java_version }}_jdk
-          export JAVA_HOME=$JAVA_HOME
-          export PATH=$JAVA_HOME/bin:$PATH
-          export SANITIZER=${{ matrix.config }}
-          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
-              split($2, v, "[._]");
-              if (v[1] == "1") {
-              # Java 8 or older: Include major, minor, and update
-              printf "%s.%s.%s\n", v[2], v[3], v[4]
-            } else {
-              # Java 9 or newer: Major, minor, and patch
-              printf "%s.%s.%s\n", v[1], v[2], v[3]
-            }
-          }')
-          ./gradlew -PkeepJFRs :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs
-          EXIT_CODE=$?
-          rm -rf $JAVA_TEST_HOME
-          if [ $EXIT_CODE -ne 0 ]; then
-            echo "glibc-zing-${{ matrix.java_version }}-${{ matrix.config }}-amd64" >> failures_zing-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
-            exit 1
-          fi
-      - name: Upload logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: reports-linux-zing-jdk-${{ matrix.java_version }}-amd64.zip
-          path: |
-            ddprof-test/hs_err_*
-            ddprof-test/build/reports/tests/test
-            ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
-            ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
-      - uses: actions/upload-artifact@v4
-        if: success()
-        with:
-          name: glibc-zing-${{ matrix.java_version }}-${{ matrix.config }}-amd64
-          path: build/
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: failures
-          path: failures_zing-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: recordings
-          path: /tmp/recordings
-
-  test-linux-glibc-zing-aarch64:
-    strategy:
-      fail-fast: false
-      matrix:
-        java_version: [ 8, 11, 17, 21 ]
+        java_version: [ "8", "8-j9", "8-zing", "11", "11-j9", "11-zing", "17", "17-j9", "17-zing", "17-graal", "21", "21-zing", "21-graal", "23", "23-graal" ]
         config: ${{ fromJson(inputs.configuration) }}
     runs-on:
       group: ARM LINUX SHARED
       labels: arm-4core-linux
     timeout-minutes: 180
-
     steps:
-      - name: Set config output
-        id: set_config
-        run: echo "::set-output name=config::${{ matrix.config }}"
-      - uses: actions/checkout@v3
-        if: steps.set_config.outputs.config == 'release' || steps.set_config.outputs.config == 'debug'
-      - name: Setup OS
+      - name: Set enabled flag
+        id: set_enabled
         run: |
-          sudo apt update -y
-          sudo apt remove -y g++
-          sudo apt autoremove -y
-          sudo apt install -y curl zip unzip clang make build-essential
+          echo "enabled=true" >> $GITHUB_OUTPUT
+          if [[ "${{ matrix.java_version }}" =~ -zing ]]; then
+            if [[ "${{ matrix.config }}" != "release" ]] && [[ "${{ matrix.config }}" != "debug" ]]; then
+              echo "enabled=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+      - uses: actions/checkout@v3
+        if: steps.set_enabled.outputs.enabled == 'true'
       - name: Cache Gradle Wrapper Binaries
+        if: steps.set_enabled.outputs.enabled == 'true'
         uses: actions/cache@v4
         with:
           path: ~/.gradle/wrapper/dists
@@ -927,101 +233,70 @@ jobs:
           restore-keys: |
             gradle-wrapper-${{ runner.os }}-
       - name: Cache Gradle User Home
+        if: steps.set_enabled.outputs.enabled == 'true'
         uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: gradle-caches-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-caches-${{ runner.os }}-
-      - name: Prepare build JDK
-        if: steps.set_config.outputs.config == 'release' || steps.set_config.outputs.config == 'debug'
-        uses: actions/setup-java@v3
+      - name: Setup cached JDK
+        id: cache-jdk
+        if: steps.set_enabled.outputs.enabled == 'true'
+        uses: ./.github/actions/setup_cached_java
         with:
-          distribution: 'temurin'
-          java-version: "11"
-      - name: Cache JDK ${{ matrix.java_version }} [aarch64-zing]
-        uses: actions/cache@v3
-        with:
-          path: |
-            test_${{ matrix.java_version }}_jdk
-          key: ${{ matrix.java_version }}-aarch64-zing-${{ github.run_id }}
-          restore-keys: |
-            ${{ matrix.java_version }}-aarch64-zing-
-      - name: Prepare JDK ${{ matrix.java_version }}
-        if: steps.set_config.outputs.config == 'release' || steps.set_config.outputs.config == 'debug'
+          version: ${{ matrix.java_version }}
+          arch: 'aarch64'
+      - name: Setup OS
+        if: steps.set_enabled.outputs.enabled == 'true'
         run: |
-          sudo apt-get -y update && sudo apt-get -y install curl g++-9 gcc-9
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9
-          sudo update-alternatives --set gcc /usr/bin/gcc-9
-          TEST_JDK_DIR=test_${{ matrix.java_version }}_jdk
-          if [ ! -e ${TEST_JDK_DIR}/bin/java ]; then
-            set -eux
-            mkdir -p ${TEST_JDK_DIR}
-            if [ "${{ matrix.java_version }}" = "8" ]; then
-              # jdk1.8.0_431
-              curl -L --fail "https://cdn.azul.com/zing-zvm/ZVM24.10.0.0/zing24.10.0.0-4-jdk8.0.431-linux_aarch64.tar.gz" | sudo tar -xvzf - -C ${TEST_JDK_DIR} --strip-components 1
-            elif [ "${{ matrix.java_version }}" = "11" ]; then
-              # jdk 11.0.24
-              curl -L --fail "https://cdn.azul.com/zing-zvm/ZVM24.10.0.0/zing24.10.0.0-4-jdk11.0.24.0.101-linux_aarch64.tar.gz" | sudo tar -xvzf - -C ${TEST_JDK_DIR} --strip-components 1
-            elif [ "${{ matrix.java_version }}" = "17" ]; then
-              # jdk 17.0.12
-              curl -L --fail "https://cdn.azul.com/zing-zvm/ZVM24.10.0.0/zing24.10.0.0-4-jdk17.0.12.0.101-linux_aarch64.tar.gz" | sudo tar -xvzf - -C ${TEST_JDK_DIR} --strip-components 1
-            elif [ "${{ matrix.java_version }}" = "21" ]; then
-              # jdk 21.0.4
-              curl -L --fail "https://cdn.azul.com/zing-zvm/ZVM24.10.0.0/zing24.10.0.0-4-jdk21.0.4.0.101-linux_aarch64.tar.gz" | sudo tar -xvzf - -C ${TEST_JDK_DIR} --strip-components 1
-            fi
+          sudo apt update -y
+          sudo apt remove -y g++
+          sudo apt autoremove -y
+          sudo apt install -y curl zip unzip clang make build-essential
+          if [[ ${{ matrix.java_version }} =~ "-zing" ]]; then
+            sudo apt -y install g++-9 gcc-9
+            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9
+            sudo update-alternatives --set gcc /usr/bin/gcc-9
           fi
+      - name: Extract Versions
+        if: steps.set_enabled.outputs.enabled == 'true'
+        uses: ./.github/actions/extract_versions
       - name: Test
-        if: steps.set_config.outputs.config == 'release' || steps.set_config.outputs.config == 'debug'
+        if: steps.set_enabled.outputs.enabled == 'true'
         run: |
+          sudo sysctl vm.mmap_rnd_bits=28
+
           set +e
           export KEEP_JFRS=true
           export TEST_COMMIT=${{ github.sha }}
-          export TEST_CONFIGURATION=glibc/zing/${{ matrix.java_version }}-aarch64
+          export TEST_CONFIGURATION=glibc/${{ matrix.java_version }}-${{ matrix.config }}-aarch64
           export LIBC=glibc
-          export JAVA_TEST_HOME=$(pwd)/test_${{ matrix.java_version }}_jdk
-          export JAVA_HOME=$JAVA_HOME
-          export PATH=$JAVA_HOME/bin:$PATH
           export SANITIZER=${{ matrix.config }}
-          export JAVA_VERSION=$(${JAVA_TEST_HOME}/bin/java -version 2>&1 | awk -F '"' '/version/ {
-              split($2, v, "[._]");
-              if (v[1] == "1") {
-              # Java 8 or older: Include major, minor, and update
-              printf "%s.%s.%s\n", v[2], v[3], v[4]
-            } else {
-              # Java 9 or newer: Major, minor, and patch
-              printf "%s.%s.%s\n", v[1], v[2], v[3]
-            }
-          }')
+
           ./gradlew -PkeepJFRs :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs
           EXIT_CODE=$?
-          rm -rf $JAVA_TEST_HOME
+
           if [ $EXIT_CODE -ne 0 ]; then
-            echo "glibc-zing-${{ matrix.java_version }}-${{ matrix.config }}-aarch64" >> failures_zing-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
+            echo "glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64" >> failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
             exit 1
           fi
-      - name: Upload logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: reports-linux-zing-jdk-${{ matrix.java_version }}-aarch64.zip
-          path: |
-            ddprof-test/hs_err_*
-            ddprof-test/build/reports/tests/test
-            ddprof-lib/src/test/build/Testing/Temporary/LastTest.log
-            ddprof-lib/build/tmp/compileReleaseLinuxCpp/output.txt
       - uses: actions/upload-artifact@v4
         if: success()
         with:
-          name: glibc-zing-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
+          name: test-linux-glibc-aarch64 (${{ matrix.java_version }}, ${{ matrix.config }})] (build)
           path: build/
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: failures
-          path: failures_zing-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
+          name: failures-glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
+          path: failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
+      - name: Prepare reports
+        if: failure()
+        run: |
+          .github/scripts/prepare_reports.sh
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: recordings
-          path: /tmp/recordings
+          name: test-linux-glibc-aarch64 (${{ matrix.java_version }}, ${{ matrix.config }}) (reports)
+          path: reports

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ datadog/maven/resources
 **/launcher*
 /gradle.properties
 **/hs_err*
+


### PR DESCRIPTION
**What does this PR do?**:
This cleans up the CI workflow definition

**Motivation**:
We want to have the least number of places to modify when we update the CI jobs - with this change we can reduce them to 3 different jobs (glibc-amd64, glibc-aarch64 and musl-amd64) and make the maintenance much easier.
Also, it makes it easier to set up shared JDK caching, saving time and CPU resources on test reruns.

The anecdotical evidence is ~10 minutes of CI run time before this change vs. ~5 minutes after this change (of course, if we do not spend 5 minutes waiting for ubuntu mirrors ...)

**How the JDK caching works**
We have a dedicated job which refresh the caches once a day such that they are not expired accidentally. 
Also, that job is triggered by changes on 'main' branch to the files defining the used JAVA versions making it 'relatively' easy to bump the update versions regularly.

However, this would work only for the 'main' branch because the caches are per-branch (and there is no way around). Hence, we also run the cache-refresh before the test matrix to prevent cache failures for feature branches/PR. This also means that the first build will not be faster than before - but subsequent rebuilds should benefit from the cached binaries.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-11327]

Unsure? Have a question? Request a review!


[PROF-11327]: https://datadoghq.atlassian.net/browse/PROF-11327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ