### PR TITLE
Fix compatibility with musl libc 1.2.4

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -120,7 +120,7 @@ jobs:
         config: ${{ fromJson(inputs.configuration) }}
     runs-on: ubuntu-latest
     container:
-      image: "alpine:3.14"
+      image: "alpine:3.21"
       options: --cpus 4 --workdir /github/workspace -v /home/runner/work/_temp:/home/runner/work/_temp
     timeout-minutes: 180
     steps:

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -24,6 +24,9 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+// make sure lseek will use 64 bits offset
+#define _FILE_OFFSET_BITS 64
 #include <unistd.h>
 
 ElfSection *ElfParser::findSection(uint32_t type, const char *name) {
@@ -68,7 +71,7 @@ bool ElfParser::parseFile(CodeCache *cc, const char *base,
     return false;
   }
 
-  size_t length = (size_t)lseek64(fd, 0, SEEK_END);
+  size_t length = (size_t)lseek(fd, 0, SEEK_END);
   void *addr = mmap(NULL, length, PROT_READ, MAP_PRIVATE, fd, 0);
   close(fd);
 


### PR DESCRIPTION
**What does this PR do?**:
It removes the usage of `lseek64` which is undefined in musl libc 1.2.4 and thus is causing profiler failure

**Motivation**:
Make profiler working with recent musl libc versions.

**Additional notes**:
I am changing `lseek64` to `lseek` and defining `_FILE_OFFSET_BITS 64` to make sure the lseek offset is 64 bits (https://man7.org/linux/man-pages/man3/lseek64.3.html)

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-11453]

Unsure? Have a question? Request a review!


[PROF-11453]: https://datadoghq.atlassian.net/browse/PROF-11453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ