### PR TITLE
Stresstest fix - Add limits to the graph mutation stress test

### DIFF
--- a/ddprof-stresstest/src/jmh/java/com/datadoghq/profiler/stresstest/scenarios/counters/GraphMutation.java
+++ b/ddprof-stresstest/src/jmh/java/com/datadoghq/profiler/stresstest/scenarios/counters/GraphMutation.java
@@ -3,17 +3,24 @@ package com.datadoghq.profiler.stresstest.scenarios.counters;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Threads;
 
-import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class GraphMutation {
 
     public static class GraphNode {
-        private final Queue<GraphNode> nodes = new ConcurrentLinkedQueue<>();
+        private volatile ConcurrentLinkedQueue<GraphNode> nodes = new ConcurrentLinkedQueue<>();
+        private final AtomicLong linkCount = new AtomicLong(0);
 
         public void link(GraphNode node) {
             nodes.add(node);
+            
+            // Switch to new data structure every 100,000 operations
+            // Other threads can finish with the old one
+            if (linkCount.incrementAndGet() % 100000 == 0) {
+                nodes = new ConcurrentLinkedQueue<>();
+            }
         }
     }
 


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->
Add limits to the number of nodes and links.

**Motivation**:
<!-- What inspired you to submit this pull request? -->
Ensure we don't go in [OOM error](https://gitlab.ddbuild.io/DataDog/apm-reliability/async-profiler-build/-/jobs/1020575451) in the stresstest.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
