### PR TITLE
[PROF-12372] Update process context support with version 0.0.7 of reference library

### DIFF
--- a/ddprof-lib/src/main/cpp/otel_process_ctx.h
+++ b/ddprof-lib/src/main/cpp/otel_process_ctx.h
@@ -1,9 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License (Version 2.0).
+// This product includes software developed at Datadog (https://www.datadoghq.com/) Copyright 2025 Datadog, Inc.
+
 #pragma once
 
 #define OTEL_PROCESS_CTX_VERSION_MAJOR 0
 #define OTEL_PROCESS_CTX_VERSION_MINOR 0
-#define OTEL_PROCESS_CTX_VERSION_PATCH 5
-#define OTEL_PROCESS_CTX_VERSION_STRING "0.0.5"
+#define OTEL_PROCESS_CTX_VERSION_PATCH 7
+#define OTEL_PROCESS_CTX_VERSION_STRING "0.0.7"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
**What does this PR do?**

This PR upgrades the process context support with the latest version (0.0.7) of the reference library, taken from
<https://github.com/DataDog/fullhost-code-hotspots-wip/tree/5ec6258b3bd498d5aded14e081bc740a8134ed54/lang-exp/anonmapping-clib>.

Of interest, this version of the context support library:
* Fixes a build issue on the noop build (non-Linux support)
* Fixes dropping the mapping not fully dropping the mapping correctly
* Makes reading work on Linux < 5.17

No changes are needed on the Java side to adopt these improvements.

**Motivation:**

Get latest version into dd-trace-java!

**Additional Notes:**

N/A

**How to test the change?**

The current test coverage should be enough to validate these changes.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [JIRA-12372]