### PR TITLE
Patch upstream stackWalker.cpp not to fail on unaligned access

### DIFF
--- a/ddprof-lib/build.gradle
+++ b/ddprof-lib/build.gradle
@@ -215,9 +215,34 @@ def patchStackFrame = tasks.register("patchStackFrame") {
   }
 }
 
+def patchStackWalker = tasks.register("patchStackWalker") {
+  description = 'Patch stackWalker.cpp after copying'
+  configure {
+    dependsOn copyUpstreamFiles
+  }
+  doLast {
+    def file = file("${projectDir}/src/main/cpp-external/stackWalker.cpp")
+    if (!file.exists()) throw new GradleException("File not found: ${file}")
+
+    def content = file.getText('UTF-8')
+    def original = content
+
+    // Add no_sanitize to walkVM
+    content = content.replaceAll(
+      /(int\s+StackWalker::walkVM\s*\()/,
+      '__attribute__((no_sanitize("address"))) int StackWalker::walkVM('
+      )
+
+    if (content != original) {
+      file.write(content, 'UTF-8')
+      println "Patched stackWalker.cpp"
+    }
+  }
+}
+
 def initSubrepoTask = tasks.register('initSubrepo') {
   configure {
-    dependsOn copyUpstreamFiles, patchStackFrame
+    dependsOn copyUpstreamFiles, patchStackFrame, patchStackWalker
   }
 }
 


### PR DESCRIPTION
**Motivation**:
Nightly sanitized tests are failing consistently for  Java 21 JVMCI on aarch64 due to unaligned access in vm stackwalking.
This is adding a patch to suppress asan address check in `walkVM` function.


Unsure? Have a question? Request a review!
