### PR TITLE
ContendedWallclockSamplesTest also fails intermittently when cstack=vmx with graal/aarch64

### DIFF
--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContendedWallclockSamplesTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContendedWallclockSamplesTest.java
@@ -53,7 +53,8 @@ public class ContendedWallclockSamplesTest extends CStackAwareAbstractProfilerTe
     public void test(@CStack String cstack) {
         // Skip test entirely on unsupported JVMs (don't use assumeFalse which gets retried)
         if (Platform.isZing() || Platform.isJ9() ||
-            (isInCI() && isAsan() && Platform.isGraal() && Platform.isAarch64() && "vm".equals(cstack))) {
+            (isInCI() && isAsan() && Platform.isGraal() && Platform.isAarch64() &&
+             ("vm".equals(cstack) || "vmx".equals(cstack)))) {
             return;
         }
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContendedWallclockSamplesTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/ContendedWallclockSamplesTest.java
@@ -5,7 +5,6 @@ import com.datadoghq.profiler.Platform;
 import com.datadoghq.profiler.context.ContextExecutor;
 import com.datadoghq.profiler.junit.CStack;
 import com.datadoghq.profiler.junit.RetryTest;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openjdk.jmc.common.item.IItem;
@@ -21,8 +20,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 
 public class ContendedWallclockSamplesTest extends CStackAwareAbstractProfilerTest {


### PR DESCRIPTION
**What does this PR do?**:
Exclude intermittent test failure.

**Motivation**:
Reduce noise

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
