### PR TITLE
Enable ASGCT by default on fairly safe J9 JDK versions

### DIFF
--- a/.github/scripts/prepare_reports.sh
+++ b/.github/scripts/prepare_reports.sh
@@ -1,8 +1,9 @@
-#!/usr/bin/env bash
+  #!/usr/bin/env bash
 
 set -e
 mkdir -p reports
 cp /tmp/hs_err* reports/ || true
+cp ddprof-test/javacore*.txt reports/ || true
 cp ddprof-test/build/hs_err* reports/ || true
 cp -r ddprof-lib/build/tmp reports/native_build || true
 cp -r ddprof-test/build/reports/tests reports/tests || true

--- a/ddprof-lib/src/main/cpp/arguments.cpp
+++ b/ddprof-lib/src/main/cpp/arguments.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "arguments.h"
+#include "vmEntry.h"
+
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -340,6 +342,14 @@ Error Arguments::parse(const char *args) {
 
   if (_event == NULL && _cpu < 0 && _wall < 0 && _memory < 0) {
     _event = EVENT_CPU;
+  }
+
+  if (VM::isOpenJ9()) {
+    if (_cstack == CSTACK_FP) {
+      // J9 is compiled without FP
+      //   switch to DWARF for better results
+      _cstack = CSTACK_DWARF;
+    }
   }
 
   return Error::OK;

--- a/ddprof-lib/src/main/cpp/javaApi.cpp
+++ b/ddprof-lib/src/main/cpp/javaApi.cpp
@@ -109,6 +109,14 @@ Java_com_datadoghq_profiler_JavaProfiler_execute0(JNIEnv *env, jobject unused,
   return NULL;
 }
 
+extern "C" DLLEXPORT jstring JNICALL
+Java_com_datadoghq_profiler_JavaProfiler_getStatus0(JNIEnv* env, 
+                                                    jobject unused) {
+  char msg[2048];
+  int ret = Profiler::instance()->status((char*)msg, sizeof(msg) - 1);
+  return env->NewStringUTF(msg);
+}
+
 extern "C" DLLEXPORT jlong JNICALL
 Java_com_datadoghq_profiler_JavaProfiler_getSamples(JNIEnv *env,
                                                     jobject unused) {

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -7,6 +7,7 @@
 #include "profiler.h"
 #include "asyncSampleMutex.h"
 #include "context.h"
+#include "common.h"
 #include "counters.h"
 #include "ctimer.h"
 #include "dwarf.h"

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -135,6 +135,7 @@ private:
   void updateJavaThreadNames();
   void updateNativeThreadNames();
   void mangle(const char *name, char *buf, size_t size);
+
   Engine *selectCpuEngine(Arguments &args);
   Engine *selectWallEngine(Arguments &args);
   Engine *selectAllocEngine(Arguments &args);
@@ -168,6 +169,8 @@ public:
   static Profiler *instance() {
     return _instance;
   }
+
+  int status(char* status, int max_len);
 
   const char* cstack() {
     switch (_cstack) {

--- a/ddprof-lib/src/main/cpp/vmEntry.cpp
+++ b/ddprof-lib/src/main/cpp/vmEntry.cpp
@@ -383,10 +383,6 @@ bool VM::initProfilerBridge(JavaVM *vm, bool attach) {
       *flag_addr = 1;
     }
   }
-  char *flag_addr = (char *)JVMFlag::find("KeepJNIIDs", {JVMFlag::Type::Bool});
-  if (flag_addr != NULL) {
-    *flag_addr = 1;
-  }
 
   // if the user sets -XX:+UseAdaptiveGCBoundary we will just disable the
   // profiler to avoid the risk of crashing flag was made obsolete (inert) in 15

--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
@@ -167,6 +167,10 @@ public final class JavaProfiler {
         }
     }
 
+    public String getStatus() {
+        return getStatus0();
+    }
+
     /**
      * Execute an agent-compatible profiling command -
      * the comma-separated list of arguments described in arguments.cpp
@@ -472,4 +476,6 @@ public final class JavaProfiler {
     private static native long tscFrequency0();
 
     private static native void mallocArenaMax0(int max);
+
+    private static native String getStatus0();
 }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/AbstractProcessProfilerTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/AbstractProcessProfilerTest.java
@@ -1,0 +1,94 @@
+package com.datadoghq.profiler;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+public abstract class AbstractProcessProfilerTest {
+    protected final boolean launch(String target, List<String> jvmArgs, String commands, Function<String, Boolean> onStdoutLine, Function<String, Boolean> onStderrLine) throws Exception {
+        String javaHome = System.getenv("JAVA_TEST_HOME");
+        if (javaHome == null) {
+            javaHome = System.getenv("JAVA_HOME");
+        }
+        if (javaHome == null) {
+            javaHome = System.getProperty("java.home");
+        }
+        assertNotNull(javaHome);
+
+        List<String> args = new ArrayList<>();
+        args.add(javaHome + "/bin/java");
+        args.addAll(jvmArgs);
+        args.add("-cp");
+        args.add(System.getProperty("java.class.path"));
+        args.add(ExternalLauncher.class.getName());
+        args.add(target);
+        if (commands != null && !commands.isEmpty()) {
+            args.add(commands);
+        }
+
+        ProcessBuilder pb = new ProcessBuilder(args);
+        Process p = pb.start();
+        Thread stdoutReader = new Thread(() -> {
+            Function<String, Boolean> lineProcessor = onStdoutLine != null ? onStdoutLine : l -> true;
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    System.out.println("[out] " + line);
+                    if (!lineProcessor.apply(line)) {
+                        try {
+                            p.getOutputStream().write(1);
+                            p.getOutputStream().flush();
+                        } catch (IOException ignored) {
+                        }
+                    } else {
+                        if (line.contains("[ready]")) {
+                            p.getOutputStream().write(1);
+                            p.getOutputStream().flush();
+                        }
+                    }
+                }
+            } catch (IOException ignored) {
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }, "stdout-reader");
+        Thread stderrReader = new Thread(() -> {
+            Function<String, Boolean> lineProcessor = onStderrLine != null ? onStderrLine : l -> true;
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(p.getErrorStream()))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    System.out.println("[err] " + line);
+                    if (!lineProcessor.apply(line)) {
+                        try {
+                            p.getOutputStream().write(1);
+                            p.getOutputStream().flush();
+                        } catch (IOException ignored) {
+                        }
+                    }
+                }
+            } catch (IOException ignored) {
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }, "stderr-reader");
+
+        stdoutReader.setDaemon(true);
+        stderrReader.setDaemon(true);
+
+        stdoutReader.start();
+        stderrReader.start();
+
+        boolean val = p.waitFor(10, TimeUnit.SECONDS);
+        if (!val) {
+            p.destroyForcibly();
+        }
+        return val;
+    }
+}

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/ExternalLauncher.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/ExternalLauncher.java
@@ -2,13 +2,27 @@ package com.datadoghq.profiler;
 
 public class ExternalLauncher {
     public static void main(String[] args) throws Exception {
-        if (args.length != 1) {
-            throw new RuntimeException();
+        try {
+            if (args.length < 1) {
+                throw new RuntimeException();
+            }
+            if (args[0].equals("library")) {
+                JVMAccess.getInstance();
+            } else if (args[0].equals("profiler")) {
+                JavaProfiler instance = JavaProfiler.getInstance();
+                if (args.length == 2) {
+                    String commands = args[1];
+                    if (!commands.isEmpty()) {
+                        instance.execute(commands);
+                    }
+                }
+            }
+        } finally {
+            System.out.println("[ready]");
+            System.out.flush();
+            System.err.flush();
         }
-        if (args[0].equals("library")) {
-            JVMAccess.getInstance();
-        } else if (args[0].equals("profiler")) {
-            JavaProfiler.getInstance();
-        }
+        // wait for signal to exit
+        System.in.read();
     }
 }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/junit/CStackInjector.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/junit/CStackInjector.java
@@ -51,7 +51,7 @@ public class CStackInjector implements TestTemplateInvocationContextProvider {
             return Stream.of(new ParameterizedTestContext("no", retryCount));
         } else {
             return Stream.of(valueSource.strings()).
-                    filter(param -> (!Platform.isJ9() || !param.startsWith("vm"))).
+                    filter(param -> (!Platform.isJ9() || "dwarf".equals(param))).
                     map(param -> new ParameterizedTestContext(param, retryCount));
         }
     }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/SmokeWallTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/SmokeWallTest.java
@@ -16,6 +16,7 @@ import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class SmokeWallTest extends CStackAwareAbstractProfilerTest {
     private ProfiledCode profiledCode;


### PR DESCRIPTION
**What does this PR do?**:
It updates the 'safe' versions for J9 usage of ASGCT.
These versions have been tested and are behaving correctly.

**Motivation**:
The JVMTI based sampler is causing a noticeable overhead. Being able to use ASGCT where it is fairly safe will make the usage of profiler much nicer experience.

**Additional Notes**:
This change is adding support for forcing the 'jvmti' samplers by setting system property `dd.profiling.ddprof.j9.sampler=jvmti`

**How to test the change?**:
Added sanity tests which will be executed when running on J9 JVMs

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x]  JIRA: [PROF-11356]

Unsure? Have a question? Request a review!


[PROF-11356]: https://datadoghq.atlassian.net/browse/PROF-11356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ