### PR TITLE
Downport async-profiler no-allocation changes

### DIFF
--- a/ddprof-lib/src/main/cpp/codeCache.cpp
+++ b/ddprof-lib/src/main/cpp/codeCache.cpp
@@ -22,12 +22,14 @@ char *NativeFunc::create(const char *name, short lib_index) {
 void NativeFunc::destroy(char *name) { free(from(name)); }
 
 CodeCache::CodeCache(const char *name, short lib_index, bool imports_patchable,
-                     const void *min_address, const void *max_address) {
+                     const void *min_address, const void *max_address,
+                     const char* image_base) {
   _name = NativeFunc::create(name, -1);
   _lib_index = lib_index;
   _min_address = min_address;
   _max_address = max_address;
   _text_base = NULL;
+  _image_base = image_base;
 
   _plt_offset = 0;
   _plt_size = 0;

--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -109,6 +109,7 @@ private:
   const void *_min_address;
   const void *_max_address;
   const char *_text_base;
+  const char* _image_base;
 
   unsigned int _plt_offset;
   unsigned int _plt_size;
@@ -132,7 +133,8 @@ public:
   explicit CodeCache(const char *name, short lib_index = -1,
                      bool imports_patchable = false,
                      const void *min_address = NO_MIN_ADDRESS,
-                     const void *max_address = NO_MAX_ADDRESS);
+                     const void *max_address = NO_MAX_ADDRESS,
+                     const char* image_base = NULL);
   // Copy constructor
   CodeCache(const CodeCache &other);
   // Copy assignment operator
@@ -147,6 +149,8 @@ public:
   const void *minAddress() const { return _min_address; }
 
   const void *maxAddress() const { return _max_address; }
+
+  const char* imageBase() const { return _image_base; }
 
   bool contains(const void *address) const {
     return address >= _min_address && address < _max_address;

--- a/ddprof-lib/src/main/cpp/symbols.h
+++ b/ddprof-lib/src/main/cpp/symbols.h
@@ -24,6 +24,7 @@ class Symbols {
 private:
   static Mutex _parse_lock;
   static bool _have_kernel_symbols;
+  static bool _libs_limit_reported;
 
 public:
   static void parseKernelSymbols(CodeCache *cc);

--- a/ddprof-lib/src/main/cpp/symbols.h
+++ b/ddprof-lib/src/main/cpp/symbols.h
@@ -38,4 +38,18 @@ public:
   static bool isRootSymbol(const void* address);
 };
 
+class UnloadProtection {
+  private:
+    void* _lib_handle;
+    bool _valid;
+
+  public:
+    UnloadProtection(const CodeCache *cc);
+    ~UnloadProtection();
+
+    UnloadProtection& operator=(const UnloadProtection& other) = delete;
+
+    bool isValid() const { return _valid; }
+};
+
 #endif // _SYMBOLS_H

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -631,9 +631,7 @@ void Symbols::parseLibraries(CodeCacheArray *array, bool kernel_symbols) {
             lib.file[len - 10] = 0;
         }
 
-        if (strchr(lib.file, ':') != NULL) {
-            // Do not try to parse pseudofiles like anon_inode:name, /memfd:name
-        } else if (strcmp(lib.file, "[vdso]") == 0) {
+       if (strcmp(lib.file, "[vdso]") == 0) {
             ElfParser::parseProgramHeaders(cc, lib.map_start, lib.map_end, true);
         } else if (lib.image_base == NULL) {
             // Unlikely case when image base has not been found: not safe to access program headers.

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -496,7 +496,6 @@ bool Symbols::_libs_limit_reported = false;
 static std::unordered_set<u64> _parsed_inodes;
 
 void Symbols::clearParsingCaches() {
-  _parsed_libraries.clear();
   _parsed_inodes.clear();
 }
 
@@ -573,11 +572,6 @@ static void collectSharedLibraries(std::unordered_map<u64, SharedLibrary>& libs,
         continue;  // all shared libraries have inode, except vDSO
     }
 
-    int count = array->count();
-    if (count >= MAX_NATIVE_LIBS) {
-      break;
-    }
-
     const char* map_start = map.addr();
     const char *map_end = map.end();
     if (inode != last_inode && map.offs() == 0) {
@@ -598,8 +592,9 @@ static void collectSharedLibraries(std::unordered_map<u64, SharedLibrary>& libs,
         }
     }
 
-  free(str);
-  fclose(f);
+    free(str);
+    fclose(f);
+  }
 }
 
 void Symbols::parseLibraries(CodeCacheArray *array, bool kernel_symbols) {

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -12,18 +12,20 @@
 #include "log.h"
 #include "safeAccess.h"
 #include "symbols.h"
+#include <dlfcn.h>
 #include <elf.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <link.h>
 #include <linux/limits.h>
-#include <set>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unordered_map>
+#include <unordered_set>
 
 // make sure lseek will use 64 bits offset
 #define _FILE_OFFSET_BITS 64
@@ -481,10 +483,17 @@ void ElfParser::addRelocationSymbols(ElfSection *reltab, const char *plt) {
   }
 }
 
+struct SharedLibrary {
+    char* file;
+    const char* map_start;
+    const char* map_end;
+    const char* image_base;
+};
+
 Mutex Symbols::_parse_lock;
 bool Symbols::_have_kernel_symbols = false;
-static std::set<const void *> _parsed_libraries;
-static std::set<u64> _parsed_inodes;
+bool Symbols::_libs_limit_reported = false;
+static std::unordered_set<u64> _parsed_inodes;
 
 void Symbols::clearParsingCaches() {
   _parsed_libraries.clear();
@@ -531,22 +540,20 @@ void Symbols::parseKernelSymbols(CodeCache *cc) {
   fclose(f);
 }
 
-static int parseLibrariesCallback(struct dl_phdr_info *info, size_t size,
-                                  void *data) {
+static void collectSharedLibraries(std::unordered_map<u64, SharedLibrary>& libs, int max_count) {
 
   FILE *f = fopen("/proc/self/maps", "r");
   if (f == NULL) {
-    return 1;
+    return;
   }
 
-  CodeCacheArray *array = (CodeCacheArray *)data;
   const char *image_base = NULL;
   u64 last_inode = 0;
   char *str = NULL;
   size_t str_size = 0;
   ssize_t len;
 
-  while ((len = getline(&str, &str_size, f)) > 0) {
+  while (max_count > 0 && (len = getline(&str, &str_size, f)) > 0) {
     str[len - 1] = 0;
     MemoryMapDesc map(str);
     if (!map.isReadable() || map.file() == NULL || map.file()[0] == 0) {
@@ -557,17 +564,13 @@ static int parseLibrariesCallback(struct dl_phdr_info *info, size_t size,
       continue;
     }
 
-    const char *map_start = map.addr();
-    unsigned long map_offs = map.offs();
-
-    if (map_offs == 0) {
-      image_base = map_start;
-      last_inode = u64(map.dev()) << 32 | map.inode();
+    u64 inode = u64(map.dev()) << 32 | map.inode();
+    if (_parsed_inodes.find(inode) != _parsed_inodes.end()) {
+       continue;  // shared object is already parsed
     }
 
-    if (!map.isExecutable() || !_parsed_libraries.insert(map_start).second) {
-      // Not an executable segment or it has been already parsed
-      continue;
+    if (inode == 0 && strcmp(map.file(), "[vdso]") != 0) {
+        continue;  // all shared libraries have inode, except vDSO
     }
 
     int count = array->count();
@@ -575,44 +578,36 @@ static int parseLibrariesCallback(struct dl_phdr_info *info, size_t size,
       break;
     }
 
+    const char* map_start = map.addr();
     const char *map_end = map.end();
-    // Do not try to parse pseudofiles like anon_inode:name, /memfd:name
-    if (strchr(map.file(), ':') == NULL) {
-      CodeCache *cc = new CodeCache(map.file(), count, false, map_start, map_end);
-      TEST_LOG("Procesing library: %s", map.file());
-      u64 inode = u64(map.dev()) << 32 | map.inode();
-      if (inode != 0) {
-        // Do not parse the same executable twice, e.g. on Alpine Linux
-        if (_parsed_inodes.insert(inode).second) {
-          if (inode == last_inode) {
-            // If last_inode is set, image_base is known to be valid and
-            // readable
-            ElfParser::parseFile(cc, image_base, map.file(), true);
-            // Parse program headers after the file to ensure debug symbols are
-            // parsed first
-            ElfParser::parseProgramHeaders(cc, image_base, map_end, MUSL);
-          } else if ((unsigned long)map_start > map_offs) {
-            // Unlikely case when image_base has not been found.
-            // Be careful: executable file is not always ELF, e.g. classes.jsa
-            ElfParser::parseFile(cc, map_start - map_offs, map.file(), true);
-          }
-        }
-      } else if (strcmp(map.file(), "[vdso]") == 0) {
-        ElfParser::parseProgramHeaders(cc, map_start, map_end, true);
-      }
-
-      cc->sort();
-      array->add(cc);
+    if (inode != last_inode && map.offs() == 0) {
+        image_base = map_start;
+        last_inode = inode;
     }
-  }
+
+    if (map.isExecutable()) {
+        SharedLibrary& lib = libs[inode];
+        if (lib.file == nullptr) {
+            lib.file = strdup(map.file());
+            lib.map_start = map_start;
+            lib.map_end = map_end;
+            lib.image_base = inode == last_inode ? image_base : NULL;
+            max_count--;
+            // The same library may have multiple executable segments mapped
+            lib.map_end = map_end;
+        }
+    }
 
   free(str);
   fclose(f);
-  return 1; // stop at first iteration
 }
 
 void Symbols::parseLibraries(CodeCacheArray *array, bool kernel_symbols) {
   MutexLocker ml(_parse_lock);
+
+  if (array->count() >= MAX_NATIVE_LIBS) {
+    return;
+  }
 
   if (kernel_symbols && !haveKernelSymbols()) {
     CodeCache *cc = new CodeCache("[kernel]");
@@ -625,12 +620,58 @@ void Symbols::parseLibraries(CodeCacheArray *array, bool kernel_symbols) {
       delete cc;
     }
   }
+    std::unordered_map<u64, SharedLibrary> libs;
+    collectSharedLibraries(libs, MAX_NATIVE_LIBS - array->count());
 
-  // In glibc, dl_iterate_phdr() holds dl_load_write_lock, therefore preventing
-  // concurrent loading and unloading of shared libraries.
-  // Without it, we may access memory of a library that is being unloaded.
-  dl_iterate_phdr(parseLibrariesCallback, array);
-  TEST_LOG("Parsed %d libraries", array->count());
+    for (auto& it : libs) {
+        u64 inode = it.first;
+        _parsed_inodes.insert(inode);
+
+        SharedLibrary& lib = it.second;
+        CodeCache* cc = new CodeCache(lib.file, array->count(), false, lib.map_start, lib.map_end);
+
+        // Strip " (deleted)" suffix so that removed library can be reopened
+        size_t len = strlen(lib.file);
+        if (len > 10 && strcmp(lib.file + len - 10, " (deleted)") == 0) {
+            lib.file[len - 10] = 0;
+        }
+
+        if (strchr(lib.file, ':') != NULL) {
+            // Do not try to parse pseudofiles like anon_inode:name, /memfd:name
+        } else if (strcmp(lib.file, "[vdso]") == 0) {
+            ElfParser::parseProgramHeaders(cc, lib.map_start, lib.map_end, true);
+        } else if (lib.image_base == NULL) {
+            // Unlikely case when image base has not been found: not safe to access program headers.
+            // Be careful: executable file is not always ELF, e.g. classes.jsa
+            ElfParser::parseFile(cc, lib.map_start, lib.file, true);
+        } else {
+            // Parse debug symbols first
+            ElfParser::parseFile(cc, lib.image_base, lib.file, true);
+
+            dlerror();  // reset any error from previous dl function calls
+
+            // Protect library from unloading while parsing in-memory ELF program headers.
+            // Also, dlopen() ensures the library is fully loaded.
+            // Main executable and ld-linux interpreter cannot be dlopen'ed, but dlerror() returns NULL for them.
+            void* handle = dlopen(lib.file, RTLD_LAZY | RTLD_NOLOAD);
+            if (handle != NULL || dlerror() == NULL) {
+               if (handle != NULL) {
+                    dlclose(handle);
+                }
+            }
+        }
+
+        free(lib.file);
+
+        cc->sort();
+        applyPatch(cc);
+        array->add(cc);
+    }
+
+    if (array->count() >= MAX_NATIVE_LIBS && !_libs_limit_reported) {
+        Log::warn("Number of parsed libraries reached the limit of %d", MAX_NATIVE_LIBS);
+        _libs_limit_reported = true;
+    }
 }
 
 bool Symbols::isRootSymbol(const void* address) {

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -649,6 +649,7 @@ void Symbols::parseLibraries(CodeCacheArray *array, bool kernel_symbols) {
             // Main executable and ld-linux interpreter cannot be dlopen'ed, but dlerror() returns NULL for them.
             void* handle = dlopen(lib.file, RTLD_LAZY | RTLD_NOLOAD);
             if (handle != NULL || dlerror() == NULL) {
+               ElfParser::parseProgramHeaders(cc, lib.image_base, lib.map_end, MUSL);
                if (handle != NULL) {
                     dlclose(handle);
                 }

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -567,7 +567,6 @@ static void collectSharedLibraries(std::unordered_map<u64, SharedLibrary>& libs,
     if (_parsed_inodes.find(inode) != _parsed_inodes.end()) {
        continue;  // shared object is already parsed
     }
-
     if (inode == 0 && strcmp(map.file(), "[vdso]") != 0) {
         continue;  // all shared libraries have inode, except vDSO
     }
@@ -587,14 +586,14 @@ static void collectSharedLibraries(std::unordered_map<u64, SharedLibrary>& libs,
             lib.map_end = map_end;
             lib.image_base = inode == last_inode ? image_base : NULL;
             max_count--;
+        } else {
             // The same library may have multiple executable segments mapped
             lib.map_end = map_end;
         }
     }
-
-    free(str);
-    fclose(f);
   }
+  free(str);
+  fclose(f);
 }
 
 void Symbols::parseLibraries(CodeCacheArray *array, bool kernel_symbols) {
@@ -659,7 +658,6 @@ void Symbols::parseLibraries(CodeCacheArray *array, bool kernel_symbols) {
         free(lib.file);
 
         cc->sort();
-        applyPatch(cc);
         array->add(cc);
     }
 


### PR DESCRIPTION
**What does this PR do?**:
Downport asyn-profiler's fix for deadlock when using tcmalloc.

**Motivation**:
Avoid deadlock when using tcmalloc library.

**Additional Notes**:
The downport is based on async profiler's [PR #1220](https://github.com/async-profiler/async-profiler/pull/1220). I also downported `UnloadProtection` from current head, which is more robust. Without it, `elfparser_ut` fails intermittently. 

**How to test the change?**:
```
export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_and_profiler.so

java -javaagent:dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.profiling.upload.period=10 -Ddd.profiling.start-force-first=true -Ddd.profiling.ddprof.debug.lib=/home/zhengyu/
ws/java-profiler/ddprof-lib/build/lib/main/debug/linux/x64/libjavaProfiler.so -Ddd.env=workspace-jb -Ddd.service=akka-uct -XX:NativeMemoryTracking=summary -Ddd.profiling.smap.aggregation.enabl
ed=false -Ddd.profiling.experimental.ddprof.wall.jvmti=true -Ddd.profiling.ddprof.wall.context.filter=false -jar renaissance-gpl-0.16.0.jar akka-uct -r 500000
```
Before patch, above test deadlock 1 out 6-8 runs. With patch, it did not deadlock with 50 runs.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-11600](https://datadoghq.atlassian.net/browse/PROF-11600)

Unsure? Have a question? Request a review!


[PROF-11600]: https://datadoghq.atlassian.net/browse/PROF-11600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ