### PR TITLE
Remap thread id to avoid bitmap contention

### DIFF
--- a/ddprof-lib/src/main/cpp/threadFilter.h
+++ b/ddprof-lib/src/main/cpp/threadFilter.h
@@ -45,6 +45,8 @@ private:
         __ATOMIC_ACQUIRE);
   }
 
+  static int hashThreadId(int thread_id);
+
   u64 &word(u64 *bitmap, int thread_id) {
     // todo: add thread safe APIs
     return bitmap[((u32)thread_id % BITMAP_CAPACITY) >> 6];


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->

An application starts a few threads in short period of windows, the newly created threads are likely to have consecutive or close thread ids. When  `ThreadFilter` maps them to the bits on bitmap, there is high chance that they may be mapped to a single cache line, that results cache line contention when updating the bitmap concurrently.

The PR purposes to remap thread id  by swapping lower 2 bytes of thread id, so that consecutive/close thread ids map to different cache lines.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

Reduce cache line contention, improve performance.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
