### PR TITLE
improve performance using Unsafe to activate/deactivate thread filter

### DIFF
--- a/ddprof-lib/src/main/cpp/javaApi.cpp
+++ b/ddprof-lib/src/main/cpp/javaApi.cpp
@@ -406,3 +406,24 @@ Java_com_datadoghq_profiler_JVMAccess_healthCheck0(JNIEnv *env,
                                                          jobject unused) {
   return true;
 }
+
+extern "C" DLLEXPORT jlong JNICALL
+Java_com_datadoghq_profiler_ActiveBitmap_bitmapAddressFor0(JNIEnv *env,
+		                                     jclass unused,
+						     jint tid) {
+  u64* bitmap = Profiler::instance()->threadFilter()->bitmapAddressFor((int)tid);
+  return (jlong)bitmap;
+}
+
+extern "C" DLLEXPORT jboolean JNICALL
+Java_com_datadoghq_profiler_ActiveBitmap_isActive0(JNIEnv *env,
+                                                   jclass unused,
+                                                   jint tid) {
+  return Profiler::instance()->threadFilter()->accept((int)tid) ? JNI_TRUE : JNI_FALSE;
+}
+
+extern "C" DLLEXPORT jlong JNICALL
+Java_com_datadoghq_profiler_ActiveBitmap_getActiveCountAddr0(JNIEnv *env,
+                                                              jclass unused) {
+  return (jlong)Profiler::instance()->threadFilter()->addressOfSize();
+}

--- a/ddprof-lib/src/main/cpp/reverse_bits.h
+++ b/ddprof-lib/src/main/cpp/reverse_bits.h
@@ -1,0 +1,23 @@
+//
+// Borrow the implementation from openjdk
+// https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/reverse_bits.hpp
+//
+
+#ifndef REVERSE_BITS_H
+#define REVERSE_BITS_H
+#include "arch_dd.h"
+#include <stdint.h>
+
+static constexpr u32 rep_5555 = static_cast<u32>(UINT64_C(0x5555555555555555));
+static constexpr u32 rep_3333 = static_cast<u32>(UINT64_C(0x3333333333333333));
+static constexpr u32 rep_0F0F = static_cast<u32>(UINT64_C(0x0F0F0F0F0F0F0F0F));
+
+inline u16 reverse16(u16 v) {
+  u32 x = static_cast<u32>(v);
+  x = ((x & rep_5555) << 1) | ((x >> 1) & rep_5555);
+  x = ((x & rep_3333) << 2) | ((x >> 2) & rep_3333);
+  x = ((x & rep_0F0F) << 4) | ((x >> 4) & rep_0F0F);
+  return __builtin_bswap16(static_cast<u16>(x));
+}
+
+#endif //REVERSE_BITS_H

--- a/ddprof-lib/src/main/cpp/threadFilter.cpp
+++ b/ddprof-lib/src/main/cpp/threadFilter.cpp
@@ -86,6 +86,8 @@ void ThreadFilter::clear() {
 }
 
 int ThreadFilter::mapThreadId(int thread_id) {
+  // We want to map the thread_id inside the same bitmap
+  static_assert(BITMAP_SIZE >= (u16)0xffff, "Potential verflow");
   u16 lower16 = (u16)(thread_id & 0xffff);
   lower16 = ((lower16 & 0x00ff) << 8) | ((lower16 & 0xff00) >> 8);
   int tid = (thread_id & ~0xffff) | lower16;

--- a/ddprof-lib/src/main/cpp/threadFilter.cpp
+++ b/ddprof-lib/src/main/cpp/threadFilter.cpp
@@ -86,6 +86,7 @@ void ThreadFilter::clear() {
   _size = 0;
 }
 
+// The mapping has to be reversible: f(f(x)) == x
 int ThreadFilter::mapThreadId(int thread_id) {
   // We want to map the thread_id inside the same bitmap
   static_assert(BITMAP_SIZE >= (u16)0xffff, "Potential verflow");

--- a/ddprof-lib/src/main/cpp/threadFilter.cpp
+++ b/ddprof-lib/src/main/cpp/threadFilter.cpp
@@ -17,7 +17,6 @@
 #include "threadFilter.h"
 #include "counters.h"
 #include "os.h"
-#include <cassert>
 #include <stdlib.h>
 #include <string.h>
 

--- a/ddprof-lib/src/main/cpp/threadFilter.cpp
+++ b/ddprof-lib/src/main/cpp/threadFilter.cpp
@@ -17,6 +17,7 @@
 #include "threadFilter.h"
 #include "counters.h"
 #include "os.h"
+#include "reverse_bits.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -89,7 +90,7 @@ int ThreadFilter::mapThreadId(int thread_id) {
   // We want to map the thread_id inside the same bitmap
   static_assert(BITMAP_SIZE >= (u16)0xffff, "Potential verflow");
   u16 lower16 = (u16)(thread_id & 0xffff);
-  lower16 = ((lower16 & 0x00ff) << 8) | ((lower16 & 0xff00) >> 8);
+  lower16 = reverse16(lower16);
   int tid = (thread_id & ~0xffff) | lower16;
   return tid; 
 }

--- a/ddprof-lib/src/main/cpp/threadFilter.h
+++ b/ddprof-lib/src/main/cpp/threadFilter.h
@@ -45,6 +45,8 @@ private:
         __ATOMIC_ACQUIRE);
   }
 
+  static int hashThreadId(int thread_id);
+
   u64 &word(u64 *bitmap, int thread_id) {
     // todo: add thread safe APIs
     return bitmap[((u32)thread_id % BITMAP_CAPACITY) >> 6];

--- a/ddprof-lib/src/main/cpp/threadFilter.h
+++ b/ddprof-lib/src/main/cpp/threadFilter.h
@@ -45,7 +45,7 @@ private:
         __ATOMIC_ACQUIRE);
   }
 
-  static int hashThreadId(int thread_id);
+  static int mapThreadId(int thread_id);
 
   u64 &word(u64 *bitmap, int thread_id) {
     // todo: add thread safe APIs

--- a/ddprof-lib/src/main/cpp/threadFilter.h
+++ b/ddprof-lib/src/main/cpp/threadFilter.h
@@ -52,14 +52,20 @@ private:
     return bitmap[((u32)thread_id % BITMAP_CAPACITY) >> 6];
   }
 
+  u64* const wordAddress(u64 *bitmap, int thread_id) const {
+    return &bitmap[((u32)thread_id % BITMAP_CAPACITY) >> 6];
+  }
+
+  u64* getBitmapFor(int thread_id);
 public:
   ThreadFilter();
   ThreadFilter(ThreadFilter &threadFilter) = delete;
   ~ThreadFilter();
 
-  bool enabled() { return _enabled; }
+  bool enabled() const { return _enabled; }
 
-  int size() { return _size; }
+  int size() const { return _size; }
+  const volatile int* addressOfSize() const { return &_size; }
 
   void init(const char *filter);
   void clear();
@@ -67,6 +73,7 @@ public:
   bool accept(int thread_id);
   void add(int thread_id);
   void remove(int thread_id);
+  u64* bitmapAddressFor(int thread_id);
 
   void collect(std::vector<int> &v);
 };

--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/ActiveBitmap.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/ActiveBitmap.java
@@ -1,0 +1,74 @@
+package com.datadoghq.profiler;
+
+import sun.misc.Unsafe;
+import java.lang.reflect.Field;
+
+
+class ActiveBitmap {
+    private static final Unsafe UNSAFE = JavaProfiler.UNSAFE;
+
+    // Address to size field of ThreadFilter in native
+    private static long activeCountAddr;
+
+    private static final ThreadLocal<Long> Address = new ThreadLocal<Long>() {
+        @Override protected Long initialValue() {
+            return -1L;
+        }
+    };
+
+    public static void initialize() {
+        activeCountAddr = getActiveCountAddr0();
+    }
+
+    // On native side, we reverse lower 16 bits of thread id when maps to bitmap bit.
+    // So the active bit position of the specific thread id maps to the reverse order
+    // of the second lowest byte of thread id.
+    static long getBitmask(int tid) {
+        int tmp = (tid >> 8) & 0xff ;
+        int bits = 0;
+        for (int index = 0; index < 7 ; index++) {
+            if ((tmp & 0x01) == 0x01) {
+                bits |= 0x01;
+            }
+            tmp >>= 1;
+            bits <<= 1;
+        }
+        return 1L << (bits & 0x3f);
+    }
+
+    static void setActive(int tid, boolean active) {
+        long addr = Address.get();
+        if (addr == -1) {
+            addr = bitmapAddressFor0(tid);
+            Address.set(addr);
+        }
+        long bitmask = getBitmask(tid);
+        long value = UNSAFE.getLong(addr);
+        long newVal;
+        if (active) {
+            newVal = value | bitmask;
+        } else {
+            newVal = value & ~bitmask;
+        }
+        while (!UNSAFE.compareAndSwapLong(null, addr, value, newVal)) {
+            value = UNSAFE.getLong(addr);
+            newVal = active ? (value | bitmask) : (value & ~bitmask);
+        }
+        int delta = active ? 1 : -1;
+        assert activeCountAddr != 0;
+        UNSAFE.getAndAddInt(null, activeCountAddr, delta);
+
+        assert isActive0(tid) == active;
+    }
+
+
+
+    // Address of bitmap word that contains the active bit of this thread Id
+    private static native long bitmapAddressFor0(int tid);
+
+    private static native long getActiveCountAddr0();
+
+    // For validation
+    private static native boolean isActive0(int tid);
+}
+

--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
@@ -34,17 +34,17 @@ import java.util.Map;
  * libjavaProfiler.so.
  */
 public final class JavaProfiler {
-    private static final Unsafe UNSAFE;
+    static final Unsafe UNSAFE;
+    static final boolean isJDK8;
     static {
         Unsafe unsafe = null;
         String version = System.getProperty("java.version");
-        if (version.startsWith("1.8")) {
-            try {
-                Field f = Unsafe.class.getDeclaredField("theUnsafe");
-                f.setAccessible(true);
-                unsafe = (Unsafe) f.get(null);
-            } catch (Exception ignore) { }
-        }
+        isJDK8 = version.startsWith("1.8");
+        try {
+            Field f = Unsafe.class.getDeclaredField("theUnsafe");
+            f.setAccessible(true);
+            unsafe = (Unsafe) f.get(null);
+        } catch (Exception ignore) { }
         UNSAFE = unsafe;
     }
 
@@ -108,6 +108,7 @@ public final class JavaProfiler {
             throw new IOException("Failed to load Datadog Java profiler library", result.error);
         }
         init0();
+        ActiveBitmap.initialize();
 
         profiler.initializeContextStorage();
         instance = profiler;
@@ -208,7 +209,11 @@ public final class JavaProfiler {
      * 'filter' option must be enabled to use this method.
      */
     public void addThread() {
-        filterThread0(true);
+        if (UNSAFE != null) {
+            ActiveBitmap.setActive(TID.get(), true);
+        } else {
+            filterThread0(true);
+        }
     }
 
     /**
@@ -216,7 +221,11 @@ public final class JavaProfiler {
      * 'filter' option must be enabled to use this method.
      */
     public void removeThread() {
-        filterThread0(false);
+        if (UNSAFE != null) {
+            ActiveBitmap.setActive(TID.get(), false);
+        } else {
+            filterThread0(false);
+        }
     }
 
 
@@ -229,7 +238,7 @@ public final class JavaProfiler {
      */
     public void setContext(long spanId, long rootSpanId) {
         int tid = TID.get();
-        if (UNSAFE != null) {
+        if (isJDK8) {
             setContextJDK8(tid, spanId, rootSpanId);
         } else {
             setContextByteBuffer(tid, spanId, rootSpanId);
@@ -304,7 +313,7 @@ public final class JavaProfiler {
      */
     public void setContextValue(int offset, int value) {
         int tid = TID.get();
-        if (UNSAFE != null) {
+        if (isJDK8) {
             setContextJDK8(tid, offset, value);
         } else {
             setContextByteBuffer(tid, offset, value);
@@ -335,7 +344,7 @@ public final class JavaProfiler {
 
     void copyTags(int[] snapshot) {
         int tid = TID.get();
-        if (UNSAFE != null) {
+        if (isJDK8) {
             copyTagsJDK8(tid, snapshot);
         } else {
             copyTagsByteBuffer(tid, snapshot);


### PR DESCRIPTION
**What does this PR do?**:
JavaProfiler activate/deactivate a thread for profiling via JNI call, which is expensive.

This enhancement intends to expose native bitmap, that is used for tracking thread’s state, to java and uses Unsafe API to update the bitmap directly.

**Motivation**:
Improve performance

**Additional Notes**:

Used Erwan's thread filter benchmark:

Baseline:
<img width="1038" alt="before" src="https://github.com/user-attachments/assets/fbf122f8-6891-431f-bede-0f00d2fe7134" />


After patch:
<img width="1044" alt="Screenshot 2025-06-16 at 10 10 35 AM" src="https://github.com/user-attachments/assets/a1d13d17-dd56-46dc-80ba-8a34dc7f11dd" />

**How to test the change?**:
- gradlew testdebug/testrelease
- ddprof-stresstest + Erwan's thread filter benchmark

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-12008](https://datadoghq.atlassian.net/browse/PROF-12008)

Unsure? Have a question? Request a review!
