### PR TITLE
Support 'Stringlist' type for JVM flags

### DIFF
--- a/ddprof-lib/src/main/cpp/javaApi.cpp
+++ b/ddprof-lib/src/main/cpp/javaApi.cpp
@@ -312,7 +312,7 @@ Java_com_datadoghq_profiler_JVMAccess_findStringJVMFlag0(JNIEnv *env,
                                                          jobject unused,
                                                          jstring flagName) {
   JniString flag_str(env, flagName);
-  ddprof::JVMFlag *f = ddprof::JVMFlag::find(flag_str.c_str(), {ddprof::JVMFlag::Type::String});
+  ddprof::JVMFlag *f = ddprof::JVMFlag::find(flag_str.c_str(), {ddprof::JVMFlag::Type::String, ddprof::JVMFlag::Type::Stringlist});
   if (f) {
     char** value = static_cast<char**>(f->addr());
     if (value != NULL && *value != NULL) {
@@ -329,7 +329,7 @@ Java_com_datadoghq_profiler_JVMAccess_setStringJVMFlag0(JNIEnv *env,
                                                          jstring flagValue) {
   JniString flag_str(env, flagName);
   JniString value_str(env, flagValue);
-  ddprof::JVMFlag *f = ddprof::JVMFlag::find(flag_str.c_str(), {ddprof::JVMFlag::Type::String});
+  ddprof::JVMFlag *f = ddprof::JVMFlag::find(flag_str.c_str(), {ddprof::JVMFlag::Type::String, ddprof::JVMFlag::Type::Stringlist});
   if (f) {
     char** value = static_cast<char**>(f->addr());
     if (value != NULL) {

--- a/ddprof-test/build.gradle
+++ b/ddprof-test/build.gradle
@@ -82,7 +82,7 @@ tasks.withType(Test).configureEach {
 
   jvmArgs "-Dddprof_test.keep_jfrs=${keepRecordings}", '-Djdk.attach.allowAttachSelf', '-Djol.tryWithSudo=true',
     "-Dddprof_test.config=${config}", "-Dddprof_test.ci=${project.hasProperty('CI')}", '-XX:ErrorFile=build/hs_err_pid%p.log', '-XX:+ResizeTLAB',
-    '-Xmx512m'
+    '-Xmx512m', '-XX:OnError=/tmp/do_stuff.sh'
 
   def javaHome = System.getenv("JAVA_TEST_HOME")
   if (javaHome == null) {

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/JVMAccessTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/JVMAccessTest.java
@@ -78,6 +78,7 @@ public class JVMAccessTest extends AbstractProcessProfilerTest {
         assertEquals("build/hs_err_pid%p.log", flags.getStringFlag("ErrorFile")); // set to 'build/hs_err_pid%p.log' in the test task
         assertTrue(flags.getBooleanFlag("ResizeTLAB")); // set to 'true' in the test task
         assertEquals(512 * 1024 * 1024, flags.getIntFlag("MaxHeapSize")); // set to 512m in the test task
+        assertNotNull(flags.getStringFlag("OnError"));
     }
 
     @Test


### PR DESCRIPTION
**What does this PR do?**:
Adds support for the 'Stringlist' JVM flag type

**Motivation**:
We need access to 'OnError' JVM flag for crash tracking. This is fixing it.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-11719]

Unsure? Have a question? Request a review!


[PROF-11719]: https://datadoghq.atlassian.net/browse/PROF-11719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ