### PR TITLE
Fix a crash related to ElfParser::loadSymbolTable (#191)

### DIFF
--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -353,14 +353,11 @@ void ElfParser::loadSymbolTable(const char *symbols, size_t total_size,
        symbols += ent_size) {
     ElfSymbol *sym = (ElfSymbol *)symbols;
     if (sym->st_name != 0 && sym->st_value != 0) {
-      // sanity check the offsets not to exceed the file size
-      if (_length == 0 || (sym->st_name < _length && sym->st_value < _length)) {
-        // Skip special AArch64 mapping symbols: $x and $d
-        if (sym->st_size != 0 || sym->st_info != 0 ||
-            strings[sym->st_name] != '$') {
-          _cc->add(_base + sym->st_value, (int)sym->st_size,
-                   strings + sym->st_name);
-        }
+      // Skip special AArch64 mapping symbols: $x and $d
+      if (sym->st_size != 0 || sym->st_info != 0 ||
+          strings[sym->st_name] != '$') {
+        _cc->add(_base + sym->st_value, (int)sym->st_size,
+                 strings + sym->st_name);
       }
     }
   }


### PR DESCRIPTION
**What does this PR do?**:
Revert code in ElfParser::loadSymbolTable to fix a possible crash

**Motivation**:
I encountered the crash last week, after discussion in #191, it's acceptable to revert the code

**Additional Notes**:


**How to test the change?**:
- The test `gradle assembleReleaseJar` is successful
- The fixed version does not crash (/usr/lib/jvm/java-8-openjdk-amd64/bin/java -agentpath:java-profiler-fork/ddprof-lib/build/lib/main/release/linux/x64/libjavaProfiler.so=start,cpu=10ms,file=/tmp/ap.jfr -cp java Demo)

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

I would be very grateful if you could review this PR !
