### PR TITLE
Fix the async-profiler re-fetch

### DIFF
--- a/ddprof-lib/build.gradle
+++ b/ddprof-lib/build.gradle
@@ -291,7 +291,10 @@ def cloneAPTask = tasks.register('cloneAsyncProfiler') {
         println "async-profiler commit hash differs (current: ${currentCommit}, expected: ${commit_lock}), updating..."
         exec {
           workingDir targetDir.absolutePath
-          commandLine 'git', 'fetch', 'origin', branch_lock, '--depth', '1'
+          commandLine 'rm', '-rf', targetDir.absolutePath
+        }
+        exec {
+          commandLine 'git', 'clone', '--branch', branch_lock, 'https://github.com/datadog/async-profiler.git', targetDir.absolutePath
         }
         exec {
           workingDir targetDir.absolutePath


### PR DESCRIPTION
The 'fetch/checkout' combo is not working well for updating the upstream repo.
It is replaced with 'clean/clone/checkout' instead