### PR TITLE
Fix gradle build task

### DIFF
--- a/ddprof-lib/benchmarks/build.gradle
+++ b/ddprof-lib/benchmarks/build.gradle
@@ -17,7 +17,10 @@ application {
 
 // Include the main library headers
 tasks.withType(CppCompile).configureEach {
+  dependsOn ':ddprof-lib:copyUpstreamFiles'
+
   includes file('../src/main/cpp').toString()
+  includes file('../src/main/cpp-external').toString()
 }
 
 // Add a task to run the benchmark


### PR DESCRIPTION
**What does this PR do?**:
Fix `./gradlew build` task

**Motivation**:

Currently, run `./gradlew build` from java-profiler repository results following error:

```
> Task :ddprof-lib:benchmarks:compileDebugMacosAarch64Cpp FAILED
In file included from /Users/zhengyu.gu/go/src/github.com/DataDog/java-profiler/ddprof-lib/benchmarks/src/unwindFailuresBenchmark.cpp:2:
In file included from /Users/zhengyu.gu/go/src/github.com/DataDog/java-profiler/ddprof-lib/src/main/cpp/unwindStats.h:5:
In file included from /Users/zhengyu.gu/go/src/github.com/DataDog/java-profiler/ddprof-lib/src/main/cpp/spinLock.h:20:
/Users/zhengyu.gu/go/src/github.com/DataDog/java-profiler/ddprof-lib/src/main/cpp/arch_dd.h:4:10: fatal error: 'arch.h' file not found
    4 | #include "arch.h"
      |          ^~~~~~~~
1 error generated.
```

This patch fixes above error.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
Run `./gradlew build` from `java-profiler` repo, build should succeed without error.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
