### PR TITLE
Add a test for crash-recovery in the 'vm' stackwalker.

### DIFF
--- a/ddprof-test/src/test/java/com/datadoghq/profiler/ExternalLauncher.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/ExternalLauncher.java
@@ -1,7 +1,25 @@
 package com.datadoghq.profiler;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.Random;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * External launcher for the profiler under test.
+ * <p>
+ * This class is used to launch the profiler in a separate process for testing purposes.
+ * </p>
+ * The main method takes the following arguments:
+ * <ul>
+ *     <li>library - loads the profiler library</li>
+ *     <li>profiler [comma delimited profiler command list] - starts the profiler</li>
+ *     <li>profiler-work:<expectedCpuTime> [comma delimited profiler command list] - starts the profiler and runs a CPU-intensive task</li>
+ * </ul>
+ */
 public class ExternalLauncher {
     public static void main(String[] args) throws Exception {
+        Thread worker = null;
         try {
             if (args.length < 1) {
                 throw new RuntimeException();
@@ -16,6 +34,35 @@ public class ExternalLauncher {
                         instance.execute(commands);
                     }
                 }
+            } else if (args[0].startsWith("profiler-work:")) {
+                long expectedCpuTime = Long.parseLong(args[0].substring("profiler-work:".length()));
+                ThreadMXBean thrdBean = ManagementFactory.getThreadMXBean();
+                JavaProfiler instance = JavaProfiler.getInstance();
+                if (args.length == 2) {
+                    String commands = args[1];
+                    if (!commands.isEmpty()) {
+                        instance.execute(commands);
+                        worker = new Thread(() -> {
+                            Random rnd = new Random();
+                            LongAdder adder = new LongAdder();
+                            long counter = 0;
+                            long cpuTime = thrdBean.getThreadCpuTime(Thread.currentThread().getId());
+                            while (!Thread.currentThread().isInterrupted()) {
+                                adder.add(rnd.nextLong());
+                                // make sure we caused some CPU load and print the progress
+                                if (++counter % 1000000 == 0) {
+                                    if (thrdBean.getThreadCpuTime(Thread.currentThread().getId()) - cpuTime > expectedCpuTime * 1_000_000L) {
+                                        cpuTime = thrdBean.getThreadCpuTime(Thread.currentThread().getId());
+                                        System.out.println("[working]");
+                                        System.out.flush();
+                                    }
+                                }
+                            }
+                            System.out.println("[async] " + adder.sum());
+                        });
+                        worker.start();
+                    }
+                }
             }
         } finally {
             System.out.println("[ready]");
@@ -24,5 +71,9 @@ public class ExternalLauncher {
         }
         // wait for signal to exit
         System.in.read();
+        if (worker != null) {
+            worker.interrupt();
+            worker.join();
+        }
     }
 }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/JVMAccessTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/JVMAccessTest.java
@@ -29,10 +29,10 @@ public class JVMAccessTest extends AbstractProcessProfilerTest {
             l -> {
                 initLibraryFound.set(initLibraryFound.get() | l.contains("[TEST::INFO] VM::initLibrary"));
                 initProfilerFound.set(initProfilerFound.get() | l.contains("[TEST::INFO] VM::initProfilerBridge"));
-                return true;
+                return LineConsumerResult.CONTINUE;
             },
             null
-        );
+        ).inTime;
 
         assertTrue(rslt);
 
@@ -57,10 +57,10 @@ public class JVMAccessTest extends AbstractProcessProfilerTest {
         boolean rslt = launch("library", Collections.emptyList(), null, l -> {
             if (l.contains("[TEST::INFO] jvm_version#")) {
                 foundVersion.set(l.split("#")[1]);
-                return false;
+                return LineConsumerResult.STOP;
             }
-            return true;
-        }, null);
+            return LineConsumerResult.CONTINUE;
+        }, null).inTime;
 
         assertTrue(rslt);
 


### PR DESCRIPTION
**What does this PR do?**:
This adds a smoke test for the crash-recovery mechanism used in the 'vm' stackwalker

**Motivation**:
A followup for bugfix #214 

**How to test the change?**:
The test runs automatically

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-11839]

Unsure? Have a question? Request a review!


[PROF-11839]: https://datadoghq.atlassian.net/browse/PROF-11839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ