### PR TITLE
Relax memory constraint on independent counters

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ trigger_internal_build:
     - when: always
       allow_failure: false
   variables:
-    DOWNSTREAM_BRANCH: "zgu/remove_legacy_flag"
+    DOWNSTREAM_BRANCH: "main"
     UPSTREAM_PROJECT: ${CI_PROJECT_PATH}
     UPSTREAM_PROJECT_NAME: ${CI_PROJECT_NAME}
     UPSTREAM_BRANCH: ${CI_COMMIT_BRANCH}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ trigger_internal_build:
     - when: always
       allow_failure: false
   variables:
-    DOWNSTREAM_BRANCH: "main"
+    DOWNSTREAM_BRANCH: "zgu/fix-heap-size"
     UPSTREAM_PROJECT: ${CI_PROJECT_PATH}
     UPSTREAM_PROJECT_NAME: ${CI_PROJECT_NAME}
     UPSTREAM_BRANCH: ${CI_COMMIT_BRANCH}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ trigger_internal_build:
     - when: always
       allow_failure: false
   variables:
-    DOWNSTREAM_BRANCH: "main"
+    DOWNSTREAM_BRANCH: "zgu/remove_legacy_flag"
     UPSTREAM_PROJECT: ${CI_PROJECT_PATH}
     UPSTREAM_PROJECT_NAME: ${CI_PROJECT_NAME}
     UPSTREAM_BRANCH: ${CI_COMMIT_BRANCH}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ trigger_internal_build:
     - when: always
       allow_failure: false
   variables:
-    DOWNSTREAM_BRANCH: "zgu/fix-heap-size"
+    DOWNSTREAM_BRANCH: "main"
     UPSTREAM_PROJECT: ${CI_PROJECT_PATH}
     UPSTREAM_PROJECT_NAME: ${CI_PROJECT_NAME}
     UPSTREAM_BRANCH: ${CI_COMMIT_BRANCH}

--- a/ddprof-lib/src/main/cpp/arch_dd.h
+++ b/ddprof-lib/src/main/cpp/arch_dd.h
@@ -14,25 +14,32 @@ static inline long long atomicInc(volatile long long &var,
   return __sync_fetch_and_add(&var, increment);
 }
 
-
-static inline long long atomicIncRelaxed(volatile long long &var,
-                                         long long increment = 1) {
+template <typename T>
+static inline long long atomicIncRelaxed(volatile T &var,
+                                         T increment = 1) {
   return __atomic_fetch_add(&var, increment, __ATOMIC_RELAXED);
 }
 
-static inline u64 loadAcquire(volatile u64 &var) {
+// Atomic load/store (unordered)
+template <typename T>
+static inline T load(volatile T& var) {
+    return __atomic_load_n(&var, __ATOMIC_RELAXED);
+}
+
+template <typename T>
+static inline void store(volatile T& var, T value) {
+  return __atomic_store_n(&var, value, __ATOMIC_RELAXED);
+}
+
+
+// Atomic load-acquire/release-store
+template <typename T>
+static inline T loadAcquire(volatile T& var) {
   return __atomic_load_n(&var, __ATOMIC_ACQUIRE);
 }
 
-static inline size_t loadAcquire(volatile size_t &var) {
-  return __atomic_load_n(&var, __ATOMIC_ACQUIRE);
-}
-
-static inline void storeRelease(volatile long long &var, long long value) {
-  return __atomic_store_n(&var, value, __ATOMIC_RELEASE);
-}
-
-static inline void storeRelease(volatile size_t &var, size_t value) {
+template <typename T>
+static inline void storeRelease(volatile T& var, T value) {
   return __atomic_store_n(&var, value, __ATOMIC_RELEASE);
 }
 

--- a/ddprof-lib/src/main/cpp/arch_dd.h
+++ b/ddprof-lib/src/main/cpp/arch_dd.h
@@ -14,6 +14,12 @@ static inline long long atomicInc(volatile long long &var,
   return __sync_fetch_and_add(&var, increment);
 }
 
+
+static inline long long atomicIncRelaxed(volatile long long &var,
+                                         long long increment = 1) {
+  return __atomic_fetch_add(&var, increment, __ATOMIC_RELAXED);
+}
+
 static inline u64 loadAcquire(volatile u64 &var) {
   return __atomic_load_n(&var, __ATOMIC_ACQUIRE);
 }

--- a/ddprof-lib/src/main/cpp/callTraceHashTable.cpp
+++ b/ddprof-lib/src/main/cpp/callTraceHashTable.cpp
@@ -301,7 +301,7 @@ u64 CallTraceHashTable::put(int num_frames, ASGCT_CallFrame *frames,
 
     if (++step >= capacity) {
       // Very unlikely case of a table overflow
-      atomicInc(_overflow);
+      atomicIncRelaxed(_overflow);
       return OVERFLOW_TRACE_ID;
     }
     // Improved version of linear probing
@@ -359,7 +359,7 @@ void CallTraceHashTable::collectAndCopySelective(std::unordered_set<CallTrace *>
     traces.insert(&_overflow_trace);
     if (trace_ids_to_preserve.find(OVERFLOW_TRACE_ID) != trace_ids_to_preserve.end()) {
       // Copy overflow trace to target - it's a static trace so just increment overflow counter
-      atomicInc(target->_overflow);
+      atomicIncRelaxed(target->_overflow);
     }
   }
 }

--- a/ddprof-lib/src/main/cpp/callTraceHashTable.h
+++ b/ddprof-lib/src/main/cpp/callTraceHashTable.h
@@ -52,7 +52,7 @@ private:
 
   LinearAllocator _allocator;
   LongHashTable *_current_table;
-  u64 _overflow;
+  volatile u64 _overflow;
 
   u64 calcHash(int num_frames, ASGCT_CallFrame *frames, bool truncated);
   CallTrace *storeCallTrace(int num_frames, ASGCT_CallFrame *frames,

--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -124,9 +124,9 @@ public:
   static void increment(CounterId counter, long long delta = 1,
                         int offset = 0) {
 #ifdef COUNTERS
-    atomicInc(Counters::instance()
-                  ._counters[address(static_cast<int>(counter) + offset)],
-              delta);
+    atomicIncRelaxed(Counters::instance()
+                         ._counters[address(static_cast<int>(counter) + offset)],
+                     delta);
 #endif // COUNTERS
   }
 

--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -30,8 +30,8 @@ void LivenessTracker::cleanup_table(bool forced) {
   u64 target_gc_epoch = load(_gc_epoch);
 
   if ((target_gc_epoch == _last_gc_epoch ||
-       !__sync_bool_compare_and_swap(&_last_gc_epoch, current,
-                                     target_gc_epoch)) &&
+       !__atomic_compare_exchange_n(&_last_gc_epoch, &current,
+                                     target_gc_epoch, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) &&
       !forced) {
     // if the last processed GC epoch hasn't changed, or if we failed to update
     // it, there's nothing to do

--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -26,8 +26,8 @@ constexpr int LivenessTracker::MAX_TRACKING_TABLE_SIZE;
 constexpr int LivenessTracker::MIN_SAMPLING_INTERVAL;
 
 void LivenessTracker::cleanup_table(bool forced) {
-  u64 current = loadAcquire(_last_gc_epoch);
-  u64 target_gc_epoch = loadAcquire(_gc_epoch);
+  u64 current = load(_last_gc_epoch);
+  u64 target_gc_epoch = load(_gc_epoch);
 
   if ((target_gc_epoch == _last_gc_epoch ||
        !__sync_bool_compare_and_swap(&_last_gc_epoch, current,
@@ -383,10 +383,10 @@ void LivenessTracker::onGC() {
   }
 
   // just increment the epoch
-  atomicInc(_gc_epoch, 1);
+  atomicIncRelaxed(_gc_epoch,u64(1));
 
   if (!ddprof::HeapUsage::isLastGCUsageSupported()) {
-    storeRelease(_used_after_last_gc, ddprof::HeapUsage::get(false)._used);
+    store(_used_after_last_gc, ddprof::HeapUsage::get(false)._used);
   }
 }
 

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -93,7 +93,7 @@ private:
   WaitableMutex _timer_lock;
   void *_timer_id;
 
-  u64 _total_samples;
+  volatile u64 _total_samples;
   u64 _failures[ASGCT_FAILURE_TYPES];
 
   SpinLock _class_map_lock;


### PR DESCRIPTION
**What does this PR do?**:
Relax memory constraints on independent counters.

**Motivation**:
Independent counter only requires atomic guarantee, stronger memory constraints can result unnecessary performance degradation.

**Additional Notes**:


**How to test the change?**:
- Regular unit tests
- Stress tests
- Benchmarks

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-12559](https://datadoghq.atlassian.net/browse/PROF-12559)

Unsure? Have a question? Request a review!


[PROF-12559]: https://datadoghq.atlassian.net/browse/PROF-12559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ