### PR TITLE
Improve performance using Unsafe to activate/deactivate thread filter

### DIFF
--- a/ddprof-lib/src/main/cpp/javaApi.cpp
+++ b/ddprof-lib/src/main/cpp/javaApi.cpp
@@ -406,3 +406,24 @@ Java_com_datadoghq_profiler_JVMAccess_healthCheck0(JNIEnv *env,
                                                          jobject unused) {
   return true;
 }
+
+extern "C" DLLEXPORT jlong JNICALL
+Java_com_datadoghq_profiler_ActiveBitmap_bitmapAddressFor0(JNIEnv *env,
+		                                                    jclass unused,
+						                                    jint tid) {
+  u64* bitmap = Profiler::instance()->threadFilter()->bitmapAddressFor((int)tid);
+  return (jlong)bitmap;
+}
+
+extern "C" DLLEXPORT jboolean JNICALL
+Java_com_datadoghq_profiler_ActiveBitmap_isActive0(JNIEnv *env,
+                                                   jclass unused,
+                                                   jint tid) {
+  return Profiler::instance()->threadFilter()->accept((int)tid) ? JNI_TRUE : JNI_FALSE;
+}
+
+extern "C" DLLEXPORT jlong JNICALL
+Java_com_datadoghq_profiler_ActiveBitmap_getActiveCountAddr0(JNIEnv *env,
+                                                              jclass unused) {
+  return (jlong)Profiler::instance()->threadFilter()->addressOfSize();
+}

--- a/ddprof-lib/src/main/cpp/threadFilter.h
+++ b/ddprof-lib/src/main/cpp/threadFilter.h
@@ -51,14 +51,21 @@ private:
     // todo: add thread safe APIs
     return bitmap[((u32)thread_id % BITMAP_CAPACITY) >> 6];
   }
+
+  u64* const wordAddress(u64 *bitmap, int thread_id) const {
+    return &bitmap[((u32)thread_id % BITMAP_CAPACITY) >> 6];
+  }
+
+  u64* getBitmapFor(int thread_id);
 public:
   ThreadFilter();
   ThreadFilter(ThreadFilter &threadFilter) = delete;
   ~ThreadFilter();
 
-  bool enabled() { return _enabled; }
+  bool enabled() const { return _enabled; }
 
-  int size() { return _size; }
+  int size() const { return _size; }
+  const volatile int* addressOfSize() const { return &_size; }
 
   void init(const char *filter);
   void clear();
@@ -66,6 +73,7 @@ public:
   bool accept(int thread_id);
   void add(int thread_id);
   void remove(int thread_id);
+  u64* bitmapAddressFor(int thread_id);
 
   void collect(std::vector<int> &v);
 };

--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/ActiveBitmap.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/ActiveBitmap.java
@@ -1,0 +1,71 @@
+package com.datadoghq.profiler;
+
+import sun.misc.Unsafe;
+import java.lang.reflect.Field;
+
+
+class ActiveBitmap {
+    private static final Unsafe UNSAFE = JavaProfiler.UNSAFE;
+
+    // Address to size field of ThreadFilter in native
+    private static long activeCountAddr;
+
+    private static final ThreadLocal<Long> Address = new ThreadLocal<Long>() {
+        @Override protected Long initialValue() {
+            return -1L;
+        }
+    };
+
+    public static void initialize() {
+        activeCountAddr = getActiveCountAddr0();
+    }
+
+    // On native side, we reverse lower 16 bits of thread id when maps to bitmap bit.
+    // So the active bit position of the specific thread id maps to the reverse order
+    // of the second lowest byte of thread id.
+    static long getBitmask(int tid) {
+        int tmp = (tid >> 8) & 0xff ;
+        int bits = 0;
+        for (int index = 0; index <= 7; index++) {
+            if ((tmp & 0x01) == 0x01) {
+                bits |= 1 << (7 - index);
+            }
+            tmp >>>= 1;
+        }
+        return 1L << (bits & 0x3f);
+    }
+
+    static void setActive(int tid, boolean active) {
+        long addr = Address.get();
+        if (addr == -1) {
+            addr = bitmapAddressFor0(tid);
+            Address.set(addr);
+        }
+        long bitmask = getBitmask(tid);
+        long value = UNSAFE.getLong(addr);
+        long newVal = active ? (value | bitmask) : (value & ~bitmask);
+
+        while (!UNSAFE.compareAndSwapLong(null, addr, value, newVal)) {
+            value = UNSAFE.getLong(addr);
+            newVal = active ? (value | bitmask) : (value & ~bitmask);
+        }
+        int delta = active ? 1 : -1;
+        assert activeCountAddr != 0;
+        UNSAFE.getAndAddInt(null, activeCountAddr, delta);
+        if (isActive0(tid) != active) {
+            throw new RuntimeException("SetActive Failed");
+        }
+
+        assert isActive0(tid) == active;
+    }
+
+
+    // Address of bitmap word that contains the active bit of this thread Id
+    private static native long bitmapAddressFor0(int tid);
+
+    private static native long getActiveCountAddr0();
+
+    // For validation
+    private static native boolean isActive0(int tid);
+}
+


### PR DESCRIPTION
**What does this PR do?**:
JavaProfiler activate/deactivate a thread for profiling via JNI call, which is expensive.

This enhancement intends to expose native bitmap, that is used for tracking thread’s state, to java and uses Unsafe API to update the bitmap directly.

**Motivation**:
Performance improvement.

Baseline:
<img width="1038" alt="before" src="https://github.com/user-attachments/assets/097ed0d7-edb2-45b4-a951-7f2028e5d37b" />

After patch:
<img width="1044" alt="Screenshot 2025-06-16 at 10 10 35 AM" src="https://github.com/user-attachments/assets/e8ea3a21-a3be-4b13-953d-7083b4af584d" />



**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
- ddprof-test and ddprof-stresstest

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-12008](https://datadoghq.atlassian.net/browse/PROF-12008)
Unsure? Have a question? Request a review!


[PROF-12008]: https://datadoghq.atlassian.net/browse/PROF-12008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ