### PR TITLE
Increase number of stack frames for synthetic frames, port of 6c0aff4

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -601,7 +601,7 @@ u32 Profiler::recordJVMTISample(u64 counter, int tid, jthread thread, jint event
 
     int num_frames = 0;
 
-    if (VM::jvmti()->GetStackTrace(thread, 0, _max_stack_depth, jvmti_frames, &num_frames) == JVMTI_ERROR_NONE && num_frames > 0) {
+    if (VM::jvmti()->GetStackTrace(thread, 0, max_depth, jvmti_frames, &num_frames) == JVMTI_ERROR_NONE && num_frames > 0) {
       // Convert to AsyncGetCallTrace format.
       // Note: jvmti_frames and frames may overlap.
       for (int i = 0; i < num_frames; i++) {

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -37,7 +37,7 @@ __asm__(".symver exp,exp@GLIBC_2.17");
 #endif
 
 const int MAX_NATIVE_FRAMES = 128;
-const int RESERVED_FRAMES = 4;
+const int RESERVED_FRAMES = 10;
 
 enum EventMask { EM_CPU = 1 << 0, EM_WALL = 1 << 1, EM_ALLOC = 1 << 2 };
 


### PR DESCRIPTION
**What does this PR do?**:
Ports over commit `6c0aff4`, identified as of interest during our downporting preparation


**For Datadog employees**:
- [] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-11143]

Unsure? Have a question? Request a review!


[PROF-11143]: https://datadoghq.atlassian.net/browse/PROF-11143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ