### PR TITLE
IBM J9 8u361 corresponds to OpenJDK 8u362

### DIFF
--- a/ddprof-lib/src/main/cpp/j9Ext.h
+++ b/ddprof-lib/src/main/cpp/j9Ext.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2022 Andrei Pangin
- * Copyright 2024 Datadog, Inc
+ * Copyright 2024, 2025 Datadog, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public:
   static bool can_use_ASGCT() {
     // as of 21.0.6 the use of ASGCT will lead to almost immediate crash
     //   or livelock on J9
-    return (VM::java_version() == 8 && VM::java_update_version() >= 362) ||
+    return (VM::java_version() == 8 && VM::java_update_version() >= 361) ||
            (VM::java_version() == 11 && VM::java_update_version() >= 18) ||
            (VM::java_version() == 17 && VM::java_update_version() >= 6) ||
            (VM::java_version() >= 18 && VM::java_version() < 21);

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/JfrDumpTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/JfrDumpTest.java
@@ -16,10 +16,14 @@ public abstract class JfrDumpTest extends AbstractProfilerTest {
     }
 
     public void runTest(String eventName, String ... patterns) throws Exception {
+        runTest(eventName, 10, patterns);
+    }
+
+    public void runTest(String eventName, int dumpCnt, String ... patterns) throws Exception {
         Assumptions.assumeTrue(Platform.isJavaVersionAtLeast(11));
         Assumptions.assumeFalse(Platform.isJ9());
 
-        for (int j = 0; j < 10; j++) {
+        for (int j = 0; j < dumpCnt; j++) {
             Path recording = Files.createTempFile("dump-", ".jfr");
             try {
                 for (int i = 0; i < 50; i++) {

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/ObjectSampleDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/ObjectSampleDumpSmokeTest.java
@@ -21,6 +21,6 @@ public class ObjectSampleDumpSmokeTest extends JfrDumpTest {
     @RetryingTest(5)
     @Timeout(value = 300)
     public void test() throws Exception {
-        runTest("datadog.ObjectSample", "method3");
+        runTest("datadog.ObjectSample", 3, "method3");
     }
 }


### PR DESCRIPTION
**What does this PR do?**:
It modifies the check in `can_use_ASGCT` to include the closed-source version of IBM J9

**Motivation**:
We are not able to extract the exact version information from IBM J9 - we are using the date tag to assert whether it is after 8u361 or before.
However, the ASGCT check was based on the open source version 8.0.362 which corresponds to the closed source version 8.0.361 (or 8u361)

**How to test the change?**:
Running 
**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
