### PR TITLE
Avoid GITHUB_TOKEN for PR approval

### DIFF
--- a/.github/chainguard/self.approve-trivial.approve-pr.sts.yaml
+++ b/.github/chainguard/self.approve-trivial.approve-pr.sts.yaml
@@ -1,0 +1,14 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/java-profiler:pull_request
+
+claim_pattern:
+  event_name: pull_request_target
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/java-profiler/\.github/workflows/approve-trivial\.yml@refs/heads/main
+
+permissions:
+  contents: read
+  pull_requests: write
+

--- a/.github/workflows/approve-trivial.yml
+++ b/.github/workflows/approve-trivial.yml
@@ -4,16 +4,19 @@ on:
   pull_request_target:
     types: [labeled]
 
-permissions:
-  pull-requests: write
-  contents: read
-
 jobs:
   auto-approve:
     if: contains(github.event.pull_request.labels.*.name, 'trivial') || contains(github.event.pull_request.labels.*.name, 'no-review')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Needed to federate tokens
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/java-profiler
+          policy: self.approve-trivial.approve-pr
       - name: Auto-approve PR
         uses: hmarr/auto-approve-action@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.octo-sts.outputs.token }}


### PR DESCRIPTION
**What does this PR do?**:
This PR migrates the `approve-trivial.yml` workflow from using the repository's `GITHUB_TOKEN` to `dd-octo-sts` for secure pull request approval operations.

Changes
- **Added**: Trust policy `.github/chainguard/self.approve-trivial.approve-pr.sts.yaml` that defines the security boundaries for the workflow
- **Updated**: `.github/workflows/approve-trivial.yml` to use `dd-octo-sts-action` instead of `GITHUB_TOKEN`

**Motivation**:
Allows us to remove the `GITHUB_TOKEN` permission to create/approve PRs which is a branch protection bypass risk.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
