### PR TITLE
Avoid calling profiler.stop() twice in ThreadFilterBenchmark

### DIFF
--- a/ddprof-stresstest/src/jmh/java/com/datadoghq/profiler/stresstest/scenarios/counters/ThreadFilterBenchmark.java
+++ b/ddprof-stresstest/src/jmh/java/com/datadoghq/profiler/stresstest/scenarios/counters/ThreadFilterBenchmark.java
@@ -103,13 +103,6 @@ public class ThreadFilterBenchmark extends Configuration {
             Thread.currentThread().interrupt();
         }
 
-        // Stop the profiler if it's active
-        try {
-            profiler.stop();
-        } catch (IllegalStateException e) {
-            System.out.println("Profiler was not active at teardown.");
-        }
-
         long endTime = System.currentTimeMillis();
         long totalOps = operationCount.get();
         double durationSecs = (endTime - startTime) / 1000.0;


### PR DESCRIPTION
**What does this PR do?**:
Avoid  `IllegalStateException` exception due to double stop, which can result no output from jmh profiler.

**Motivation**:
Cleanup and make benchmark more robust.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
Run the benchmark, `ThreadFilterBenchmark` no longer throws `IllegalStateException` exception.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [ ] JIRA: [PROF-12247](https://datadoghq.atlassian.net/browse/PROF-12247)

Unsure? Have a question? Request a review!


[PROF-12247]: https://datadoghq.atlassian.net/browse/PROF-12247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ