### PR TITLE
A set of fixes related to clang, aarch64 and musl pecularities of vmstructs stack unwinder

### DIFF
--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -113,7 +113,7 @@ private:
 
   void expand();
   void makeImportsPatchable();
-    void saveImport(ImportId id, void** entry);
+  void saveImport(ImportId id, void** entry);
 
 public:
   explicit CodeCache(const char *name, short lib_index = -1,

--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -177,6 +177,9 @@ public:
   }
 
   int count() { return _count; }
+  CodeBlob* blob(int idx) {
+    return &_blobs[idx];
+  }
 };
 
 class CodeCacheArray {

--- a/ddprof-lib/src/main/cpp/dwarf.h
+++ b/ddprof-lib/src/main/cpp/dwarf.h
@@ -36,6 +36,7 @@ const int DW_REG_SP = 7;
 const int DW_REG_PC = 16;
 const int EMPTY_FRAME_SIZE = DW_STACK_SLOT;
 const int LINKED_FRAME_SIZE = 2 * DW_STACK_SLOT;
+const int LINKED_FRAME_CLANG_SIZE = LINKED_FRAME_SIZE;
 
 #elif defined(__i386__)
 
@@ -46,6 +47,7 @@ const int DW_REG_SP = 4;
 const int DW_REG_PC = 8;
 const int EMPTY_FRAME_SIZE = DW_STACK_SLOT;
 const int LINKED_FRAME_SIZE = 2 * DW_STACK_SLOT;
+const int LINKED_FRAME_CLANG_SIZE = LINKED_FRAME_SIZE;
 
 #elif defined(__aarch64__)
 
@@ -55,13 +57,9 @@ const int DW_REG_FP = 29;
 const int DW_REG_SP = 31;
 const int DW_REG_PC = 30;
 const int EMPTY_FRAME_SIZE = 0;
-
-// aarch64 function prologue looks like this (if frame pointer is used):
-// stp x29, x30, [sp, -16]!   // Save FP (x29) and LR (x30)
-// mov x29, sp                // Set FP to SP
-// ---
-// LINKED_FRAME_SIZE should be 16
-const int LINKED_FRAME_SIZE = 2 * DW_STACK_SLOT;
+const int LINKED_FRAME_SIZE = 0;
+// clang compiler uses different frame layout than GCC
+const int LINKED_FRAME_CLANG_SIZE = 2 * DW_STACK_SLOT;
 
 #else
 
@@ -72,6 +70,7 @@ const int DW_REG_SP = 1;
 const int DW_REG_PC = 2;
 const int EMPTY_FRAME_SIZE = 0;
 const int LINKED_FRAME_SIZE = 0;
+const int LINKED_FRAME_CLANG_SIZE = LINKED_FRAME_SIZE;
 
 #endif
 
@@ -83,6 +82,7 @@ struct FrameDesc {
 
   static FrameDesc empty_frame;
   static FrameDesc default_frame;
+  static FrameDesc default_clang_frame;
 
   static int comparator(const void *p1, const void *p2) {
     FrameDesc *fd1 = (FrameDesc *)p1;

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -252,10 +252,10 @@ CodeBlob *Profiler::findRuntimeStub(const void *address) {
   return _runtime_stubs.findBlobByAddress(address);
 }
 
-bool Profiler::isAddressInCode(const void *pc) {
+bool Profiler::isAddressInCode(const void *pc, bool include_stubs) {
   if (CodeHeap::contains(pc)) {
     return CodeHeap::findNMethod(pc) != NULL &&
-           !(pc >= _call_stub_begin && pc < _call_stub_end);
+           (include_stubs || !(pc >= _call_stub_begin && pc < _call_stub_end));
   } else {
     return _libs->findLibraryByAddress(pc) != NULL;
   }

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -243,7 +243,7 @@ public:
   const char *getLibraryName(const char *native_symbol);
   const char *findNativeMethod(const void *address);
   CodeBlob *findRuntimeStub(const void *address);
-  bool isAddressInCode(const void *pc);
+  bool isAddressInCode(const void *pc, bool include_stubs = true);
 
   static void segvHandler(int signo, siginfo_t *siginfo, void *ucontext);
   static void busHandler(int signo, siginfo_t *siginfo, void *ucontext);

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -427,6 +427,10 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
           JavaFrameAnchor* e_anchor = JavaFrameAnchor::fromEntryFrame(fp);
           if (e_anchor == NULL) {
             if (anchor != NULL && !recovered_from_anchor && anchor->lastJavaSP() != 0) {
+              if (anchor->lastJavaPC() == nullptr || anchor->lastJavaSP() == 0) {
+                // end of Java stack
+                break;
+              }
               TEST_LOG("Reusing thread anchor");
               fillSkipFrame(frames[depth++]);
               e_anchor = anchor;
@@ -532,11 +536,16 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
         // Let's try to jump to the stored Java frame -
         //   the garbled frame is leaf so there is no danger we 'loop' back to the top Java frame
         if (anchor && !recovered_from_anchor && anchor->lastJavaSP() != 0) {
+          if (anchor->lastJavaPC() == nullptr || anchor->lastJavaSP() == 0) {
+            // end of Java stack
+            break;
+          }
           recovered_from_anchor = true;
           fillSkipFrame(frames[depth++]);
           sp = anchor->lastJavaSP();
           fp = anchor->lastJavaFP();
           pc = anchor->lastJavaPC();
+
           continue;
         }
       }
@@ -571,6 +580,10 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
     }
 
     if (anchor && !recovered_from_anchor && !VMStructs::goodPtr((const void*)fp) && anchor->lastJavaSP() != 0) {
+      if (anchor->lastJavaPC() == nullptr || anchor->lastJavaSP() == 0) {
+        // end of Java stack
+        break;
+      }
       recovered_from_anchor = true;
       fillSkipFrame(frames[depth++]);
       sp = anchor->lastJavaSP();

--- a/ddprof-lib/src/main/cpp/symbols.h
+++ b/ddprof-lib/src/main/cpp/symbols.h
@@ -32,6 +32,9 @@ public:
   // There are internal caches that are not associated to the array
   static void clearParsingCaches();
   static bool haveKernelSymbols() { return _have_kernel_symbols; }
+
+  // Some symbols are always roots - eg. no unwinding should be attempted once they are encountered
+  static bool isRootSymbol(const void* address);
 };
 
 #endif // _SYMBOLS_H

--- a/ddprof-lib/src/main/cpp/symbols_linux.h
+++ b/ddprof-lib/src/main/cpp/symbols_linux.h
@@ -122,8 +122,16 @@ static const bool MUSL = true;
 static const bool MUSL = false;
 #endif // __musl__
 
+enum RootSymbolKind {
+  _start, start_thread, _ZL19thread_native_entryP6Thread, _thread_start, thread_start,
+  LAST_ROOT_SYMBOL_KIND
+};
+
 class ElfParser {
+friend Symbols;
 private:
+  static uintptr_t _root_symbols[LAST_ROOT_SYMBOL_KIND];
+
   CodeCache *_cc;
   const char *_base;
   const char *_file_name;
@@ -193,6 +201,8 @@ private:
   void loadSymbolTable(const char *symbols, size_t total_size, size_t ent_size,
                        const char *strings);
   void addRelocationSymbols(ElfSection *reltab, const char *plt);
+
+  void addSymbol(const void *start, int length, const char *name, bool update_bounds = false);
 
 public:
   static void parseProgramHeaders(CodeCache *cc, const char *base,

--- a/ddprof-lib/src/main/cpp/symbols_linux.h
+++ b/ddprof-lib/src/main/cpp/symbols_linux.h
@@ -153,6 +153,10 @@ private:
   }
 
   ElfSection *section(int index) {
+    if (index >= _header->e_shnum) {
+      // invalid section index
+      return NULL;
+    }
     return (ElfSection *)(_sections + index * _header->e_shentsize);
   }
 

--- a/ddprof-lib/src/main/cpp/symbols_linux.h
+++ b/ddprof-lib/src/main/cpp/symbols_linux.h
@@ -122,10 +122,29 @@ static const bool MUSL = true;
 static const bool MUSL = false;
 #endif // __musl__
 
-enum RootSymbolKind {
-  _start, start_thread, _ZL19thread_native_entryP6Thread, _thread_start, thread_start,
-  LAST_ROOT_SYMBOL_KIND
+#define ROOT_SYMBOL_KIND(X)                                                  \
+  X(_start, "_start")                                                        \
+  X(start_thread, "start_thread")                                            \
+  X(_ZL19thread_native_entryP6Thread, "_ZL19thread_native_entryP6Thread")    \
+  X(_thread_start, "_thread_start")                                          \
+  X(thread_start, "thread_start")
+
+#define X_ENUM(a, b) a,
+typedef enum RootSymbolKind : int {
+  ROOT_SYMBOL_KIND(X_ENUM) LAST_ROOT_SYMBOL_KIND
+} RootSymbolKind;
+#undef X_ENUM
+
+typedef struct {
+  const char* name;
+  RootSymbolKind kind;
+} RootSymbolEntry;
+
+#define X_ENTRY(a, b) { b, a },
+static const RootSymbolEntry root_symbol_table[] = {
+  ROOT_SYMBOL_KIND(X_ENTRY)
 };
+#undef X_ENTRY
 
 class ElfParser {
 friend Symbols;

--- a/ddprof-lib/src/main/cpp/symbols_macos.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_macos.cpp
@@ -180,4 +180,9 @@ void Symbols::parseLibraries(CodeCacheArray *array, bool kernel_symbols) {
   }
 }
 
+bool Symbols::isRootSymbol(const void* address) {
+  // no known 'always-root' symbols
+  return false;
+}
+
 #endif // __APPLE__

--- a/ddprof-lib/src/main/cpp/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/vmStructs.h
@@ -162,10 +162,6 @@ protected:
   static void initUnsafeFunctions();
   static void initMemoryUsage(JNIEnv *env);
 
-  static bool goodPtr(const void* ptr) {
-    return (uintptr_t)ptr >= 0x1000 && ((uintptr_t)ptr & (sizeof(uintptr_t) - 1)) == 0;
-  }
-
   const char *at(int offset) { return (const char *)this + offset; }
 
   static bool aligned(const void *ptr) {
@@ -184,6 +180,10 @@ private:
   static bool isFlagTrue(const char *name);
 
 public:
+  static bool goodPtr(const void* ptr) {
+    return (uintptr_t)ptr >= 0x1000 && ((uintptr_t)ptr & (sizeof(uintptr_t) - 1)) == 0;
+  }
+
   static void init(CodeCache *libjvm);
   static void ready();
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/AbstractProfilerTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/AbstractProfilerTest.java
@@ -208,7 +208,7 @@ public abstract class AbstractProfilerTest {
   protected void after() throws Exception {
   }
 
-  protected final boolean isInCI() {
+  public static final boolean isInCI() {
     return Boolean.getBoolean("ddprof_test.ci");
   }
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/CTimerSamplerTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/CTimerSamplerTest.java
@@ -43,7 +43,7 @@ public class CTimerSamplerTest extends CStackAwareAbstractProfilerTest {
 
     @RetryTest(10)
     @TestTemplate
-    @ValueSource(strings = {"fp", "dwarf", "vm", "vmx"})
+    @ValueSource(strings = {"vm", "vmx", "fp", "dwarf"})
     public void test(@CStack String cstack) throws ExecutionException, InterruptedException {
         // timer_create is available on Linux only
         assumeTrue(Platform.isLinux());

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/ContextCpuTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/ContextCpuTest.java
@@ -42,7 +42,7 @@ public class ContextCpuTest extends CStackAwareAbstractProfilerTest {
 
     @RetryTest(10)
     @TestTemplate
-    @ValueSource(strings = {"fp", "dwarf", "vm", "vmx"})
+    @ValueSource(strings = {"vm", "vmx", "fp", "dwarf"})
     public void test(@CStack String cstack) throws ExecutionException, InterruptedException {
         Assumptions.assumeTrue(!Platform.isJ9());
         for (int i = 0, id = 1; i < 100; i++, id += 3) {

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/IOBoundCode.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/IOBoundCode.java
@@ -68,10 +68,12 @@ public class IOBoundCode {
         try (ServerSocket s = new ServerSocket(0)) {
             String host = "localhost";
             int port = s.getLocalPort();
-            new IdleClient(host, port).start();
+            Thread t1 = new IdleClient(host, port);
+            t1.start();
             OutputStream idleClient = s.accept().getOutputStream();
 
-            new BusyClient(host, port).start();
+            Thread t2 = new BusyClient(host, port);
+            t2.start();
             OutputStream busyClient = s.accept().getOutputStream();
 
             byte[] buf = new byte[4096];
@@ -85,6 +87,8 @@ public class IOBoundCode {
                     busyClient.write(buf);
                 }
                 if (System.nanoTime() >= target) {
+                    t1.interrupt();
+                    t2.interrupt();
                     break;
                 }
             }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/IOBoundCode.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/IOBoundCode.java
@@ -1,0 +1,93 @@
+package com.datadoghq.profiler.cpu;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class IOBoundCode {
+    private static final class IdleClient extends Thread {
+        private final String host;
+        private final int port;
+
+        public IdleClient(String host, int port) {
+            this.host = host;
+            this.port = port;
+            setDaemon(true);
+        }
+
+        @Override
+        public void run() {
+            try {
+                byte[] buf = new byte[4096];
+
+                try (Socket s = new Socket(host, port)) {
+                    InputStream in = s.getInputStream();
+                    while (in.read(buf) >= 0) {
+                        // keep reading
+                    }
+                    System.out.println(Thread.currentThread().getName() + " stopped");
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private static final class BusyClient extends Thread {
+        private final String host;
+        private final int port;
+
+        public BusyClient(String host, int port) {
+            this.host = host;
+            this.port = port;
+            setDaemon(true);
+        }
+
+        @Override
+        public void run() {
+            try {
+                byte[] buf = new byte[4096];
+
+                try (Socket s = new Socket(host, port)) {
+
+                    InputStream in = s.getInputStream();
+                    while (in.read(buf) >= 0) {
+                        // keep reading
+                    }
+                    System.out.println(Thread.currentThread().getName() + " stopped");
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    void run() throws Exception {
+        try (ServerSocket s = new ServerSocket(0)) {
+            String host = "localhost";
+            int port = s.getLocalPort();
+            new IdleClient(host, port).start();
+            OutputStream idleClient = s.accept().getOutputStream();
+
+            new BusyClient(host, port).start();
+            OutputStream busyClient = s.accept().getOutputStream();
+
+            byte[] buf = new byte[4096];
+            ThreadLocalRandom.current().nextBytes(buf);
+
+            long target = System.nanoTime() + 3_000_000_000L;
+            for (int i = 0; ; i++) {
+                if ((i % 10_000_000) == 0) {
+                    idleClient.write(buf, 0, 1);
+                } else {
+                    busyClient.write(buf);
+                }
+                if (System.nanoTime() >= target) {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/SmokeCpuTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/SmokeCpuTest.java
@@ -21,24 +21,48 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.datadoghq.profiler.Platform;
 
 public class SmokeCpuTest extends CStackAwareAbstractProfilerTest {
-    private ProfiledCode profiledCode;
-
     public SmokeCpuTest(@CStack String cstack) {
         super(cstack);
-    }
-
-    @Override
-    protected void before() {
-        profiledCode = new ProfiledCode(profiler);
     }
 
     @RetryTest(10)
     @TestTemplate
     @ValueSource(strings = {"fp", "dwarf", "vm", "vmx"})
-    public void test(@CStack String cstack) throws ExecutionException, InterruptedException {
-        for (int i = 0, id = 1; i < 100; i++, id += 3) {
-            profiledCode.method1(id);
+    public void testComputations(@CStack String cstack) throws Exception {
+        try (ProfiledCode profiledCode = new ProfiledCode(profiler)) {
+            for (int i = 0, id = 1; i < 100; i++, id += 3) {
+                profiledCode.method1(id);
+            }
+            stopProfiler();
+
+            verifyCStackSettings();
+
+            IItemCollection events = verifyEvents("datadog.ExecutionSample");
+
+            // on mac the usage of itimer to drive the sampling provides very unreliable outputs
+            for (IItemIterable cpuSamples : events) {
+                IMemberAccessor<String, IItem> frameAccessor = JdkAttributes.STACK_TRACE_STRING.getAccessor(cpuSamples.getType());
+                for (IItem sample : cpuSamples) {
+                    String stackTrace = frameAccessor.getMember(sample);
+                    assertFalse(stackTrace.contains("jvmtiError"));
+                    if ("vmx".equals(stackTrace)) {
+                        // extra checks to make sure we see the mixed stacktraces
+                        assertTrue(stackTrace.contains("JavaCalls::call_virtual()"),
+                                "JavaCalls::call_virtual() (above call_stub) found in stack trace");
+                        assertTrue(stackTrace.contains("call_stub()"),
+                                "call_stub() (sentinel value used to halt unwinding) found in stack trace");
+                    }
+                }
+            }
         }
+    }
+
+    @RetryTest(10)
+    @TestTemplate
+    @ValueSource(strings = {"vm", "fp", "dwarf", "vmx"})
+    public void testIOBound(@CStack String cstack) throws Exception {
+        new IOBoundCode().run();
+
         stopProfiler();
 
         verifyCStackSettings();
@@ -60,11 +84,6 @@ public class SmokeCpuTest extends CStackAwareAbstractProfilerTest {
                 }
             }
         }
-    }
-
-    @Override
-    protected void after() throws Exception {
-        profiledCode.close();
     }
 
     @Override

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/SmokeCpuTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/SmokeCpuTest.java
@@ -27,7 +27,7 @@ public class SmokeCpuTest extends CStackAwareAbstractProfilerTest {
 
     @RetryTest(10)
     @TestTemplate
-    @ValueSource(strings = {"fp", "dwarf", "vm", "vmx"})
+    @ValueSource(strings = {"vm", "vmx", "fp", "dwarf"})
     public void testComputations(@CStack String cstack) throws Exception {
         try (ProfiledCode profiledCode = new ProfiledCode(profiler)) {
             for (int i = 0, id = 1; i < 100; i++, id += 3) {
@@ -59,7 +59,7 @@ public class SmokeCpuTest extends CStackAwareAbstractProfilerTest {
 
     @RetryTest(10)
     @TestTemplate
-    @ValueSource(strings = {"vm", "fp", "dwarf", "vmx"})
+    @ValueSource(strings = {"vm", "vmx", "fp", "dwarf"})
     public void testIOBound(@CStack String cstack) throws Exception {
         new IOBoundCode().run();
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/junit/CStackInjector.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/junit/CStackInjector.java
@@ -63,6 +63,13 @@ public class CStackInjector implements TestTemplateInvocationContextProvider {
         if (Platform.isAarch64() && !Platform.isJavaVersionAtLeast(17)) {
             return mode.startsWith("vm");
         }
+        if (AbstractProfilerTest.isInCI()) {
+            if (Platform.isMusl() && !Platform.isAarch64()) {
+                // our CI runner for musl on x64 is iffy and inexplicably locks up
+                //   randomly when doing vm stackwalking
+                return !mode.startsWith("vm");
+            }
+        }
         return true;
     }
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/junit/CStackInjector.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/junit/CStackInjector.java
@@ -51,9 +51,19 @@ public class CStackInjector implements TestTemplateInvocationContextProvider {
             return Stream.of(new ParameterizedTestContext("no", retryCount));
         } else {
             return Stream.of(valueSource.strings()).
-                    filter(param -> (!Platform.isJ9() || "dwarf".equals(param))).
+                    filter(CStackInjector::isModeSafe).
                     map(param -> new ParameterizedTestContext(param, retryCount));
         }
+    }
+
+    private static boolean isModeSafe(String mode) {
+        if (Platform.isJ9()) {
+            return "dwarf".equals(mode);
+        }
+        if (Platform.isAarch64() && !Platform.isJavaVersionAtLeast(17)) {
+            return mode.startsWith("vm");
+        }
+        return true;
     }
 
     public static class TestInfoAdapter implements TestInfo {

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/metadata/BoundMethodHandleMetadataSizeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/metadata/BoundMethodHandleMetadataSizeTest.java
@@ -22,6 +22,7 @@ public class BoundMethodHandleMetadataSizeTest extends AbstractProfilerTest {
     @Test
     public void test() throws Throwable {
         assumeFalse(Platform.isJ9() && Platform.isJavaVersion(17)); // JVMTI::GetClassSignature() is reliably crashing on a valid 'class' instance ¯\_(ツ)_/¯
+        assumeFalse(Platform.isAarch64() && Platform.isMusl() && !Platform.isJavaVersionAtLeast(11)); // aarch64 + musl + jdk 8 will crash very often
         registerCurrentThreadForWallClockProfiling();
         int numBoundMethodHandles = 10_000;
         int x = generateBoundMethodHandles(numBoundMethodHandles);

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContendedWallclockSamplesTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContendedWallclockSamplesTest.java
@@ -52,12 +52,6 @@ public class ContendedWallclockSamplesTest extends CStackAwareAbstractProfilerTe
     @ValueSource(strings = {"fp", "dwarf", "vm", "vmx"})
     public void test(@CStack String cstack) {
         assumeFalse(Platform.isZing() || Platform.isJ9());
-        // on aarch64 and JDK 8 the vmstructs unwinding for wallclock is extremely unreliable
-        //   ; perhaps due to something missing in the unwinder but until we figure it out we will just not run the tests in CI
-        assumeTrue(!isInCI() || !Platform.isAarch64() || !cstack.startsWith("vm") || Platform.isJavaVersionAtLeast(11));
-        // TODO: investigate why this test fails on musl
-        // on musl the missing fp unwinding makes the wallclock tests unreliable
-        assumeTrue(!Platform.isMusl() || !cstack.startsWith("vm"));
 
         long result = 0;
         for (int i = 0; i < 10; i++) {

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContendedWallclockSamplesTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContendedWallclockSamplesTest.java
@@ -49,7 +49,7 @@ public class ContendedWallclockSamplesTest extends CStackAwareAbstractProfilerTe
 
     @RetryTest(10)
     @TestTemplate
-    @ValueSource(strings = {"fp", "dwarf", "vm", "vmx"})
+    @ValueSource(strings = {"vm", "vmx", "fp", "dwarf"})
     public void test(@CStack String cstack) {
         assumeFalse(Platform.isZing() || Platform.isJ9());
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContextWallClockTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContextWallClockTest.java
@@ -31,7 +31,7 @@ public class ContextWallClockTest extends CStackAwareAbstractProfilerTest {
 
     @RetryTest(5)
     @TestTemplate
-    @ValueSource(strings = {"fp", "dwarf", "vmx", "vm"})
+    @ValueSource(strings = {"vm", "vmx", "fp", "dwarf"})
     public void test(@CStack String cstack) throws ExecutionException, InterruptedException, Exception {
         base.test(this);
     }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContextWallClockTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContextWallClockTest.java
@@ -31,14 +31,8 @@ public class ContextWallClockTest extends CStackAwareAbstractProfilerTest {
 
     @RetryTest(5)
     @TestTemplate
-    @ValueSource(strings = {"fp", "dwarf", "vm", "vmx"})
-    public void test(@CStack String cstack) throws ExecutionException, InterruptedException {
-        // on aarch64 and JDK < 17 the vmstructs unwinding for wallclock is extremely unreliable
-        //   ; perhaps due to something missing in the unwinder but until we figure it out we will just not run the tests in CI
-        assumeTrue(!isInCI() || !Platform.isAarch64() || !cstack.startsWith("vm") || Platform.isJavaVersionAtLeast(17));
-        // TODO: investigate why this test fails on musl
-        // on musl the missing fp unwinding makes the wallclock tests unreliable
-        assumeTrue(!Platform.isMusl() || !cstack.startsWith("vm"));
+    @ValueSource(strings = {"fp", "dwarf", "vmx", "vm"})
+    public void test(@CStack String cstack) throws ExecutionException, InterruptedException, Exception {
         base.test(this);
     }
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/SmokeWallTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/SmokeWallTest.java
@@ -32,7 +32,7 @@ public class SmokeWallTest extends CStackAwareAbstractProfilerTest {
 
     @RetryTest(10)
     @TestTemplate
-    @ValueSource(strings = {"fp", "dwarf", "vm", "vmx"})
+    @ValueSource(strings = {"vm", "vmx", "fp", "dwarf"})
     public void test(@CStack String cstack) throws ExecutionException, InterruptedException {
         for (int i = 0, id = 1; i < 100; i++, id += 3) {
             profiledCode.method1(id);


### PR DESCRIPTION
**What does this PR do?**:
It addresses the shortcomings of the current implementation of the vmstructs stack walker on aarch64, clang and musl and their combinations.

**Motivation**:
Iron out the last wrinkles on the vmstructs based stack walker such we can even consider using it as default.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-11294], [PROF-11299]

Unsure? Have a question? Request a review!


[PROF-11294]: https://datadoghq.atlassian.net/browse/PROF-11294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROF-11299]: https://datadoghq.atlassian.net/browse/PROF-11299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ