### PR TITLE
Relax benchmark commandline restriction

### DIFF
--- a/ddprof-stresstest/build.gradle
+++ b/ddprof-stresstest/build.gradle
@@ -39,7 +39,7 @@ task runStressTests(type: Exec) {
   }
   group = 'Execution'
   description = 'Run JMH stresstests'
-  commandLine "${javaHome}/bin/java", '-jar', 'build/libs/stresstests.jar', 'counters.*'
+  commandLine "${javaHome}/bin/java", '-jar', 'build/libs/stresstests.jar', '-prof', 'com.datadoghq.profiler.stresstest.WhiteboxProfiler', 'counters.*'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/ddprof-stresstest/src/jmh/java/com/datadoghq/profiler/stresstest/Main.java
+++ b/ddprof-stresstest/src/jmh/java/com/datadoghq/profiler/stresstest/Main.java
@@ -16,16 +16,10 @@ public class Main {
     public static final String SCENARIOS_PACKAGE = "com.datadoghq.profiler.stresstest.scenarios.";
 
     public static void main(String... args) throws Exception {
-        String filter = "*";
-        if (args.length >= 1) {
-            filter = args[0];
-        } 
         CommandLineOptions commandLineOptions = new CommandLineOptions(args);
         Mode mode = Mode.AverageTime;
         Options options = new OptionsBuilder()
                 .parent(new CommandLineOptions(args))
-                .include(SCENARIOS_PACKAGE + filter)
-                .addProfiler(WhiteboxProfiler.class)
                 .forks(commandLineOptions.getForkCount().orElse(1))
                 .warmupIterations(commandLineOptions.getWarmupIterations().orElse(0))
                 .measurementIterations(commandLineOptions.getMeasurementIterations().orElse(1))

--- a/ddprof-stresstest/src/jmh/java/com/datadoghq/profiler/stresstest/Main.java
+++ b/ddprof-stresstest/src/jmh/java/com/datadoghq/profiler/stresstest/Main.java
@@ -17,12 +17,9 @@ public class Main {
 
     public static void main(String... args) throws Exception {
         String filter = "*";
-        if (args.length == 1) {
+        if (args.length >= 1) {
             filter = args[0];
-        } else if (args.length > 1) {
-            System.err.println("Usage: java -jar ddprof-stresstest.jar [scenario filter]");
-            System.exit(1);
-        }
+        } 
         CommandLineOptions commandLineOptions = new CommandLineOptions(args);
         Mode mode = Mode.AverageTime;
         Options options = new OptionsBuilder()


### PR DESCRIPTION
**What does this PR do?**:
Allow additional jmh arguments, e.g. profiling option

**Motivation**:
Run jmh benchmark with profiler, e.g.

`java -jar ddprof-stresstest.jar throughput.ThreadFilterBenchmark -prof perfasm`

**Additional Notes**:

**How to test the change?**:

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
