### PR TITLE
Cherry-pick 6c0aff4

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -37,7 +37,7 @@ __asm__(".symver exp,exp@GLIBC_2.17");
 #endif
 
 const int MAX_NATIVE_FRAMES = 128;
-const int RESERVED_FRAMES = 4;
+const int RESERVED_FRAMES   = 10;  // for synthetic frames
 
 enum EventMask { EM_CPU = 1 << 0, EM_WALL = 1 << 1, EM_ALLOC = 1 << 2 };
 


### PR DESCRIPTION
**What does this PR do?**:
This picks https://github.com/async-profiler/async-profiler/commit/6c0aff487bc86fcaabbc21f8b020e25b1ddf5ea3 to our repo (increase number of reserved frames).


**Additional Notes**:
This constant is used in slightly different codepaths compared to the AP codebase. @jbachorik and I have discussed what this cherry pick + merge should look like and settled on only changing the constant.

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
- [x] JIRA: [PROF-11143]

Unsure? Have a question? Request a review!


[PROF-11143]: https://datadoghq.atlassian.net/browse/PROF-11143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ