### PR TITLE
Split debug - publish debug info

### DIFF
--- a/ddprof-lib/build.gradle
+++ b/ddprof-lib/build.gradle
@@ -83,6 +83,9 @@ def createDebugExtractionTask(config, linkTask) {
     description = 'Extract debug symbols from release library'
     workingDir project.buildDir
 
+    // Declare outputs so Gradle knows what files this task creates
+    outputs.file getDebugFilePath(config)
+
     doFirst {
       def sourceFile = linkTask.get().linkedFile.get().asFile
       def debugFile = getDebugFilePath(config)
@@ -127,7 +130,7 @@ def createDebugCopyTask(config, extractDebugTask) {
     }
     dependsOn extractDebugTask
     from file("$buildDir/lib/main/${config.name}/${osIdentifier()}/${archIdentifier()}/debug")
-    into file(libraryTargetPath(config.name + '-debug'))
+    into file(libraryTargetPath(config.name))
     include '**/*.debug'
     include '**/*.dSYM/**'
   }
@@ -164,12 +167,6 @@ def setupDebugExtraction(config, linkTask) {
 
       // Create an extra folder for the debug symbols
       copyTask.dependsOn copyDebugTask
-    }
-
-    // Wire up the debug info JAR to depend on debug files being copied
-    def debugInfoJarTask = tasks.findByName("debugInfoJar")
-    if (debugInfoJarTask != null) {
-      debugInfoJarTask.dependsOn copyDebugTask
     }
   }
 }
@@ -258,19 +255,10 @@ tasks.register('copyExternalLibs', Copy) {
     from(project.getProperty("with-libs")) {
       include "**/*.so"
       include "**/*.dylib"
-    }
-    into "${projectDir}/build/classes/java/main/META-INF/native-libs"
-  }
-}
-
-// Copy debug files from external libraries if they exist
-tasks.register('copyExternalDebugFiles', Copy) {
-  if (project.hasProperty("with-libs")) {
-    from(project.getProperty("with-libs")) {
       include "**/*.debug"
       include "**/*.dSYM/**"
     }
-    into libraryTargetBase('release-debug') + "/META-INF/native-libs"
+    into "${projectDir}/build/classes/java/main/META-INF/native-libs"
   }
 }
 
@@ -450,6 +438,7 @@ buildConfigNames().each { name ->
     if (!project.hasProperty('skip-native')) {
       dependsOn copyTask
     }
+
     from sourceSets.main.output.classesDirs
     from files(libraryTargetBase(name)) {
       include "**/*"
@@ -615,19 +604,7 @@ tasks.register('javadocJar', Jar) {
   from javadoc.destinationDir
 }
 
-tasks.register('debugInfoJar', Jar) {
-  archiveBaseName = libraryName
-  archiveClassifier = 'debugInfo'
-  archiveVersion = component_version
-  from files(libraryTargetBase('release-debug')) {
-    include "**/*"
-  }
 
-  // When using external libraries, depend on copyExternalDebugFiles
-  if (project.hasProperty("with-libs")) {
-    dependsOn copyExternalDebugFiles
-  }
-}
 
 tasks.register('scanBuild', Exec) {
   workingDir "${projectDir}/src/test/make"
@@ -698,7 +675,6 @@ publishing {
       }
       publication.artifact sourcesJar
       publication.artifact javadocJar
-      publication.artifact debugInfoJar
 
       publication.groupId = 'com.datadoghq'
       publication.artifactId = 'ddprof'

--- a/ddprof-lib/build.gradle
+++ b/ddprof-lib/build.gradle
@@ -165,6 +165,12 @@ def setupDebugExtraction(config, linkTask) {
       // Create an extra folder for the debug symbols
       copyTask.dependsOn copyDebugTask
     }
+
+    // Wire up the debug info JAR to depend on debug files being copied
+    def debugInfoJarTask = tasks.findByName("debugInfoJar")
+    if (debugInfoJarTask != null) {
+      debugInfoJarTask.dependsOn copyDebugTask
+    }
   }
 }
 
@@ -254,6 +260,17 @@ tasks.register('copyExternalLibs', Copy) {
       include "**/*.dylib"
     }
     into "${projectDir}/build/classes/java/main/META-INF/native-libs"
+  }
+}
+
+// Copy debug files from external libraries if they exist
+tasks.register('copyExternalDebugFiles', Copy) {
+  if (project.hasProperty("with-libs")) {
+    from(project.getProperty("with-libs")) {
+      include "**/*.debug"
+      include "**/*.dSYM/**"
+    }
+    into libraryTargetBase('release-debug') + "/META-INF/native-libs"
   }
 }
 
@@ -598,6 +615,20 @@ tasks.register('javadocJar', Jar) {
   from javadoc.destinationDir
 }
 
+tasks.register('debugInfoJar', Jar) {
+  archiveBaseName = libraryName
+  archiveClassifier = 'debugInfo'
+  archiveVersion = component_version
+  from files(libraryTargetBase('release-debug')) {
+    include "**/*"
+  }
+  
+  // When using external libraries, depend on copyExternalDebugFiles
+  if (project.hasProperty("with-libs")) {
+    dependsOn copyExternalDebugFiles
+  }
+}
+
 tasks.register('scanBuild', Exec) {
   workingDir "${projectDir}/src/test/make"
   commandLine 'scan-build'
@@ -667,6 +698,7 @@ publishing {
       }
       publication.artifact sourcesJar
       publication.artifact javadocJar
+      publication.artifact debugInfoJar
 
       publication.groupId = 'com.datadoghq'
       publication.artifactId = 'ddprof'

--- a/gradle/configurations.gradle
+++ b/gradle/configurations.gradle
@@ -119,7 +119,7 @@ def commonLinuxCompilerArgs = [
   "-DCOUNTERS"
 ]
 
-def commonLinuxLinkerArgs = ["-ldl", "-Wl,-z,defs", "--verbose", "-lpthread", "-lm", "-lrt", "-v"]
+def commonLinuxLinkerArgs = ["-ldl", "-Wl,-z,defs", "--verbose", "-lpthread", "-lm", "-lrt", "-v", "-Wl,--build-id"]
 
 def commonMacosCompilerArgs = commonLinuxCompilerArgs + ["-D_XOPEN_SOURCE", "-D_DARWIN_C_SOURCE"]
 


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->

- Change the way the debug file is published

We discussed that the debug info could be moved into the main JAR.
This will make it easier to push the .debug file into the sonatype (instead of creating a separate JAR).
As we create a separate JAR for dd-trace-java, we don't need to worry about increasing the footprint of the deployed library.

- Add a linker flag to ensure build ID is added (even on musl)

**Motivation**:
<!-- What inspired you to submit this pull request? -->
Ensure we can download debug info from maven.
Simplify how debug info is published.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->
This will require a simple downstream PR (changing the folder we are looking at)

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
