### PR TITLE
Re-connect crash recursion protection with VM stackwalker

### DIFF
--- a/ddprof-lib/build.gradle
+++ b/ddprof-lib/build.gradle
@@ -143,6 +143,9 @@ def copyUpstreamFiles = tasks.register('copyUpstreamFiles', Copy) {
   configure {
     dependsOn cloneAPTask
   }
+  onlyIf {
+    !project.hasProperty("debug-ap")
+  }
   description = 'Copy shared upstream files'
   from("${projectDir}/build/async-profiler/src") {
     include "arch.h"

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -910,7 +910,7 @@ bool Profiler::crashHandler(int signo, siginfo_t *siginfo, void *ucontext) {
   if (VM::isHotspot()) {
     // the following checks require vmstructs and therefore HotSpot
 
-    StackWalker::checkFault();
+    ddprof::StackWalker::checkFault(thrd);
 
     // Workaround for JDK-8313796. Setting cstack=dwarf also helps
     if (VMStructs::isInterpretedFrameValidFunc((const void *)pc) &&


### PR DESCRIPTION
**What does this PR do?**:
It fixes an omission from the migration to the vanilla upstream stackwalker implementations.
Our stackwalker was providing a callback to reset the crash handler recursion protection when it needed to longjump to recover. Without that, it is easier to get into an inconsistent state when sooner or later the segfaults won't get handled because the protection thinks we are recursing too deeply.

**Motivation**:
Fix up the omission from the migration. Fix the problems we are seeing in some services.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
Testing is rather cumbersome. We would have to simulate segfault in the vm stackwalking code and make sure we are properly resetting the tracking.
I did this manually by patching `VMMethod:id()` to dereference a nullptr. Without this patch I will get an immediate crash - with this patch everything works as expected.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-11839]

Unsure? Have a question? Request a review!


[PROF-11839]: https://datadoghq.atlassian.net/browse/PROF-11839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ