### PR TITLE
Fix #200 Crash related to aligned_alloc and free in context

### DIFF
--- a/ddprof-lib/src/main/cpp/context.h
+++ b/ddprof-lib/src/main/cpp/context.h
@@ -52,7 +52,7 @@ class Contexts {
 private:
   static int _max_pages;
   static Context **_pages;
-  static void initialize(int pageIndex);
+  static bool initialize(int pageIndex);
 
 public:
   // get must not allocate

--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -43,6 +43,7 @@
   X(CONTEXT_BOUNDS_MISS_GETS, "context_bounds_miss_gets")                      \
   X(CONTEXT_CHECKSUM_REJECT_GETS, "context_checksum_reject_gets")              \
   X(CONTEXT_NULL_PAGE_GETS, "context_null_page_gets")                          \
+  X(CONTEXT_ALLOC_FAILS, "context_alloc_fails")                                \
   X(CALLTRACE_STORAGE_BYTES, "calltrace_storage_bytes")                        \
   X(CALLTRACE_STORAGE_TRACES, "calltrace_storage_traces")                      \
   X(LINEAR_ALLOCATOR_BYTES, "linear_allocator_bytes")                          \

--- a/ddprof-lib/src/main/cpp/javaApi.cpp
+++ b/ddprof-lib/src/main/cpp/javaApi.cpp
@@ -144,6 +144,9 @@ Java_com_datadoghq_profiler_JavaProfiler_getContextPage0(JNIEnv *env,
                                                          jobject unused,
                                                          jint tid) {
   ContextPage page = Contexts::getPage((int)tid);
+  if (page.storage == 0) {
+    return NULL;
+  }
   return env->NewDirectByteBuffer((void *)page.storage, (jlong)page.capacity);
 }
 


### PR DESCRIPTION
Hi, Could I have a review of this patch ?

**What does this PR do?**:
Fix #200 

**Motivation**:
Replace `aligned_alloc` with `posix_memalign`

**Additional Notes**:
If `posix_memalign` can not alloc memory and returns a none-zero, we should avoid subsequent memory access, so return an empty `ContextPage` and the Java code check for this.

**How to test the change?**:
The following tests are passed:
- gradle test
- gradle testRelease

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
