### PR TITLE
Unify context propagation

### DIFF
--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
@@ -35,11 +35,9 @@ import java.util.Map;
  */
 public final class JavaProfiler {
     static final Unsafe UNSAFE;
-    static final boolean isJDK8;
     static {
         Unsafe unsafe = null;
         String version = System.getProperty("java.version");
-        isJDK8 = version.startsWith("1.8");
         try {
             Field f = Unsafe.class.getDeclaredField("theUnsafe");
             f.setAccessible(true);
@@ -129,7 +127,7 @@ public final class JavaProfiler {
         if (this.contextStorage == null) {
             int maxPages = getMaxContextPages0();
             if (maxPages > 0) {
-                if (isJDK8) {
+                if (UNSAFE != null) {
                     contextBaseOffsets = new long[maxPages];
                     // be sure to choose an illegal address as a sentinel value
                     Arrays.fill(contextBaseOffsets, Long.MIN_VALUE);
@@ -238,14 +236,14 @@ public final class JavaProfiler {
      */
     public void setContext(long spanId, long rootSpanId) {
         int tid = TID.get();
-        if (isJDK8) {
-            setContextJDK8(tid, spanId, rootSpanId);
+        if (UNSAFE != null) {
+            setContextUnsafe(tid, spanId, rootSpanId);
         } else {
             setContextByteBuffer(tid, spanId, rootSpanId);
         }
     }
 
-    private void setContextJDK8(int tid, long spanId, long rootSpanId) {
+    private void setContextUnsafe(int tid, long spanId, long rootSpanId) {
         if (contextBaseOffsets == null) {
             return;
         }
@@ -313,14 +311,14 @@ public final class JavaProfiler {
      */
     public void setContextValue(int offset, int value) {
         int tid = TID.get();
-        if (isJDK8) {
-            setContextJDK8(tid, offset, value);
+        if (UNSAFE != null) {
+            setContextUnsafe(tid, offset, value);
         } else {
             setContextByteBuffer(tid, offset, value);
         }
     }
 
-    private void setContextJDK8(int tid, int offset, int value) {
+    private void setContextUnsafe(int tid, int offset, int value) {
         if (contextBaseOffsets == null) {
             return;
         }
@@ -344,14 +342,14 @@ public final class JavaProfiler {
 
     void copyTags(int[] snapshot) {
         int tid = TID.get();
-        if (isJDK8) {
-            copyTagsJDK8(tid, snapshot);
+        if (UNSAFE != null) {
+            copyTagsUnsafe(tid, snapshot);
         } else {
             copyTagsByteBuffer(tid, snapshot);
         }
     }
 
-    void copyTagsJDK8(int tid, int[] snapshot) {
+    void copyTagsUnsafe(int tid, int[] snapshot) {
         if (contextBaseOffsets == null) {
             return;
         }


### PR DESCRIPTION
**What does this PR do?**:
Discussed with @Jaroslav Bachorík , we want to unify context propagation crosses all current jdk versions.

Use `Unsafe` API, whenever available, to update context and bitmap

Fallback to `DirectByteBuffer` for updating context and `JNI` call for updating bitmap when Unsafe is not available.

**Motivation**:
Code cleanup

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-12046](https://datadoghq.atlassian.net/browse/PROF-12046)

Unsure? Have a question? Request a review!


[PROF-12046]: https://datadoghq.atlassian.net/browse/PROF-12046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ