### PR TITLE
Explicitly initialize empty context page

### DIFF
--- a/ddprof-lib/src/main/cpp/context.cpp
+++ b/ddprof-lib/src/main/cpp/context.cpp
@@ -87,7 +87,7 @@ ContextPage Contexts::getPage(int tid) {
     return {.capacity = DD_CONTEXT_PAGE_SIZE * sizeof(Context),
       .storage = _pages[pageIndex]};
   } else {
-    return {};
+    return {.capacity = 0, .storage = NULL};
   }
 }
 


### PR DESCRIPTION
(followup to #308)

**What does this PR do?**:
It fixes compilation error on an old g++

**Motivation**:
We need to build on some rather old systems for compatibility sakes and it requires explicit initialization of the struct


Unsure? Have a question? Request a review!
