### PR TITLE
Modify version extraction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 version = "1.21.0"
 
 apply plugin: "com.dipien.semantic-version"
-version = project.hasProperty("ddprof_version") ? project.ddprof_version : version
+version = project.findProperty("ddprof_version") ?: version
 
 allprojects {
   repositories {

--- a/gradle/configurations.gradle
+++ b/gradle/configurations.gradle
@@ -102,6 +102,9 @@ ext {
   locateLibtsan = this.&locateLibtsan
 }
 
+// make sure the provided version is correctly propagated to the build
+version = project.findProperty("ddprof_version") ?: version
+
 // ======= Define build configurations below ========
 
 def commonLinuxCompilerArgs = [


### PR DESCRIPTION
**What does this PR do?**:
It does fix the version extraction such that we bake in the correct version to a release artifact

**Motivation**:
Currently, the release artifacts are reporting incorrect version (the next version). We want to have this fixed

Unsure? Have a question? Request a review!
