### PR TITLE
Do not write null values to jvminfo event

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -903,9 +903,9 @@ void Recording::writeJvmInfo(Buffer *buf) {
   buf->putVar64(_start_ticks);
   buf->putUtf8(jvm_name);
   buf->putUtf8(jvm_version);
-  buf->putUtf8(_jvm_args);
-  buf->putUtf8(_jvm_flags);
-  buf->putUtf8(_java_command);
+  buf->putUtf8(_jvm_args != nullptr ? _jvm_args : "");
+  buf->putUtf8(_jvm_flags != nullptr ? _jvm_flags : "");
+  buf->putUtf8(_java_command != nullptr ? _java_command : "");
   buf->putVar64(OS::processStartTime());
   buf->putVar64(OS::processId());
   buf->putVar32(start, buf->offset() - start);

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/ObjectSampleDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/ObjectSampleDumpSmokeTest.java
@@ -15,11 +15,11 @@ public class ObjectSampleDumpSmokeTest extends JfrDumpTest {
 
     @Override
     protected String getProfilerCommand() {
-        return "memory=1024:a";
+        return "memory=128:a";
     }
 
     @RetryingTest(5)
-    @Timeout(value = 60)
+    @Timeout(value = 300)
     public void test() throws Exception {
         runTest("datadog.ObjectSample", "method3");
     }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/settings/DatadogSettingsTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/settings/DatadogSettingsTest.java
@@ -2,6 +2,7 @@ package com.datadoghq.profiler.settings;
 
 import com.datadoghq.profiler.AbstractProfilerTest;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 import org.openjdk.jmc.common.item.IAttribute;
 import org.openjdk.jmc.common.item.IItem;
 import org.openjdk.jmc.common.item.IItemCollection;
@@ -21,7 +22,7 @@ public class DatadogSettingsTest extends AbstractProfilerTest {
         return "cpu=1ms";
     }
 
-    @Test
+    @RetryingTest(5)
     public void testRecordDatadogSetting() {
         profiler.recordSetting("dimensionless", "value");
         profiler.recordSetting("withUnit", "60", "seconds");


### PR DESCRIPTION
**What does this PR do?**:
What title says

**Motivation**:
The profiling backend gets unhappy when the event contains null values. I tried figuring out exactly where but it seems that not putting null values there is a much faster fix.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-11347]

Unsure? Have a question? Request a review!


[PROF-11347]: https://datadoghq.atlassian.net/browse/PROF-11347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ