### PR TITLE
Fix Java 24 support

### DIFF
--- a/ddprof-lib/src/main/cpp/vmEntry.cpp
+++ b/ddprof-lib/src/main/cpp/vmEntry.cpp
@@ -129,7 +129,12 @@ JavaFullVersion JavaVersionAccess::get_java_version(char* prop_value) {
     if (version.major < 9) {
       version.major = 9;
     }
-    // format is 11.0.17+8
+    char* peg_char = strchr(prop_value, '+');
+    if (peg_char) {
+      // terminate before the build specification
+      *peg_char = '\0';
+    }
+    // format is 11.0.17
     // this shortcut for parsing the update version should hold till Java 99
     version.update = atoi(prop_value + 5);
   }

--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -240,6 +240,11 @@ void VMStructs::initOffsets() {
       if (strcmp(field, "_klass_offset") == 0) {
         _klass_offset_addr = *(int **)(entry + address_offset);
       }
+    } else if (strcmp(type, "Thread") == 0) {
+      // Since JDK 24, _osthread field belongs to Thread rather than JavaThread
+      if (strcmp(field, "_osthread") == 0) {
+          _thread_osthread_offset = *(int*)(entry + offset_offset);
+      }
     } else if (strcmp(type, "JavaThread") == 0) {
       if (strcmp(field, "_osthread") == 0) {
         _thread_osthread_offset = *(int *)(entry + offset_offset);

--- a/ddprof-lib/src/test/cpp/ddprof_ut.cpp
+++ b/ddprof-lib/src/test/cpp/ddprof_ut.cpp
@@ -235,6 +235,17 @@
         EXPECT_EQ(9, hs_version1);
     }
 
+    TEST(JavaVersionAccess, testJavaVersionAccess_hs_24) {
+        char runtime_prop_value_1[] = "24+36-FR";
+        char vm_prop_value_1[] = "24+36-FR";
+
+        JavaFullVersion java_version1 = JavaVersionAccess::get_java_version(runtime_prop_value_1);
+        int hs_version1 = JavaVersionAccess::get_hotspot_version(vm_prop_value_1);
+        EXPECT_EQ(24, java_version1.major);
+        EXPECT_EQ(0, java_version1.update);
+        EXPECT_EQ(24, hs_version1);
+    }
+
     int main(int argc, char **argv) {
       ::testing::InitGoogleTest(&argc, argv);
       return RUN_ALL_TESTS();


### PR DESCRIPTION
**What does this PR do?**:
In Java 24 the version string is slightly different (to avoid confusion with Hotspot version from Java 7, which is also 24)

In addition to that, a change of vmstructs which was supposed to go to Java 25  made it to Java 24 and we need to adjust the code to avoid crashing.

**Motivation**:
We want to support Java 24

**How to test the change?**:
Extended gtest tests for the adjusted version string.
The reset is exercised using the current tests.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
