### PR TITLE
Fix MacOSX signal handler

### DIFF
--- a/ddprof-lib/src/main/cpp/os_dd.h
+++ b/ddprof-lib/src/main/cpp/os_dd.h
@@ -7,11 +7,11 @@
 namespace ddprof {
 class OS : public ::OS {
 public:
-  inline static SigAction replaceSigsegvHandler(SigAction action) {
+  static SigAction replaceSigsegvHandler(SigAction action);
+
+  inline static SigAction replaceSigbusHandler(SigAction action) {
     return ::OS::replaceCrashHandler(action);
   }
-
-  static SigAction replaceSigbusHandler(SigAction action);
 
   inline static int getMaxThreadId(int floor) {
     int maxThreadId = ::OS::getMaxThreadId();

--- a/ddprof-lib/src/main/cpp/os_dd.h
+++ b/ddprof-lib/src/main/cpp/os_dd.h
@@ -8,10 +8,7 @@ namespace ddprof {
 class OS : public ::OS {
 public:
   static SigAction replaceSigsegvHandler(SigAction action);
-
-  inline static SigAction replaceSigbusHandler(SigAction action) {
-    return ::OS::replaceCrashHandler(action);
-  }
+  static SigAction replaceSigbusHandler(SigAction action);
 
   inline static int getMaxThreadId(int floor) {
     int maxThreadId = ::OS::getMaxThreadId();

--- a/ddprof-lib/src/main/cpp/os_linux_dd.cpp
+++ b/ddprof-lib/src/main/cpp/os_linux_dd.cpp
@@ -29,6 +29,10 @@ void ddprof::OS::mallocArenaMax(int arena_max) {
 #endif
 }
 
+SigAction ddprof::OS::replaceSigsegvHandler(SigAction action) {
+  return ::OS::replaceCrashHandler(action);
+}
+
 SigAction ddprof::OS::replaceSigbusHandler(SigAction action) {
   struct sigaction sa;
   sigaction(SIGBUS, NULL, &sa);

--- a/ddprof-lib/src/main/cpp/os_macos_dd.cpp
+++ b/ddprof-lib/src/main/cpp/os_macos_dd.cpp
@@ -16,12 +16,12 @@ void ddprof::OS::mallocArenaMax(int arena_max) {
   // Not supported on macOS
 }
 
-SigAction ddprof::OS::replaceSigbusHandler(SigAction action) {
+SigAction ddprof::OS::replaceSigsegvHandler(SigAction action) {
   struct sigaction sa;
-  sigaction(SIGBUS, NULL, &sa);
+  sigaction(SIGSEGV, NULL, &sa);
   SigAction old_action = sa.sa_sigaction;
   sa.sa_sigaction = action;
-  sigaction(SIGBUS, &sa, NULL);
+  sigaction(SIGSEGV, &sa, NULL);
   return old_action;
 }
 

--- a/ddprof-lib/src/main/cpp/os_macos_dd.cpp
+++ b/ddprof-lib/src/main/cpp/os_macos_dd.cpp
@@ -16,6 +16,10 @@ void ddprof::OS::mallocArenaMax(int arena_max) {
   // Not supported on macOS
 }
 
+SigAction ddprof::OS::replaceSigbusHandler(SigAction action) {
+  return ::OS::replaceCrashHandler(action);
+}
+
 SigAction ddprof::OS::replaceSigsegvHandler(SigAction action) {
   struct sigaction sa;
   sigaction(SIGSEGV, NULL, &sa);


### PR DESCRIPTION
**What does this PR do?**:
Fix signal handler for MacOSX.

**Motivation**:
async-profiler upstream merged crash signal handler, but there is a subtle difference between Linux and MacOSX.
On linux, it handles `SIGSEGV` signal, but on MacOSX, it handles `SIGBUS`.

When downporting above change, it mistakenly reinstalled `SIGBUS` handler, resulting no signal handler for `SIGSEV` for MacOSX. The bug manifested in safeAccess_ut test failure on MacOSX.

**Additional Notes**:

**How to test the change?**:
safeAccess_ut test should pass on negative test cases.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
