### PR TITLE
Unwind String.indexOf intrinsic on AArch64

### DIFF
--- a/ddprof-lib/src/main/cpp/stackFrame_aarch64.cpp
+++ b/ddprof-lib/src/main/cpp/stackFrame_aarch64.cpp
@@ -98,7 +98,14 @@ bool StackFrame::unwindStub(instruction_t *entry, const char *name,
       pc = ((uintptr_t *)sp)[-1];
       return true;
     }
-  }
+  } else if (strncmp(name, "indexof_linear_", 15) == 0 &&
+                   entry != NULL && entry[0] == 0xa9be57f4 && entry[1] == 0xa9015ff6) {
+            // JDK-8189103: String.indexOf intrinsic.
+            // Entry and exit are covered by the very first 'if', in all other cases SP is 4 words off.
+            sp += 32;
+            pc = link();
+            return true;
+   }
   return false;
 }
 


### PR DESCRIPTION
Adds support for the `indexOf` intrinsic using prefetch on arm, see https://bugs.openjdk.org/browse/JDK-8189103

[PROF-11139]

[PROF-11139]: https://datadoghq.atlassian.net/browse/PROF-11139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ