### PR TITLE
Remap thread id to avoid bitmap contention

### DIFF
--- a/ddprof-lib/src/main/cpp/reverse_bits.h
+++ b/ddprof-lib/src/main/cpp/reverse_bits.h
@@ -1,0 +1,23 @@
+//
+// Borrow the implementation from openjdk
+// https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/reverse_bits.hpp
+//
+
+#ifndef REVERSE_BITS_H
+#define REVERSE_BITS_H
+#include "arch_dd.h"
+#include <stdint.h>
+
+static constexpr u32 rep_5555 = static_cast<u32>(UINT64_C(0x5555555555555555));
+static constexpr u32 rep_3333 = static_cast<u32>(UINT64_C(0x3333333333333333));
+static constexpr u32 rep_0F0F = static_cast<u32>(UINT64_C(0x0F0F0F0F0F0F0F0F));
+
+inline u16 reverse16(u16 v) {
+  u32 x = static_cast<u32>(v);
+  x = ((x & rep_5555) << 1) | ((x >> 1) & rep_5555);
+  x = ((x & rep_3333) << 2) | ((x >> 2) & rep_3333);
+  x = ((x & rep_0F0F) << 4) | ((x >> 4) & rep_0F0F);
+  return __builtin_bswap16(static_cast<u16>(x));
+}
+
+#endif //REVERSE_BITS_H

--- a/ddprof-lib/src/main/cpp/threadFilter.h
+++ b/ddprof-lib/src/main/cpp/threadFilter.h
@@ -45,11 +45,12 @@ private:
         __ATOMIC_ACQUIRE);
   }
 
+  static int mapThreadId(int thread_id);
+
   u64 &word(u64 *bitmap, int thread_id) {
     // todo: add thread safe APIs
     return bitmap[((u32)thread_id % BITMAP_CAPACITY) >> 6];
   }
-
 public:
   ThreadFilter();
   ThreadFilter(ThreadFilter &threadFilter) = delete;


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->

An application starts a few threads in short period of window, the newly created threads are likely to have consecutive or close thread ids. When  `ThreadFilter` maps them to the bits on bitmap, there are high chances that they may be mapped to a single cache line, that results cache line contention when updating the bitmap concurrently.

The PR purposes to remap thread id  by reversing lower 2 bytes of thread id, so that consecutive/close thread ids map to different cache lines.

The reason for only reversing lower 2 bytes, is that, thread id is remapped within the same bitmap.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

Reduce cache line contention, improve performance.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-12002](https://datadoghq.atlassian.net/browse/PROF-12002)

Unsure? Have a question? Request a review!

[PROF-12002]: https://datadoghq.atlassian.net/browse/PROF-12002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ