### PR TITLE
Remove gtest during build

### DIFF
--- a/ddprof-lib/build.gradle
+++ b/ddprof-lib/build.gradle
@@ -112,6 +112,9 @@ def createDebugLinkTask(config, linkTask, extractDebugTask) {
     }
     dependsOn extractDebugTask
     description = 'Add debug link to the original library'
+    
+    inputs.files linkTask, extractDebugTask
+    outputs.file { linkTask.get().linkedFile.get().asFile }
 
     doFirst {
       def sourceFile = linkTask.get().linkedFile.get().asFile
@@ -265,7 +268,28 @@ tasks.register('copyExternalLibs', Copy) {
 def cloneAPTask = tasks.register('cloneAsyncProfiler') {
   description = 'Clones async-profiler repo if directory is missing or updates it if commit hash differs'
   inputs.file("${rootDir}/gradle/ap-lock.properties")
-  doFirst {
+  outputs.dir("${projectDir}/build/async-profiler")
+  outputs.upToDateWhen {
+    def targetDir = file("${projectDir}/build/async-profiler")
+    if (!targetDir.exists()) {
+      return false
+    }
+    def currentCommit = ""
+    try {
+      new ByteArrayOutputStream().withStream { os ->
+        exec {
+          workingDir targetDir.absolutePath
+          commandLine 'git', 'rev-parse', 'HEAD'
+          standardOutput = os
+        }
+        currentCommit = os.toString().trim()
+      }
+      return currentCommit == commit_lock
+    } catch (Exception e) {
+      return false
+    }
+  }
+  doLast {
     def targetDir = file("${projectDir}/build/async-profiler")
     if (!targetDir.exists()) {
       println "Cloning missing async-profiler git subdirectory..."
@@ -336,6 +360,9 @@ def patchStackFrame = tasks.register("patchStackFrame") {
   configure {
     dependsOn copyUpstreamFiles
   }
+  inputs.files copyUpstreamFiles
+  outputs.file("${projectDir}/src/main/cpp-external/stackFrame_x64.cpp")
+  
   doLast {
     def file = file("${projectDir}/src/main/cpp-external/stackFrame_x64.cpp")
     if (!file.exists()) throw new GradleException("File not found: ${file}")
@@ -386,8 +413,11 @@ def patchStackFrame = tasks.register("patchStackFrame") {
 def patchStackWalker = tasks.register("patchStackWalker") {
   description = 'Patch stackWalker.cpp after copying'
   configure {
-    dependsOn copyUpstreamFiles
+    dependsOn copyUpstreamFiles, patchStackFrame
   }
+  inputs.files copyUpstreamFiles
+  outputs.file("${projectDir}/src/main/cpp-external/stackWalker.cpp")
+  
   doLast {
     def file = file("${projectDir}/src/main/cpp-external/stackWalker.cpp")
     if (!file.exists()) throw new GradleException("File not found: ${file}")
@@ -643,10 +673,6 @@ gradle.projectsEvaluated {
         if (copyTask != null) {
           copyTask.dependsOn linkTask
         }
-      }
-      def gtestTask = project(':ddprof-lib:gtest').tasks.findByName("gtest${it.capitalize()}")
-      if (gtestTask != null) {
-        linkTask.dependsOn gtestTask
       }
     }
     def javadocTask = tasks.findByName("javadoc")

--- a/ddprof-lib/build.gradle
+++ b/ddprof-lib/build.gradle
@@ -112,7 +112,7 @@ def createDebugLinkTask(config, linkTask, extractDebugTask) {
     }
     dependsOn extractDebugTask
     description = 'Add debug link to the original library'
-    
+
     inputs.files linkTask, extractDebugTask
     outputs.file { linkTask.get().linkedFile.get().asFile }
 
@@ -362,7 +362,7 @@ def patchStackFrame = tasks.register("patchStackFrame") {
   }
   inputs.files copyUpstreamFiles
   outputs.file("${projectDir}/src/main/cpp-external/stackFrame_x64.cpp")
-  
+
   doLast {
     def file = file("${projectDir}/src/main/cpp-external/stackFrame_x64.cpp")
     if (!file.exists()) throw new GradleException("File not found: ${file}")
@@ -417,7 +417,7 @@ def patchStackWalker = tasks.register("patchStackWalker") {
   }
   inputs.files copyUpstreamFiles
   outputs.file("${projectDir}/src/main/cpp-external/stackWalker.cpp")
-  
+
   doLast {
     def file = file("${projectDir}/src/main/cpp-external/stackWalker.cpp")
     if (!file.exists()) throw new GradleException("File not found: ${file}")

--- a/ddprof-lib/build.gradle
+++ b/ddprof-lib/build.gradle
@@ -295,7 +295,7 @@ def cloneAPTask = tasks.register('cloneAsyncProfiler') {
       commandLine 'git', 'config', '--global', '--add', 'safe.directory', projectDir.parentFile.absolutePath
       ignoreExitValue = true  // Don't fail if this command fails
     }
-    
+
     def targetDir = file("${projectDir}/build/async-profiler")
     if (!targetDir.exists()) {
       println "Cloning missing async-profiler git subdirectory..."
@@ -313,7 +313,7 @@ def cloneAPTask = tasks.register('cloneAsyncProfiler') {
         commandLine 'git', 'config', '--global', '--add', 'safe.directory', targetDir.absolutePath
         ignoreExitValue = true
       }
-      
+
       def currentCommit = ""
       new ByteArrayOutputStream().withStream { os ->
         exec {

--- a/ddprof-lib/build.gradle
+++ b/ddprof-lib/build.gradle
@@ -290,6 +290,12 @@ def cloneAPTask = tasks.register('cloneAsyncProfiler') {
     }
   }
   doLast {
+    // Fix for CI environments where git detects dubious ownership
+    exec {
+      commandLine 'git', 'config', '--global', '--add', 'safe.directory', projectDir.parentFile.absolutePath
+      ignoreExitValue = true  // Don't fail if this command fails
+    }
+    
     def targetDir = file("${projectDir}/build/async-profiler")
     if (!targetDir.exists()) {
       println "Cloning missing async-profiler git subdirectory..."
@@ -301,6 +307,13 @@ def cloneAPTask = tasks.register('cloneAsyncProfiler') {
         commandLine 'git', 'checkout', commit_lock
       }
     } else {
+      // Also fix git ownership for existing directory
+      exec {
+        workingDir targetDir.absolutePath
+        commandLine 'git', 'config', '--global', '--add', 'safe.directory', targetDir.absolutePath
+        ignoreExitValue = true
+      }
+      
       def currentCommit = ""
       new ByteArrayOutputStream().withStream { os ->
         exec {

--- a/ddprof-lib/gtest/build.gradle
+++ b/ddprof-lib/gtest/build.gradle
@@ -199,7 +199,8 @@ tasks.whenTaskAdded { task ->
               }
 
               inputs.files binary
-              outputs.upToDateWhen {true}
+              // Test tasks should run every time the test command is run
+              outputs.upToDateWhen { false }
             }
 
             def compileTask = tasks.findByName("compileGtest${config.name.capitalize()}_${testName}")

--- a/ddprof-test/build.gradle
+++ b/ddprof-test/build.gradle
@@ -120,5 +120,11 @@ gradle.projectsEvaluated {
     if (testTask && assembleTask) {
       assembleTask.dependsOn testTask
     }
+
+    // Hook C++ gtest tasks to run as part of the corresponding Java test tasks
+    def gtestTask = project(':ddprof-lib:gtest').tasks.findByName("gtest${it.capitalize()}")
+    if (testTask && gtestTask) {
+      testTask.dependsOn gtestTask
+    }
   }
 }


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->
Remove gtest during build
Clarify outputs for async-profiler check

**Motivation**:
<!-- What inspired you to submit this pull request? -->
Consecutive builds are faster

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->
NA

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
We already call test commands which will run gtests

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
