### PR TITLE
Pad SpinLock to avoid false sharing

### DIFF
--- a/ddprof-lib/src/main/cpp/arch_dd.h
+++ b/ddprof-lib/src/main/cpp/arch_dd.h
@@ -5,6 +5,8 @@
 
 #include <stddef.h>
 
+constexpr int DEFAULT_CACHE_LINE_SIZE = 64;
+
 static inline long long atomicInc(volatile long long &var,
                                   long long increment = 1) {
   return __sync_fetch_and_add(&var, increment);

--- a/ddprof-lib/src/main/cpp/spinLock.h
+++ b/ddprof-lib/src/main/cpp/spinLock.h
@@ -21,13 +21,13 @@
 
 // Cannot use regular mutexes inside signal handler.
 // This lock is based on CAS busy loop. GCC atomic builtins imply full barrier.
-class SpinLock {
+class alignas(DEFAULT_CACHE_LINE_SIZE) SpinLock {
 private:
   //  0 - unlocked
   //  1 - exclusive lock
   // <0 - shared lock
   volatile int _lock;
-
+  char _padding[DEFAULT_CACHE_LINE_SIZE - sizeof(_lock)];
 public:
   constexpr SpinLock(int initial_state = 0) : _lock(initial_state) {}
 

--- a/ddprof-lib/src/main/cpp/spinLock.h
+++ b/ddprof-lib/src/main/cpp/spinLock.h
@@ -29,7 +29,9 @@ private:
   volatile int _lock;
   char _padding[DEFAULT_CACHE_LINE_SIZE - sizeof(_lock)];
 public:
-  constexpr SpinLock(int initial_state = 0) : _lock(initial_state) {}
+  constexpr SpinLock(int initial_state = 0) : _lock(initial_state), _padding() {
+    static_assert(sizeof(SpinLock) == DEFAULT_CACHE_LINE_SIZE);
+  }
 
   void reset() { _lock = 0; }
 


### PR DESCRIPTION
**What does this PR do?**:
Pad `SpinLock` to avoid false sharing.

**Motivation**:
Without proper padding, `Profiler::_locks`, an array of `SpinLock`, is likely suffering from cache line false sharing.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
- Regular tests do not fail
- Benchmarks does not regress

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-12321](https://datadoghq.atlassian.net/browse/PROF-12321)

Unsure? Have a question? Request a review!


[PROF-12321]: https://datadoghq.atlassian.net/browse/PROF-12321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ