### PR TITLE
Update the async-profiler lock to use anchored walker

### DIFF
--- a/gradle/lock.properties
+++ b/gradle/lock.properties
@@ -1,5 +1,5 @@
 ap.branch=dd/master
-ap.commit=a1b896f4d1ffb6035204e41c32664422d565683b
+ap.commit=ed89a05421e2c0848d41b5a7c21b5cb3095eb916
 
 ctx_branch=main
 ctx_commit=b33673d801b85a6c38fa0e9f1a139cb246737ce8


### PR DESCRIPTION
**What does this PR do?**:
Use the improved stackwalker which gets rid of bunch of 'unknown' frames by smartly using Java frame anchor or 'inferring' root frames for situations where we eg. don't have good enough unwinding info for libc/pthread functions.

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-12677]

Unsure? Have a question? Request a review!


[PROF-12677]: https://datadoghq.atlassian.net/browse/PROF-12677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ