### PR TITLE
Fix calltracestorage concurrent and reentrant issues

### DIFF
--- a/.claude/commands/build-and-summarize
+++ b/.claude/commands/build-and-summarize
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p build/logs build/reports/claude .claude/out
+STAMP="$(date +%Y%m%d-%H%M%S)"
+
+# Args (default to 'build')
+ARGS=("$@")
+if [ "${#ARGS[@]}" -eq 0 ]; then
+  ARGS=(build)
+fi
+
+# Label for the log file from the first arg
+LABEL="$(printf '%s' "${ARGS[0]}" | tr '/:' '__')"
+LOG="build/logs/${STAMP}-${LABEL}.log"
+
+# Ensure we clean the tail on exit
+tail_pid=""
+cleanup() { [ -n "${tail_pid:-}" ] && kill "$tail_pid" 2>/dev/null || true; }
+trap cleanup EXIT INT TERM
+
+echo "▶ Logging full Gradle output to: $LOG"
+echo "▶ Running: ./gradlew ${ARGS[*]} -i --console=plain"
+echo "   (Console output here is minimized; the full log is in the file.)"
+echo
+
+# Start Gradle fully redirected to the log (no stdout/stderr to this session)
+# Use stdbuf to make the output line-buffered in the log for timely tailing.
+( stdbuf -oL -eL ./gradlew "${ARGS[@]}" -i --console=plain ) >"$LOG" 2>&1 &
+gradle_pid=$!
+
+# Minimal live progress: follow the log and print only interesting lines
+#  - Task starts
+#  - Final build status
+#  - Test summary lines
+tail -n0 -F "$LOG" | awk '
+  /^> Task / { print; fflush(); next }
+  /^BUILD (SUCCESSFUL|FAILED)/ { print; fflush(); next }
+  /[0-9]+ tests? (successful|failed|skipped)/ { print; fflush(); next }
+' &
+tail_pid=$!
+
+# Wait for Gradle to finish
+wait "$gradle_pid"
+status=$?
+
+# Stop the tail and print a compact summary from the log
+kill "$tail_pid" 2>/dev/null || true
+tail_pid=""
+
+echo
+echo "=== Summary ==="
+# Grab the last BUILD line and nearest test summary lines
+awk '
+  /^BUILD (SUCCESSFUL|FAILED)/ { lastbuild=$0 }
+  /[0-9]+ tests? (successful|failed|skipped)/ { tests=$0 }
+  END {
+    if (lastbuild) print lastbuild;
+    if (tests) print tests;
+  }
+' "$LOG" || true
+
+echo
+if [ $status -eq 0 ]; then
+  echo "✔ Gradle completed. Full log at: $LOG"
+else
+  echo "✖ Gradle failed with status $status. Full log at: $LOG"
+fi
+
+# Hand over to your logs analyst agent — keep the main session output tiny.
+echo
+echo "Delegating to gradle-logs-analyst agent…"
+# If your CLI supports non-streaming, set it here to avoid verbose output.
+# Example (uncomment if supported): export CLAUDE_NO_STREAM=1
+claude "Act as the gradle-logs-analyst agent to parse the build log at: $LOG. Generate the required Gradle summary artifacts as specified in the gradle-logs-analyst agent definition."

--- a/.claude/commands/build-and-summarize.md
+++ b/.claude/commands/build-and-summarize.md
@@ -1,33 +1,7 @@
----
-description: Run a Gradle task, capture console to a timestamped log, then delegate parsing to the sub-agent and reply briefly.
-usage: "/build-and-summarize <gradle-args...>"
----
+# build-and-summarize
 
-**Task:** Build with Gradle (plain console, info level), capture output to `build/logs/`, then have `gradle-log-analyst` parse the log and write:
-- `build/reports/claude/gradle-summary.md`
-- `build/reports/claude/gradle-summary.json`
+Runs `./gradlew` with full output captured to a timestamped log, shows minimal live progress (task starts + final build/test summary), then asks the `gradle-logs-analyst` agent to produce structured artifacts from the log.
 
-Make sure to use the JAVA_HOME environment variable is set appropriately. 
-
+## Usage
 ```bash
-set -euo pipefail
-mkdir -p build/logs build/reports/claude
-STAMP="$(date +%Y%m%d-%H%M%S)"
-
-# Default to 'build' if no args were given
-ARGS=("$@")
-if [ "${#ARGS[@]}" -eq 0 ]; then
-  ARGS=(build)
-fi
-
-# Make a filename-friendly label (first arg only)
-LABEL="$(echo "${ARGS[0]}" | tr '/:' '__')"
-LOG="build/logs/${STAMP}-${LABEL}.log"
-
-echo "Running: ./gradlew ${ARGS[*]} -i --console=plain"
-# Capture both stdout and stderr to the log while streaming to terminal
-(./gradlew "${ARGS[@]}" -i --console=plain 2>&1 | tee "$LOG") || true
-
-# Delegate parsing to the sub-agent
-echo "Delegating to gradle-logs-analyst agent..."
-claude "Act as the gradle-logs-analyst agent to parse the build log at: $LOG. Generate the required gradle summary artifacts as specified in the gradle-logs-analyst agent definition."
+./.claude/commands/build-and-summarize [<gradle-args>...]

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,8 @@
       "Bash(grep:*)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
-      "WebFetch(domain:raw.githubusercontent.com)"
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "Bash(./.claude/commands/build-and-summarize:*)"
     ],
     "deny": [],
     "ask": []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ You are the **Main Orchestrator** for this repository.
   “Use `gradle-log-analyst` to parse LOG_PATH; write the two reports; reply with only a 3–6 line status and the two relative file paths.”
 
 ### Shortcuts I Expect
-- `/build-and-summarize <gradle-task...>` to do everything in one step.
+- `./gradlew <gradle-task...>` to do everything in one step.
 - If I just say “build assembleDebugJar”, interpret that as the shortcut above.
 
 ## Build Commands
@@ -50,74 +50,74 @@ Never use 'gradle' or 'gradlew' directly. Instead, use the '/build-and-summarize
 ### Main Build Tasks
 ```bash
 # Build release version (primary artifact)
-/build-and-summarize buildRelease
+./gradlew buildRelease
 
 # Build all configurations
-/build-and-summarize assembleAll
+./gradlew assembleAll
 
 # Clean build
-/build-and-summarize clean
+./gradlew clean
 ```
 
 ### Development Builds
 ```bash
 # Debug build with symbols
-/build-and-summarize buildDebug
+./gradlew buildDebug
 
 # ASan build (if available)
-/build-and-summarize buildAsan
+./gradlew buildAsan
 
 # TSan build (if available)
-/build-and-summarize buildTsan
+./gradlew buildTsan
 ```
 
 ### Testing
 ```bash
 # Run specific test configurations
-/build-and-summarize testRelease
-/build-and-summarize testDebug
-/build-and-summarize testAsan
-/build-and-summarize testTsan
+./gradlew testRelease
+./gradlew testDebug
+./gradlew testAsan
+./gradlew testTsan
 
 # Run C++ unit tests only
-/build-and-summarize gtestDebug
-/build-and-summarize gtestRelease
+./gradlew gtestDebug
+./gradlew gtestRelease
 
 # Cross-JDK testing
-JAVA_TEST_HOME=/path/to/test/jdk /build-and-summarize testDebug
+JAVA_TEST_HOME=/path/to/test/jdk ./gradlew testDebug
 ```
 
 ### Build Options
 ```bash
 # Skip native compilation
-/build-and-summarize buildDebug -Pskip-native
+./gradlew buildDebug -Pskip-native
 
 # Skip all tests
-/build-and-summarize buildDebug -Pskip-tests
+./gradlew buildDebug -Pskip-tests
 
 # Skip C++ tests
-/build-and-summarize buildDebug -Pskip-gtest
+./gradlew buildDebug -Pskip-gtest
 
 # Keep JFR recordings after tests
-/build-and-summarize testDebug -PkeepJFRs
+./gradlew testDebug -PkeepJFRs
 
 # Skip debug symbol extraction
-/build-and-summarize buildRelease -Pskip-debug-extraction=true
+./gradlew buildRelease -Pskip-debug-extraction=true
 ```
 
 ### Code Quality
 ```bash
 # Format code
-/build-and-summarize spotlessApply
+./gradlew spotlessApply
 
 # Static analysis
-/build-and-summarize scanBuild
+./gradlew scanBuild
 
 # Run stress tests
-/build-and-summarize :ddprof-stresstest:runStressTests
+./gradlew :ddprof-stresstest:runStressTests
 
 # Run benchmarks
-/build-and-summarize runBenchmarks
+./gradlew runBenchmarks
 ```
 
 ## Architecture
@@ -338,3 +338,39 @@ With separate debug symbol packages for production debugging support.
 
 - Run tests with 'testdebug' gradle task
 - Use at most Java 21 to build and run tests
+
+## Agentic Work
+
+- Never run `./gradlew` directly.
+- Always invoke the wrapper command: `./.claude/commands/build-and-summarize`.
+- Pass through all arguments exactly as you would to `./gradlew`.
+- Examples:
+    - Instead of:
+      ```bash
+      ./gradlew build
+      ```
+      use:
+      ```bash
+      ./.claude/commands/build-and-summarize build
+      ```
+    - Instead of:
+      ```bash
+      ./gradlew :prof-utils:test --tests "UpscaledMethodSampleEventSinkTest"
+      ```
+      use:
+      ```bash
+      ./.claude/commands/build-and-summarize :prof-utils:test --tests "UpscaledMethodSampleEventSinkTest"
+      ```
+
+- This ensures the full build log is captured to a file and only a summary is shown in the main session.
+
+## Ground rules
+- Never replace the code you work on with stubs
+- Never 'fix' the tests by testing constants against constants
+- Never claim success until all affected tests are passing
+- Always provide javadoc for public classes and methods
+- Provide javadoc for non-trivial private and package private code
+- Always provide comprehensive tests for new functionality
+- Always provide tests for bug fixes - test fails before the fix, passes after the fix
+- All code needs to strive to be lean in terms of resources consumption and easy to follow -
+    do not shy away from factoring out self containing code to shorter functions with explicit name

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Introduced race-free critical section management using atomic compare-and-swap o
 Enhanced the call trace storage system from double-buffered to triple-buffered architecture with hazard pointer-based memory reclamation:
 
 - **Triple buffering**: Active, standby, and cleanup storage rotation for smoother transitions
-- **Hazard pointer system**: Per-instance thread-safe memory reclamation without global locks  
+- **Hazard pointer system**: Per-instance thread-safe memory reclamation without global locks
 - **ABA protection**: Generation counter prevents race conditions during table swaps
 - **Instance-based trace IDs**: 64-bit IDs combining instance ID and slot for collision-free trace management
 - **Lock-free hot paths**: Atomic operations minimize contention during profiling events

--- a/ddprof-lib/src/main/cpp/callTraceHashTable.cpp
+++ b/ddprof-lib/src/main/cpp/callTraceHashTable.cpp
@@ -105,9 +105,7 @@ CallTraceHashTable::~CallTraceHashTable() {
 
 void CallTraceHashTable::clear() {
   // Wait for all hazard pointers to clear before deallocation to prevent races
-  if (_parent_storage != nullptr) {
-    _parent_storage->waitForAllHazardPointersToClear();
-  }
+  HazardPointer::waitForAllHazardPointersToClear();
   
   // Clear previous chain pointers to prevent traversal during deallocation
   for (LongHashTable *table = _table; table != nullptr; table = table->prev()) {

--- a/ddprof-lib/src/main/cpp/callTraceHashTable.cpp
+++ b/ddprof-lib/src/main/cpp/callTraceHashTable.cpp
@@ -8,9 +8,12 @@
 #include "counters.h"
 #include "os.h"
 #include "arch_dd.h"
+#include "common.h"
 #include <string.h>
+#include <signal.h>
+#include <pthread.h>
 
-static const u32 INITIAL_CAPACITY = 65536;
+static const u32 INITIAL_CAPACITY = 65536;  // 64K initial table size (matches upstream)
 static const u32 CALL_TRACE_CHUNK = 8 * 1024 * 1024;
 static const u64 OVERFLOW_TRACE_ID = 0x7fffffffffffffffULL;  // Max 64-bit signed value
 
@@ -38,26 +41,21 @@ public:
     memset(_padding2, 0, sizeof(_padding2));
   }
 
-  static LongHashTable *allocate(LongHashTable *prev, u32 capacity) {
-    LongHashTable *table = (LongHashTable *)OS::safeAlloc(getSize(capacity));
+  static LongHashTable *allocate(LongHashTable *prev, u32 capacity, LinearAllocator* allocator) {
+    LongHashTable *table = (LongHashTable *)allocator->alloc(getSize(capacity));
     if (table != nullptr) {
       table->_prev = prev;
       table->_capacity = capacity;
-      // The reset is not useful with the anon mmap setting the memory is
-      // zeroed. However this silences a false positive and should not have a
-      // performance impact.
+      table->_size = 0;  // Initialize size to 0
+      // LinearAllocator doesn't zero memory like OS::safeAlloc with anon mmap
+      // so we need to explicitly clear the keys and values
       table->clear();
     }
     return table;
   }
 
-  LongHashTable *destroy() {
-    LongHashTable *prev = _prev;
-    OS::safeFree(this, getSize(_capacity));
-    return prev;
-  }
-
   LongHashTable *prev() { return _prev; }
+  void setPrev(LongHashTable* prev) { _prev = prev; }
 
   u32 capacity() { return _capacity; }
 
@@ -77,26 +75,42 @@ public:
 
 CallTrace CallTraceHashTable::_overflow_trace = {false, 1, OVERFLOW_TRACE_ID, {BCI_ERROR, LP64_ONLY(0 COMMA) (jmethodID)"storage_overflow"}};
 
-CallTraceHashTable::CallTraceHashTable() : _allocator(CALL_TRACE_CHUNK) {
-  _instance_id = 0;  // Will be set externally via setInstanceId()
-  _current_table = LongHashTable::allocate(nullptr, INITIAL_CAPACITY);
+CallTraceHashTable::CallTraceHashTable() : _allocator(CALL_TRACE_CHUNK), _instance_id(0), _parent_storage(nullptr) {
+  // Instance ID will be set externally via setInstanceId()
+  
+  // Start with initial capacity, allowing expansion as needed
+  _table = LongHashTable::allocate(nullptr, INITIAL_CAPACITY, &_allocator);
   _overflow = 0;
 }
 
 CallTraceHashTable::~CallTraceHashTable() {
-  while (_current_table != nullptr) {
-    _current_table = _current_table->destroy();
-  }
+  // LinearAllocator handles all memory cleanup automatically
+  // No need to explicitly destroy tables since they're allocated from LinearAllocator
+  // Note: No synchronization needed here because CallTraceStorage ensures
+  // no new operations can start by nullifying storage pointers first
+  _table = nullptr;
 }
 
+
 void CallTraceHashTable::clear() {
-  if (_current_table != nullptr) {
-    while (_current_table->prev() != nullptr) {
-      _current_table = _current_table->destroy();
-    }
-    _current_table->clear();
+  // Wait for all hazard pointers to clear before deallocation to prevent races
+  if (_parent_storage != nullptr) {
+    _parent_storage->waitForAllHazardPointersToClear();
   }
+  
+  // Clear previous chain pointers to prevent traversal during deallocation
+  for (LongHashTable *table = _table; table != nullptr; table = table->prev()) {
+    LongHashTable *prev_table = table->prev();
+    if (prev_table != nullptr) {
+      table->setPrev(nullptr);  // Clear link before deallocation
+    }
+  }
+  
+  // Now safe to deallocate all memory
   _allocator.clear();
+  
+  // Reinitialize with fresh table
+  _table = LongHashTable::allocate(nullptr, INITIAL_CAPACITY, &_allocator);
   _overflow = 0;
 }
 
@@ -174,14 +188,11 @@ CallTrace *CallTraceHashTable::findCallTrace(LongHashTable *table, u64 hash) {
 
 u64 CallTraceHashTable::put(int num_frames, ASGCT_CallFrame *frames,
                           bool truncated, u64 weight) {
-  // Synchronization is now handled at CallTraceStorage facade level
-  
   u64 hash = calcHash(num_frames, frames, truncated);
 
-  LongHashTable *table = _current_table;
+  LongHashTable *table = _table;
   if (table == nullptr) {
     // Table allocation failed or was cleared - drop sample
-    // This could be: 1) Initial allocation failure, 2) Use-after-destruction during shutdown
     Counters::increment(CALLTRACE_STORAGE_DROPPED);
     return CallTraceStorage::DROPPED_TRACE_ID;
   }
@@ -190,6 +201,7 @@ u64 CallTraceHashTable::put(int num_frames, ASGCT_CallFrame *frames,
   u32 capacity = table->capacity();
   u32 slot = hash & (capacity - 1);
   u32 step = 0;
+  
   while (true) {
     u64 key_value = __atomic_load_n(&keys[slot], __ATOMIC_RELAXED);
     if (key_value == hash) { 
@@ -229,18 +241,16 @@ u64 CallTraceHashTable::put(int num_frames, ASGCT_CallFrame *frames,
         // Trace is ready, use it
         return current_trace->trace_id;
       } else {
-        // Trace is nullptr but hash exists - this indicates preparation failed
-        // Read the key again to confirm it's still there
+        // Trace is nullptr but hash exists - preparation failed
         u64 recheck_key = __atomic_load_n(&keys[slot], __ATOMIC_ACQUIRE);
         if (recheck_key != hash) {
-          // Key was cleared by the preparing thread, retry the search
-          continue;
+          continue; // Key was cleared, retry
         }
-        // Key still exists but trace is null - preparation failed
         Counters::increment(CALLTRACE_STORAGE_DROPPED);
         return CallTraceStorage::DROPPED_TRACE_ID;
       }
     }
+    
     if (key_value == 0) {
       u64 expected = 0;
       if (!__atomic_compare_exchange_n(&keys[slot], &expected, hash, false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
@@ -254,71 +264,70 @@ u64 CallTraceHashTable::put(int num_frames, ASGCT_CallFrame *frames,
         __atomic_store_n(&keys[slot], 0, __ATOMIC_RELEASE);
         continue;
       }
-      
-      // Increment the table size, and if the load factor exceeds 0.75, reserve
-      // a new table
-      u32 current_size = table->incSize();
-      if (current_size == capacity * 3 / 4) {
-        LongHashTable *new_table = LongHashTable::allocate(table, capacity * 2);
+
+      // Increment size counter for statistics and check for expansion
+      u32 new_size = table->incSize();
+      u32 capacity = table->capacity();
+
+      // EXPANSION LOGIC: Check if 75% capacity reached after incrementing size
+      if (new_size == capacity * 3 / 4) {
+        // Allocate new table with double capacity using LinearAllocator
+        LongHashTable* new_table = LongHashTable::allocate(table, capacity * 2, &_allocator);
         if (new_table != nullptr) {
-          // Use atomic CAS to safely update _current_table
-          __atomic_compare_exchange_n(&_current_table, &table, new_table, false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED);
+          // Atomic table swap - only one thread succeeds
+          __atomic_compare_exchange_n(&_table, &table, new_table, false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED);
         }
       }
 
-      // Migrate from a previous table to save space
-      CallTrace *trace =
-          table->prev() == nullptr ? nullptr : findCallTrace(table->prev(), hash);
+      // Check if trace exists in previous tables to avoid duplication
+      CallTrace *trace = nullptr;
+      if (table->prev() != nullptr) {
+        trace = findCallTrace(table->prev(), hash);
+      }
+      
       if (trace == nullptr) {
         // Generate unique trace ID: upper 32 bits = instance_id, lower 32 bits = slot
-        // 64-bit provides massive collision space and JFR constant pool compatibility
-        u64 trace_id = (_instance_id << 32) | slot;
+        u64 instance_id = _instance_id;
+        u64 trace_id = (instance_id << 32) | slot;
         trace = storeCallTrace(num_frames, frames, truncated, trace_id);
         if (trace == nullptr) {
-          // Allocation failure - reset trace first, then clear key with proper memory ordering
+          // Allocation failure - reset trace first, then clear key
           table->values()[slot].setTrace(nullptr);
-          // Use full memory barrier to ensure trace=null is visible before key=0
           __atomic_thread_fence(__ATOMIC_SEQ_CST);
           __atomic_store_n(&keys[slot], 0, __ATOMIC_RELEASE);
           Counters::increment(CALLTRACE_STORAGE_DROPPED);
           return CallTraceStorage::DROPPED_TRACE_ID;
         }
       }
-      // Note: For migrated traces, we preserve their original trace_id from when they were first created
+      
       // Set the actual trace (this changes state from PREPARING to ready)
       table->values()[slot].setTrace(trace);
-      
-      // clear the slot in the prev table such it is not written out to constant
-      // pool multiple times
-      LongHashTable *prev_table = table->prev();
-      if (prev_table != nullptr) {
-        __atomic_store_n(&prev_table->keys()[slot], 0, __ATOMIC_RELEASE);
-      }
-      
-      // Return immediately since we just created/set up this trace
       return trace->trace_id;
     }
 
     if (++step >= capacity) {
-      // Very unlikely case of a table overflow
+      // Table overflow - very unlikely with expansion logic
       atomicIncRelaxed(_overflow);
       return OVERFLOW_TRACE_ID;
     }
-    // Improved version of linear probing
+    // Linear probing with step increment
     slot = (slot + step) & (capacity - 1);
   }
 }
 
 void CallTraceHashTable::collect(std::unordered_set<CallTrace *> &traces) {
-  // Simple collection without copying - used for lock-free processing
-  for (LongHashTable *table = _current_table; table != nullptr; table = table->prev()) {
+  // Lock-free collection for read-only tables (after atomic swap)
+  // No new put() operations can occur, so no synchronization needed
+  
+  // Collect from all tables in the chain (current and previous tables)
+  for (LongHashTable *table = _table; table != nullptr; table = table->prev()) {
     u64 *keys = table->keys();
     CallTraceSample *values = table->values();
     u32 capacity = table->capacity();
     for (u32 slot = 0; slot < capacity; slot++) {
       if (keys[slot] != 0) {
         CallTrace *trace = values[slot].acquireTrace();
-        if (trace != nullptr) {
+        if (trace != nullptr && trace != CallTraceSample::PREPARING) {
           traces.insert(trace);
         }
       }
@@ -331,45 +340,21 @@ void CallTraceHashTable::collect(std::unordered_set<CallTrace *> &traces) {
   }
 }
 
-void CallTraceHashTable::collectAndCopySelective(std::unordered_set<CallTrace *> &traces, 
-                                                  const std::unordered_set<u64> &trace_ids_to_preserve, 
-                                                  CallTraceHashTable* target) {
-  for (LongHashTable *table = _current_table; table != nullptr; table = table->prev()) {
-    u64 *keys = table->keys();
-    CallTraceSample *values = table->values();
-    u32 capacity = table->capacity();
-    for (u32 slot = 0; slot < capacity; slot++) {
-      if (keys[slot] != 0) {
-        CallTrace *trace = values[slot].acquireTrace();
-        if (trace != nullptr) {
-          // Always collect for JFR output - trace contains its own ID
-          traces.insert(trace);
-          
-          // Copy to target if this trace should be preserved, preserving the original trace ID
-          if (trace_ids_to_preserve.find(trace->trace_id) != trace_ids_to_preserve.end()) {
-            target->putWithExistingId(trace, 1);
-          }
-        }
-      }
-    }
-  }
-  
-  // Handle overflow trace
-  if (_overflow > 0) {
-    traces.insert(&_overflow_trace);
-    if (trace_ids_to_preserve.find(OVERFLOW_TRACE_ID) != trace_ids_to_preserve.end()) {
-      // Copy overflow trace to target - it's a static trace so just increment overflow counter
-      atomicIncRelaxed(target->_overflow);
-    }
-  }
-}
 
 void CallTraceHashTable::putWithExistingId(CallTrace* source_trace, u64 weight) {
-  // Synchronization is now handled at CallTraceStorage facade level
-  
+  // This method is rarely used now that we have lock-free preservation
   u64 hash = calcHash(source_trace->num_frames, source_trace->frames, source_trace->truncated);
   
-  LongHashTable *table = _current_table;
+  // First check if trace already exists in any table in the chain
+  for (LongHashTable *search_table = _table; search_table != nullptr; search_table = search_table->prev()) {
+    CallTrace *existing_trace = findCallTrace(search_table, hash);
+    if (existing_trace != nullptr) {
+      // Trace already exists in the chain
+      return;
+    }
+  }
+  
+  LongHashTable *table = _table;
   if (table == nullptr) {
     // Table allocation failed or was cleared - drop sample
     return;
@@ -379,7 +364,7 @@ void CallTraceHashTable::putWithExistingId(CallTrace* source_trace, u64 weight) 
   u32 capacity = table->capacity();
   u32 slot = hash & (capacity - 1);
   
-  // Look for existing entry or empty slot
+  // Look for existing entry or empty slot in current table
   while (true) {
     u64 key_value = __atomic_load_n(&keys[slot], __ATOMIC_RELAXED);
     if (key_value == hash) {
@@ -401,7 +386,7 @@ void CallTraceHashTable::putWithExistingId(CallTrace* source_trace, u64 weight) 
         copied_trace->truncated = source_trace->truncated;
         copied_trace->num_frames = source_trace->num_frames;
         copied_trace->trace_id = source_trace->trace_id; // Preserve exact trace ID
-        // Safe to use memcpy since this is not called from signal handler
+        // memcpy safe since not in signal handler
         memcpy(copied_trace->frames, source_trace->frames, source_trace->num_frames * sizeof(ASGCT_CallFrame));
         table->values()[slot].setTrace(copied_trace);
         Counters::increment(CALLTRACE_STORAGE_BYTES, total_size);
@@ -412,14 +397,72 @@ void CallTraceHashTable::putWithExistingId(CallTrace* source_trace, u64 weight) 
         return;
       }
       
-      // Check if we need to expand the table
-      u32 current_size = table->incSize();
-      if (current_size == capacity * 3 / 4) {
-        LongHashTable *new_table = LongHashTable::allocate(table, capacity * 2);
-        if (new_table != nullptr) {
-          // Use atomic CAS to safely update _current_table
-          __atomic_compare_exchange_n(&_current_table, &table, new_table, false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED);
-        }
+      // Increment table size
+      table->incSize();
+      break;
+    }
+    
+    slot = (slot + 1) & (capacity - 1);
+  }
+}
+
+void CallTraceHashTable::putWithExistingIdLockFree(CallTrace* source_trace, u64 weight) {
+  // Lock-free trace preservation for standby tables (no contention with new puts)
+  // This is safe because new put() operations go to the new active table
+  
+  u64 hash = calcHash(source_trace->num_frames, source_trace->frames, source_trace->truncated);
+  
+  // First check if trace already exists in any table in the chain
+  for (LongHashTable *search_table = _table; search_table != nullptr; search_table = search_table->prev()) {
+    CallTrace *existing_trace = findCallTrace(search_table, hash);
+    if (existing_trace != nullptr) {
+      // Trace already exists in the chain
+      return;
+    }
+  }
+  
+  LongHashTable *table = _table;
+  if (table == nullptr) {
+    return; // Table allocation failed
+  }
+  
+  u64 *keys = table->keys();
+  u32 capacity = table->capacity();
+  u32 slot = hash & (capacity - 1);
+  
+  // Look for existing entry or empty slot - no locking needed
+  while (true) {
+    u64 key_value = __atomic_load_n(&keys[slot], __ATOMIC_RELAXED);
+    if (key_value == hash) {
+      // Found existing entry - just use it (trace already preserved)
+      break;
+    }
+    if (key_value == 0) {
+      // Found empty slot - claim it atomically
+      u64 expected = 0;
+      if (!__atomic_compare_exchange_n(&keys[slot], &expected, hash, false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
+        continue; // Another thread claimed it, try next slot
+      }
+      
+      // Create a copy of the source trace preserving its exact ID
+      const size_t header_size = sizeof(CallTrace) - sizeof(ASGCT_CallFrame);
+      const size_t total_size = header_size + source_trace->num_frames * sizeof(ASGCT_CallFrame);
+      CallTrace* copied_trace = (CallTrace*)_allocator.alloc(total_size);
+      if (copied_trace != nullptr) {
+        copied_trace->truncated = source_trace->truncated;
+        copied_trace->num_frames = source_trace->num_frames;
+        copied_trace->trace_id = source_trace->trace_id; // Preserve exact trace ID
+        // memcpy safe since not in signal handler
+        memcpy(copied_trace->frames, source_trace->frames, source_trace->num_frames * sizeof(ASGCT_CallFrame));
+        table->values()[slot].setTrace(copied_trace);
+        Counters::increment(CALLTRACE_STORAGE_BYTES, total_size);
+        Counters::increment(CALLTRACE_STORAGE_TRACES);
+        
+        // Increment table size
+        table->incSize();
+      } else {
+        // Allocation failure - clear the key we claimed
+        __atomic_store_n(&keys[slot], 0, __ATOMIC_RELEASE);
       }
       break;
     }

--- a/ddprof-lib/src/main/cpp/callTraceHashTable.h
+++ b/ddprof-lib/src/main/cpp/callTraceHashTable.h
@@ -19,6 +19,10 @@ struct CallTrace {
   int num_frames;
   u64 trace_id;  // 64-bit for JFR constant pool compatibility
   ASGCT_CallFrame frames[1];
+
+  CallTrace(bool truncated, int num_frames, u64 trace_id) 
+    : truncated(truncated), num_frames(num_frames), trace_id(trace_id) {
+  }
 };
 
 struct CallTraceSample {
@@ -49,8 +53,10 @@ struct CallTraceSample {
 class CallTraceStorage;
 
 class CallTraceHashTable {
-private:
+public:
   static CallTrace _overflow_trace;
+
+private:
   u64 _instance_id;  // 64-bit instance ID for this hash table (set externally)
   CallTraceStorage* _parent_storage;  // Parent storage for hazard pointer access
 
@@ -75,8 +81,7 @@ public:
   void collect(std::unordered_set<CallTrace *> &traces);
 
   u64 put(int num_frames, ASGCT_CallFrame *frames, bool truncated, u64 weight);
-  void putWithExistingId(CallTrace* trace, u64 weight);
-  void putWithExistingIdLockFree(CallTrace* trace, u64 weight);  // For standby tables with no contention
+  void putWithExistingId(CallTrace* trace, u64 weight);  // For standby tables with no contention
   void setInstanceId(u64 instance_id) { _instance_id = instance_id; }
   void setParentStorage(CallTraceStorage* storage) { _parent_storage = storage; }
 };

--- a/ddprof-lib/src/main/cpp/callTraceStorage.cpp
+++ b/ddprof-lib/src/main/cpp/callTraceStorage.cpp
@@ -308,8 +308,8 @@ void CallTraceStorage::processTraces(std::function<void(const std::unordered_set
 
     // PHASE 2: Safe collection sequence - standby first, then rotate, then scratch
     
-    CallTraceHashTable* current_active = _active_storage.load(std::memory_order_acquire);
-    CallTraceHashTable* current_standby = _standby_storage.load(std::memory_order_acquire);
+    CallTraceHashTable* current_active = _active_storage.load(std::memory_order_relaxed);
+    CallTraceHashTable* current_standby = _standby_storage.load(std::memory_order_relaxed);
     CallTraceHashTable* current_scratch = _scratch_storage.load(std::memory_order_acquire);
     
     // Clear process collections for reuse (no malloc/free)
@@ -380,7 +380,7 @@ void CallTraceStorage::clear() {
     
     // Load current table pointers - simple operation with critical section protection
     CallTraceHashTable* active = _active_storage.load(std::memory_order_relaxed);
-    CallTraceHashTable* standby = _standby_storage.load(std::memory_order_relaxed);
+    CallTraceHashTable* standby = _standby_storage.load(std::memory_order_acquire);
     
     // Direct clear operations with critical section protection
     if (active) {

--- a/ddprof-lib/src/main/cpp/callTraceStorage.cpp
+++ b/ddprof-lib/src/main/cpp/callTraceStorage.cpp
@@ -67,7 +67,7 @@ HazardPointer& HazardPointer::operator=(HazardPointer&& other) noexcept {
     return *this;
 }
 
-void HazardPointer::waitForAllHazardPointersToClear(CallTraceHashTable* table_to_delete) {
+void HazardPointer::waitForHazardPointersToClear(CallTraceHashTable* table_to_delete) {
     const int MAX_WAIT_ITERATIONS = 5000;
     int wait_count = 0;
 
@@ -189,15 +189,15 @@ CallTraceStorage::~CallTraceStorage() {
 
     // Wait for any ongoing hazard pointer usage to complete and delete each unique table
     // Note: In triple-buffering, all three pointers should be unique, but check anyway
-    HazardPointer::waitForAllHazardPointersToClear(active);
+    HazardPointer::waitForHazardPointersToClear(active);
     delete active;
 
     if (standby != active) {
-        HazardPointer::waitForAllHazardPointersToClear(standby);
+        HazardPointer::waitForHazardPointersToClear(standby);
         delete standby;
     }
     if (scratch != active && scratch != standby) {
-        HazardPointer::waitForAllHazardPointersToClear(scratch);
+        HazardPointer::waitForHazardPointersToClear(scratch);
         delete scratch;
     }
 

--- a/ddprof-lib/src/main/cpp/callTraceStorage.cpp
+++ b/ddprof-lib/src/main/cpp/callTraceStorage.cpp
@@ -10,6 +10,7 @@
 #include "common.h"
 #include "vmEntry.h" // For BCI_ERROR constant
 #include "arch_dd.h" // For LP64_ONLY macro and COMMA macro
+#include "criticalSection.h" // For table swap critical sections
 #include <string.h>
 #include <atomic>
 
@@ -18,25 +19,42 @@ static const u64 OVERFLOW_TRACE_ID = 0x7fffffffffffffffULL;  // Max 64-bit signe
 // Static atomic for instance ID generation - explicit initialization avoids function-local static issues
 std::atomic<u64> CallTraceStorage::_next_instance_id{1};  // Start from 1, 0 is reserved
 
+// Thread-local hazard pointer info - now tracks which storage instance owns the hazard pointer
+thread_local CallTraceStorage::ThreadHazardInfo CallTraceStorage::_thread_hazard_info = {nullptr, -1, nullptr};
+
 // Lazy initialization helper to avoid global constructor race conditions
 u64 CallTraceStorage::getNextInstanceId() {
-    u64 instance_id = _next_instance_id.fetch_add(1, std::memory_order_relaxed);
+    u64 instance_id = _next_instance_id.fetch_add(1, std::memory_order_acq_rel);
     return instance_id;
 }
 
-CallTraceStorage::CallTraceStorage() : _lock(0) {
-    // Initialize active storage with its instance ID
-    _active_storage = std::make_unique<CallTraceHashTable>();
+CallTraceStorage::CallTraceStorage() : _generation_counter(1), _liveness_lock(0), _thread_counter(0) {
+    // Initialize per-instance hazard pointer list
+    for (int i = 0; i < MAX_THREADS; ++i) {
+        _hazard_list[i].store(nullptr, std::memory_order_relaxed);
+    }
+    
+    // Initialize triple-buffered storage
+    auto active_table = std::make_unique<CallTraceHashTable>();
     u64 initial_instance_id = getNextInstanceId();
-    _active_storage->setInstanceId(initial_instance_id);
+    active_table->setInstanceId(initial_instance_id);
+    active_table->setParentStorage(this);
+    _active_storage.store(active_table.release(), std::memory_order_release);
 
-    _standby_storage = std::make_unique<CallTraceHashTable>();
+    auto standby_table = std::make_unique<CallTraceHashTable>();
+    standby_table->setParentStorage(this);
     // Standby will get its instance ID during swap
+    _standby_storage.store(standby_table.release(), std::memory_order_release);
+    
+    auto scratch_table = std::make_unique<CallTraceHashTable>();
+    scratch_table->setParentStorage(this);
+    // scratch table will get instance ID when it rotates to standby
+    _scratch_storage.store(scratch_table.release(), std::memory_order_release);
 
     // Pre-allocate containers to avoid malloc() during hot path operations
     _liveness_checkers.reserve(4);      // Typical max: 1-2 checkers, avoid growth
-    _preserve_buffer.reserve(1024);     // Reserve for typical liveness workloads
-    _preserve_set.reserve(1024);        // Pre-size hash buckets for lookups
+    
+    // Thread-local collections are initialized automatically per thread in ThreadLocalCollections constructor
 
     // Initialize counters
     Counters::set(CALLTRACE_STORAGE_BYTES, 0);
@@ -44,21 +62,36 @@ CallTraceStorage::CallTraceStorage() : _lock(0) {
 }
 
 CallTraceStorage::~CallTraceStorage() {
-    TEST_LOG("CallTraceStorage::~CallTraceStorage() - shutting down, invalidating active storage to prevent use-after-destruction");
+    // Atomically invalidate storage pointers to prevent new put() operations
+    CallTraceHashTable* active = _active_storage.exchange(nullptr, std::memory_order_acq_rel);
+    CallTraceHashTable* standby = _standby_storage.exchange(nullptr, std::memory_order_acq_rel);
+    CallTraceHashTable* scratch = _scratch_storage.exchange(nullptr, std::memory_order_acq_rel);
 
-    // Take exclusive lock to ensure no ongoing put() operations
-    _lock.lock();
-
-    // Invalidate active storage first to prevent use-after-destruction
-    // Any subsequent put() calls will see nullptr and return DROPPED_TRACE_ID safely
-    _active_storage = nullptr;
-    _standby_storage = nullptr;
-
-    _lock.unlock();
-
-    TEST_LOG("CallTraceStorage::~CallTraceStorage() - destruction complete");
-    // Unique pointers will automatically clean up the actual objects
+    // Use the original per-table waiting approach but with duplicate detection
+    // Wait for any ongoing hazard pointer usage to complete and delete each unique table
+    // Note: In triple-buffering, all three pointers should be unique, but check anyway
+    if (active) {
+        waitForHazardPointersToClear(active);
+        delete active;
+    }
+    if (standby && standby != active) {
+        waitForHazardPointersToClear(standby);
+        delete standby;
+    }
+    if (scratch && scratch != active && scratch != standby) {
+        waitForHazardPointersToClear(scratch);
+        delete scratch;
+    }
+    
+    // Clean up thread-local collections for this instance in the current thread
+    // Other threads' thread-local maps will clean up automatically when threads exit
+    auto& thread_map = _instance_thread_collections;
+    thread_map.erase(this);
 }
+
+// Thread-local storage definition
+// Thread-local collections per CallTraceStorage instance - prevents cross-contamination
+thread_local std::unordered_map<CallTraceStorage*, std::unique_ptr<CallTraceStorage::ThreadLocalCollections>> CallTraceStorage::_instance_thread_collections;
 
 CallTrace* CallTraceStorage::getDroppedTrace() {
     // Static dropped trace object - created once and reused
@@ -68,135 +101,278 @@ CallTrace* CallTraceStorage::getDroppedTrace() {
     return &dropped_trace;
 }
 
+// Per-instance hazard pointer system implementation
+int CallTraceStorage::getThreadHazardSlot() {
+    // Check if current thread already has a hazard slot for this storage instance
+    if (_thread_hazard_info.storage_instance != this || _thread_hazard_info.hazard_slot == -1) {
+        // Allocate new slot for this storage instance
+        _thread_hazard_info.hazard_slot = _thread_counter.fetch_add(1, std::memory_order_relaxed) % MAX_THREADS;
+        _thread_hazard_info.storage_instance = this;
+    }
+    return _thread_hazard_info.hazard_slot;
+}
+
+void CallTraceStorage::registerHazardPointer(CallTraceHashTable* table) {
+    int slot = getThreadHazardSlot();
+    
+    // Update thread-local info for this storage instance
+    _thread_hazard_info.hazard_pointer = table;
+    _thread_hazard_info.storage_instance = this;
+    
+    // Update this storage instance's hazard list
+    _hazard_list[slot].store(table, std::memory_order_release);
+    
+    // Memory barrier to ensure hazard pointer is visible before any table access
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+}
+
+void CallTraceStorage::clearHazardPointer() {
+    // Only clear if this thread's hazard pointer belongs to this storage instance
+    if (_thread_hazard_info.storage_instance == this) {
+        int slot = _thread_hazard_info.hazard_slot;
+        
+        // Clear thread-local info for this storage instance
+        _thread_hazard_info.hazard_pointer = nullptr;
+        _hazard_list[slot].store(nullptr, std::memory_order_release);
+    }
+}
+
+void CallTraceStorage::waitForHazardPointersToClear(CallTraceHashTable* table_to_delete) {
+    // Check only this storage instance's hazard pointers
+    const int MAX_WAIT_ITERATIONS = 5000;
+    int wait_count = 0;
+    
+    while (wait_count < MAX_WAIT_ITERATIONS) {
+        bool any_hazards = false;
+        
+        // Check this storage instance's hazard pointers
+        for (int i = 0; i < MAX_THREADS; ++i) {
+            CallTraceHashTable* current_hazard = _hazard_list[i].load(std::memory_order_acquire);
+            if (current_hazard == table_to_delete) {
+                any_hazards = true;
+                break;
+            }
+        }
+        
+        if (!any_hazards) {
+            break;
+        }
+        
+        // Brief pause
+        struct timespec ts = {0, 10000};  // 10 microseconds
+        nanosleep(&ts, nullptr);
+        wait_count++;
+    }
+}
+
+void CallTraceStorage::waitForAllHazardPointersToClear() {
+    // Wait for ALL hazard pointers to clear - needed before deallocating chain memory
+    // This ensures no signal handler is traversing any hash table chains
+    const int MAX_WAIT_ITERATIONS = 5000;
+    int wait_count = 0;
+    
+    while (wait_count < MAX_WAIT_ITERATIONS) {
+        bool any_hazards = false;
+        
+        // Check this storage instance's hazard pointers
+        for (int i = 0; i < MAX_THREADS; ++i) {
+            CallTraceHashTable* current_hazard = _hazard_list[i].load(std::memory_order_acquire);
+            if (current_hazard != nullptr) {
+                any_hazards = true;
+                break;
+            }
+        }
+        
+        if (!any_hazards) {
+            break;
+        }
+        
+        // Brief pause
+        struct timespec ts = {0, 10000};  // 10 microseconds
+        nanosleep(&ts, nullptr);
+        wait_count++;
+    }
+}
+
+// Simple spinlock helpers for rare liveness operations
+void CallTraceStorage::lockLivenessCheckers() {
+    while (__sync_bool_compare_and_swap(&_liveness_lock, 0, 1) == false) {
+        // Busy wait - these operations are rare
+    }
+}
+
+void CallTraceStorage::unlockLivenessCheckers() {
+    __sync_bool_compare_and_swap(&_liveness_lock, 1, 0);
+}
+
 void CallTraceStorage::registerLivenessChecker(LivenessChecker checker) {
-    _lock.lock();
+    lockLivenessCheckers();
     _liveness_checkers.push_back(checker);
-    _lock.unlock();
+    unlockLivenessCheckers();
 }
 
 void CallTraceStorage::clearLivenessCheckers() {
-    _lock.lock();
+    lockLivenessCheckers();
     _liveness_checkers.clear();
-    _lock.unlock();
+    unlockLivenessCheckers();
+}
+
+CallTraceStorage::ThreadLocalCollections& CallTraceStorage::getInstanceThreadLocalCollections() {
+    // Get or create thread-local collections for this specific CallTraceStorage instance
+    auto& thread_map = _instance_thread_collections;
+    auto it = thread_map.find(this);
+    if (it == thread_map.end()) {
+        // Create new collections for this instance
+        auto collections = std::make_unique<ThreadLocalCollections>();
+        auto result = thread_map.emplace(this, std::move(collections));
+        return *result.first->second;
+    }
+    return *it->second;
 }
 
 u64 CallTraceStorage::put(int num_frames, ASGCT_CallFrame* frames, bool truncated, u64 weight) {
-    // Use shared lock - multiple put operations can run concurrently since each trace
-    // goes to a different slot based on its hash. Only blocked by exclusive operations like collectTraces() or clear().
-    if (!_lock.tryLockShared()) {
-        // Exclusive operation (collectTraces or clear) in progress - return special dropped trace ID
+    // Signal handlers can run concurrently with destructor
+    CallTraceHashTable* active = _active_storage.load(std::memory_order_acquire);
+    
+    // Safety check - if null, system is shutting down
+    if (active == nullptr) {
         Counters::increment(CALLTRACE_STORAGE_DROPPED);
         return DROPPED_TRACE_ID;
     }
-
-    // Safety check: if active storage is invalid (e.g., during destruction), drop the sample
-    if (_active_storage == nullptr) {
-        TEST_LOG("CallTraceStorage::put() - _active_storage is NULL (shutdown/destruction?), returning DROPPED_TRACE_ID");
-        _lock.unlockShared();
+    
+    // Register hazard pointer to prevent deletion during table access
+    registerHazardPointer(active);
+    
+    // Check again after registering hazard pointer - storage might have been nullified
+    CallTraceHashTable* current_active = _active_storage.load(std::memory_order_acquire);
+    if (current_active != active || current_active == nullptr) {
+        // Storage was swapped or nullified, clear hazard pointer and return dropped
+        clearHazardPointer();
         Counters::increment(CALLTRACE_STORAGE_DROPPED);
         return DROPPED_TRACE_ID;
     }
-
-    // Forward to active storage
-    u64 result = _active_storage->put(num_frames, frames, truncated, weight);
-
-    _lock.unlockShared();
+    
+    // Hazard pointer prevents deletion
+    u64 result = active->put(num_frames, frames, truncated, weight);
+    
+    // Clear hazard pointer
+    clearHazardPointer();
+    
     return result;
 }
 
 /*
- * This function is not thread safe. The caller must ensure that it is never called concurrently.
- *
- * For all practical purposes, we end up calling this function only via FlightRecorder::flush()
- * and that function is already locking on the recording lock, so there will never be two concurrent
- * flushes at the same time.
+ * Trace processing with signal blocking for simplified concurrency.
+ * This function is safe to call concurrently with put() operations and with itself
+ * (thread-local collections prevent race conditions between concurrent processTraces calls).
  */
 void CallTraceStorage::processTraces(std::function<void(const std::unordered_set<CallTrace*>&)> processor) {
-    // Split lock strategy: minimize time under exclusive lock by separating swap from processing
-    std::unordered_set<u64> preserve_set;
+    // Critical section for table swap operations - disallow signals to interrupt
+    CriticalSection cs;
+    
+    // Get instance-specific thread-local collections - prevents cross-contamination between storage instances
+    ThreadLocalCollections& tl = getInstanceThreadLocalCollections();
 
-    // PHASE 1: Brief exclusive lock for liveness collection and storage swap
+    // PHASE 1: Collect liveness information with simple lock (rare operation)
     {
-        _lock.lock();
-
-        // Step 1: Collect all call_trace_id values that need to be preserved
-        // Use pre-allocated containers to avoid malloc() in hot path
-        _preserve_buffer.clear();      // No deallocation - keeps reserved capacity
-        _preserve_set.clear();         // No bucket deallocation - keeps reserved buckets
+        lockLivenessCheckers();
+        
+        // Use pre-allocated containers to avoid malloc()
+        tl.preserve_set_buffer.clear();
 
         for (const auto& checker : _liveness_checkers) {
-            checker(_preserve_buffer); // Fill buffer by reference - no malloc()
+            checker(tl.preserve_set_buffer);
         }
-
-        // Copy preserve set for use outside lock - bulk insert into set
-        _preserve_set.insert(_preserve_buffer.begin(), _preserve_buffer.end());
-        preserve_set = _preserve_set; // Copy the set for lock-free processing
-
-        // Step 2: Assign new instance ID to standby storage to avoid trace ID clashes
-        u64 new_instance_id = getNextInstanceId();
-        _standby_storage->setInstanceId(new_instance_id);
-
-        // Step 3: Swap storage atomically - standby (with new instance ID) becomes active
-        // Old active becomes standby and will be processed lock-free
-        _active_storage.swap(_standby_storage);
-
-        _lock.unlock();
-        // END PHASE 1 - Lock released, put() operations can now proceed concurrently
+        
+        unlockLivenessCheckers();
     }
 
-    // PHASE 2: Lock-free processing - iterate owned storage and collect traces
-    std::unordered_set<CallTrace*> traces;
-    std::unordered_set<CallTrace*> traces_to_preserve;
+    // PHASE 2: Safe collection sequence - standby first, then rotate, then scratch
+    
+    CallTraceHashTable* current_active = _active_storage.load(std::memory_order_acquire);
+    CallTraceHashTable* current_standby = _standby_storage.load(std::memory_order_acquire);
+    CallTraceHashTable* current_scratch = _scratch_storage.load(std::memory_order_acquire);
+    
+    // Clear thread-local collections for reuse (no malloc/free)
+    tl.traces_buffer.clear();
+    tl.traces_to_preserve_buffer.clear();
+    tl.standby_traces_buffer.clear();
+    tl.active_traces_buffer.clear();
 
-    // Collect all traces and identify which ones to preserve (no lock held)
-    _standby_storage->collect(traces);  // Get all traces from standby (old active) for JFR processing
-
-    // Always ensure the dropped trace is included in JFR constant pool
-    // This guarantees that events with DROPPED_TRACE_ID have a valid stack trace entry
-    traces.insert(getDroppedTrace());
-
-    // Identify traces that need to be preserved based on their IDs
-    for (CallTrace* trace : traces) {
-        if (preserve_set.find(trace->trace_id) != preserve_set.end()) {
-            traces_to_preserve.insert(trace);
+    // Step 1: Collect from current standby FIRST (preserved traces from previous cycle)
+    current_standby->collect(tl.standby_traces_buffer);
+    
+    // Immediately preserve standby traces that need to be kept for next cycle
+    for (CallTrace* trace : tl.standby_traces_buffer) {
+        if (tl.preserve_set_buffer.find(trace->trace_id) != tl.preserve_set_buffer.end()) {
+            tl.traces_to_preserve_buffer.insert(trace);
         }
     }
-
-    // Process traces while they're still valid in standby storage (no lock held)
-    // The callback is guaranteed that all traces remain valid during execution
-    processor(traces);
-
-    // PHASE 3: Brief exclusive lock to copy preserved traces back to active storage and clear standby
-    {
-        _lock.lock();
-
-        // Copy preserved traces to current active storage, maintaining their original trace IDs
-        for (CallTrace* trace : traces_to_preserve) {
-            _active_storage->putWithExistingId(trace, 1);
+    
+    // Step 2: Clear standby after collection, prepare for rotation
+    current_standby->clear();
+    u64 new_instance_id = getNextInstanceId();
+    current_standby->setInstanceId(new_instance_id);
+    
+    // Step 3: ATOMIC SWAP - standby (now empty) becomes new active
+    CallTraceHashTable* old_active = _active_storage.exchange(current_standby, std::memory_order_acq_rel);
+    
+    // Step 4: Complete the rotation: active→scratch, scratch→standby
+    CallTraceHashTable* old_scratch = _scratch_storage.exchange(old_active, std::memory_order_acq_rel);
+    _standby_storage.store(old_scratch, std::memory_order_release);
+    
+    // Step 5: NOW collect from scratch (old active, now read-only)
+    old_active->collect(tl.active_traces_buffer);
+    
+    // Preserve traces from old active too
+    for (CallTrace* trace : tl.active_traces_buffer) {
+        if (tl.preserve_set_buffer.find(trace->trace_id) != tl.preserve_set_buffer.end()) {
+            tl.traces_to_preserve_buffer.insert(trace);
         }
-
-        // Clear standby storage (old active) now that we're done processing
-        // This keeps the hash table structure but clears all data
-        _standby_storage->clear();
-
-        _lock.unlock();
-        // END PHASE 3 - All preserved traces copied back to active storage, standby cleared for reuse
     }
+    
+    // Step 6: Combine all traces for JFR processing
+    tl.traces_buffer.insert(tl.active_traces_buffer.begin(), tl.active_traces_buffer.end());
+    tl.traces_buffer.insert(tl.standby_traces_buffer.begin(), tl.standby_traces_buffer.end());
+
+    // Always include dropped trace in JFR constant pool
+    tl.traces_buffer.insert(getDroppedTrace());
+
+    // PHASE 3: Process traces
+    processor(tl.traces_buffer);
+
+    // PHASE 4: Copy all preserved traces to current standby (old scratch, now empty)
+    old_scratch->clear();  // Should already be empty, but ensure it
+    for (CallTrace* trace : tl.traces_to_preserve_buffer) {
+        old_scratch->putWithExistingIdLockFree(trace, 1);
+    }
+    
+    // Triple-buffer rotation maintains trace continuity with thread-safe malloc-free operations:
+    // - Thread-local pre-allocated collections prevent malloc/free and concurrent access races
+    // - Standby traces collected first (safe - no signal handler writes to standby)
+    // - New active (old standby, now empty) receives new traces from signal handlers
+    // - Old active (now scratch) safely collected after rotation, then cleared
+    // - New standby (old scratch) stores preserved traces for next cycle
 }
 
-
-
 void CallTraceStorage::clear() {
-    // This is called from profiler start/dump - clear both storages
-    _lock.lock();
-
-    _active_storage->clear();
-    _standby_storage->clear();
+    // Mark critical section during clear operation for consistency
+    CriticalSection cs;
+    
+    // Load current table pointers - simple operation with critical section protection
+    CallTraceHashTable* active = _active_storage.load(std::memory_order_relaxed);
+    CallTraceHashTable* standby = _standby_storage.load(std::memory_order_relaxed);
+    
+    // Direct clear operations with critical section protection
+    if (active) {
+        active->clear();
+    }
+    if (standby) {
+        standby->clear();
+    }
 
     // Reset counters when clearing all storage
     Counters::set(CALLTRACE_STORAGE_BYTES, 0);
     Counters::set(CALLTRACE_STORAGE_TRACES, 0);
-
-    _lock.unlock();
 }
 

--- a/ddprof-lib/src/main/cpp/callTraceStorage.h
+++ b/ddprof-lib/src/main/cpp/callTraceStorage.h
@@ -57,37 +57,13 @@ private:
     // Lazy initialization helper to avoid global constructor
     static u64 getNextInstanceId();
     
-    // Thread-local reusable collections for processTraces() to eliminate malloc/free cycles
-    // Each thread gets its own pre-allocated collections to avoid concurrent access issues
-    struct ThreadLocalCollections {
-        std::unordered_set<CallTrace*> traces_buffer;           // Combined traces for JFR processing
-        std::unordered_set<CallTrace*> traces_to_preserve_buffer; // Traces selected for preservation
-        std::unordered_set<CallTrace*> standby_traces_buffer;   // Traces collected from standby
-        std::unordered_set<CallTrace*> active_traces_buffer;    // Traces collected from active/scratch
-        std::unordered_set<u64> preserve_set_buffer;           // Preserve set for current cycle
-        
-        ThreadLocalCollections() {
-            // Pre-allocate and pre-size collections with conservative load factor
-            traces_buffer.max_load_factor(0.75f);
-            traces_buffer.rehash(static_cast<size_t>(2048 / 0.75f));
-            
-            traces_to_preserve_buffer.max_load_factor(0.75f);
-            traces_to_preserve_buffer.rehash(static_cast<size_t>(512 / 0.75f));
-            
-            standby_traces_buffer.max_load_factor(0.75f);
-            standby_traces_buffer.rehash(static_cast<size_t>(512 / 0.75f));
-            
-            active_traces_buffer.max_load_factor(0.75f);
-            active_traces_buffer.rehash(static_cast<size_t>(2048 / 0.75f));
-            
-            preserve_set_buffer.max_load_factor(0.75f);
-            preserve_set_buffer.rehash(static_cast<size_t>(1024 / 0.75f));
-        }
-    };
-    
-    // Thread-local storage per CallTraceStorage instance to avoid cross-contamination
-    // Each thread maintains its own map of instance-specific collections
-    static thread_local std::unordered_map<CallTraceStorage*, std::unique_ptr<ThreadLocalCollections>> _instance_thread_collections;
+    // Pre-allocated collections for processTraces (single-threaded operation)
+    // These collections are reused to eliminate malloc/free cycles
+    std::unordered_set<CallTrace*> _traces_buffer;           // Combined traces for JFR processing
+    std::unordered_set<CallTrace*> _traces_to_preserve_buffer; // Traces selected for preservation
+    std::unordered_set<CallTrace*> _standby_traces_buffer;   // Traces collected from standby
+    std::unordered_set<CallTrace*> _active_traces_buffer;    // Traces collected from active/scratch
+    std::unordered_set<u64> _preserve_set_buffer;           // Preserve set for current cycle
     
     // Per-instance hazard pointer system for safe memory reclamation
     static constexpr int MAX_THREADS = 256;  // Maximum supported threads
@@ -108,8 +84,6 @@ private:
     void waitForHazardPointersToClear(CallTraceHashTable* table_to_delete);
     int getThreadHazardSlot();
     
-    // Get or create thread-local collections for this instance
-    ThreadLocalCollections& getInstanceThreadLocalCollections();
     
 
 

--- a/ddprof-lib/src/main/cpp/callTraceStorage.h
+++ b/ddprof-lib/src/main/cpp/callTraceStorage.h
@@ -17,13 +17,55 @@
 #include <thread>
 #include <chrono>
 
-// Forward declaration
+// Forward declarations
 class CallTraceStorage;
+class CallTraceHashTable;
 
 // Liveness checker function type
 // Fills the provided set with 64-bit call_trace_id values that should be preserved
 // Using reference parameter avoids malloc() for vector creation and copying
 typedef std::function<void(std::unordered_set<u64>&)> LivenessChecker;
+
+/**
+ * RAII guard for hazard pointer management.
+ * 
+ * This class encapsulates the hazard pointer mechanism used to protect CallTraceHashTable
+ * instances from being deleted while they are being accessed by concurrent threads.
+ *
+ * Usage:
+ *   HazardPointer guard(active_table);
+ *   // active_table is now protected from deletion
+ *   // Automatic cleanup when guard goes out of scope
+ */
+class HazardPointer {
+public:
+    static constexpr int MAX_THREADS = 256;
+    static std::atomic<CallTraceHashTable*> global_hazard_list[MAX_THREADS];
+
+private:
+    bool active_;
+    int my_slot_;  // This instance's assigned slot
+    
+    // Signal-safe slot assignment using thread ID hash
+    static int getThreadHazardSlot();
+    
+public:
+    HazardPointer(CallTraceHashTable* resource);
+    ~HazardPointer();
+    
+    // Non-copyable, movable for efficiency
+    HazardPointer(const HazardPointer&) = delete;
+    HazardPointer& operator=(const HazardPointer&) = delete;
+    
+    HazardPointer(HazardPointer&& other) noexcept;
+    HazardPointer& operator=(HazardPointer&& other) noexcept;
+    
+    // Wait for specific hazard pointers to clear (used during shutdown)
+    static void waitForAllHazardPointersToClear(CallTraceHashTable* table_to_delete);
+    
+    // Wait for ALL hazard pointers to clear (used by CallTraceHashTable::clear())
+    static void waitForAllHazardPointersToClear();
+};
 
 class CallTraceStorage {
 public:
@@ -89,24 +131,8 @@ private:
     // Each thread maintains its own map of instance-specific collections
     static thread_local std::unordered_map<CallTraceStorage*, std::unique_ptr<ThreadLocalCollections>> _instance_thread_collections;
     
-    // Per-instance hazard pointer system for safe memory reclamation
-    static constexpr int MAX_THREADS = 256;  // Maximum supported threads
-    std::atomic<CallTraceHashTable*> _hazard_list[MAX_THREADS];  // Per-instance hazard list
-    std::atomic<int> _thread_counter;  // Per-instance thread counter for slot assignment
     
-    // Thread-local storage for hazard pointer management - now uses instance pointer
-    struct ThreadHazardInfo {
-        CallTraceHashTable* hazard_pointer;
-        int hazard_slot;
-        CallTraceStorage* storage_instance;  // Which storage instance owns this hazard pointer
-    };
-    static thread_local ThreadHazardInfo _thread_hazard_info;
-    
-    // Hazard pointer management - now instance-specific
-    void registerHazardPointer(CallTraceHashTable* table);
-    void clearHazardPointer();
-    void waitForHazardPointersToClear(CallTraceHashTable* table_to_delete);
-    int getThreadHazardSlot();
+private:
     
     // Get or create thread-local collections for this instance
     ThreadLocalCollections& getInstanceThreadLocalCollections();
@@ -135,8 +161,6 @@ public:
     // Enhanced clear with liveness preservation (rarely called - uses atomic operations)
     void clear();
     
-    // Wait for all hazard pointers to clear - needed by CallTraceHashTable::clear()
-    void waitForAllHazardPointersToClear();
     
 private:
     // Simple spinlock helpers for rare liveness operations

--- a/ddprof-lib/src/main/cpp/callTraceStorage.h
+++ b/ddprof-lib/src/main/cpp/callTraceStorage.h
@@ -9,6 +9,7 @@
 
 #include "callTraceHashTable.h"
 #include "spinLock.h"
+#include "os_dd.h"
 #include <functional>
 #include <vector>
 #include <memory>
@@ -52,7 +53,7 @@ public:
     };
     
     static std::atomic<CallTraceHashTable*> global_hazard_list[MAX_THREADS];
-    static std::atomic<std::thread::id> slot_owners[MAX_THREADS];  // Thread ID ownership verification
+    static std::atomic<int> slot_owners[MAX_THREADS];  // Thread ID ownership verification
 
 private:
     bool active_;

--- a/ddprof-lib/src/main/cpp/callTraceStorage.h
+++ b/ddprof-lib/src/main/cpp/callTraceStorage.h
@@ -8,20 +8,22 @@
 #define _CALLTRACESTORAGE_H
 
 #include "callTraceHashTable.h"
-#include "spinLock.h"
 #include <functional>
 #include <vector>
 #include <memory>
 #include <unordered_set>
+#include <unordered_map>
 #include <atomic>
+#include <thread>
+#include <chrono>
 
 // Forward declaration
 class CallTraceStorage;
 
 // Liveness checker function type
-// Fills the provided vector with 64-bit call_trace_id values that should be preserved
+// Fills the provided set with 64-bit call_trace_id values that should be preserved
 // Using reference parameter avoids malloc() for vector creation and copying
-typedef std::function<void(std::vector<u64>&)> LivenessChecker;
+typedef std::function<void(std::unordered_set<u64>&)> LivenessChecker;
 
 class CallTraceStorage {
 public:
@@ -34,10 +36,20 @@ public:
     static CallTrace* getDroppedTrace();
 
 private:
-    std::unique_ptr<CallTraceHashTable> _active_storage;
-    std::unique_ptr<CallTraceHashTable> _standby_storage;
+    // Triple-buffered storage with atomic pointers  
+    // Rotation: tmp=scratch, scratch=active, active=standby, standby=tmp
+    // New active inherits preserved traces for continuity
+    std::atomic<CallTraceHashTable*> _active_storage;
+    std::atomic<CallTraceHashTable*> _standby_storage;
+    std::atomic<CallTraceHashTable*> _scratch_storage;
+    
+    // Generation counter for ABA protection during table swaps
+    std::atomic<u32> _generation_counter;
+    
+    // Liveness checkers - protected by simple spinlock during registration/clear
+    // Using vector instead of unordered_set since std::function cannot be hashed
     std::vector<LivenessChecker> _liveness_checkers;
-    SpinLock _lock;
+    volatile int _liveness_lock;  // Simple atomic lock for rare liveness operations
     
     // Static atomic for instance ID generation - avoids function-local static initialization issues
     static std::atomic<u64> _next_instance_id;
@@ -45,9 +57,59 @@ private:
     // Lazy initialization helper to avoid global constructor
     static u64 getNextInstanceId();
     
-    // Pre-allocated containers to avoid malloc() during hot path operations
-    mutable std::vector<u64> _preserve_buffer;        // Reusable buffer for 64-bit trace IDs
-    mutable std::unordered_set<u64> _preserve_set;    // Pre-sized hash set for 64-bit trace ID lookups
+    // Thread-local reusable collections for processTraces() to eliminate malloc/free cycles
+    // Each thread gets its own pre-allocated collections to avoid concurrent access issues
+    struct ThreadLocalCollections {
+        std::unordered_set<CallTrace*> traces_buffer;           // Combined traces for JFR processing
+        std::unordered_set<CallTrace*> traces_to_preserve_buffer; // Traces selected for preservation
+        std::unordered_set<CallTrace*> standby_traces_buffer;   // Traces collected from standby
+        std::unordered_set<CallTrace*> active_traces_buffer;    // Traces collected from active/scratch
+        std::unordered_set<u64> preserve_set_buffer;           // Preserve set for current cycle
+        
+        ThreadLocalCollections() {
+            // Pre-allocate and pre-size collections with conservative load factor
+            traces_buffer.max_load_factor(0.75f);
+            traces_buffer.rehash(static_cast<size_t>(2048 / 0.75f));
+            
+            traces_to_preserve_buffer.max_load_factor(0.75f);
+            traces_to_preserve_buffer.rehash(static_cast<size_t>(512 / 0.75f));
+            
+            standby_traces_buffer.max_load_factor(0.75f);
+            standby_traces_buffer.rehash(static_cast<size_t>(512 / 0.75f));
+            
+            active_traces_buffer.max_load_factor(0.75f);
+            active_traces_buffer.rehash(static_cast<size_t>(2048 / 0.75f));
+            
+            preserve_set_buffer.max_load_factor(0.75f);
+            preserve_set_buffer.rehash(static_cast<size_t>(1024 / 0.75f));
+        }
+    };
+    
+    // Thread-local storage per CallTraceStorage instance to avoid cross-contamination
+    // Each thread maintains its own map of instance-specific collections
+    static thread_local std::unordered_map<CallTraceStorage*, std::unique_ptr<ThreadLocalCollections>> _instance_thread_collections;
+    
+    // Per-instance hazard pointer system for safe memory reclamation
+    static constexpr int MAX_THREADS = 256;  // Maximum supported threads
+    std::atomic<CallTraceHashTable*> _hazard_list[MAX_THREADS];  // Per-instance hazard list
+    std::atomic<int> _thread_counter;  // Per-instance thread counter for slot assignment
+    
+    // Thread-local storage for hazard pointer management - now uses instance pointer
+    struct ThreadHazardInfo {
+        CallTraceHashTable* hazard_pointer;
+        int hazard_slot;
+        CallTraceStorage* storage_instance;  // Which storage instance owns this hazard pointer
+    };
+    static thread_local ThreadHazardInfo _thread_hazard_info;
+    
+    // Hazard pointer management - now instance-specific
+    void registerHazardPointer(CallTraceHashTable* table);
+    void clearHazardPointer();
+    void waitForHazardPointersToClear(CallTraceHashTable* table_to_delete);
+    int getThreadHazardSlot();
+    
+    // Get or create thread-local collections for this instance
+    ThreadLocalCollections& getInstanceThreadLocalCollections();
     
 
 
@@ -55,22 +117,31 @@ public:
     CallTraceStorage();
     ~CallTraceStorage();
 
-    // Register a liveness checker
+    // Register a liveness checker (rare operation - uses simple lock)
     void registerLivenessChecker(LivenessChecker checker);
 
-    // Clear liveness checkers
+    // Clear liveness checkers (rare operation - uses simple lock)
     void clearLivenessCheckers();
 
-    // Forward methods to active storage
+    // Lock-free put operation for signal handler safety
+    // Uses hazard pointers and generation counter for ABA protection
     u64 put(int num_frames, ASGCT_CallFrame* frames, bool truncated, u64 weight);
     
-    // Safe trace processing with guaranteed lifetime during callback execution
-    // The callback receives a const reference to traces that are guaranteed to be valid
-    // during the entire callback execution. Cleanup happens automatically after callback returns.
+    // Lock-free trace processing with hazard pointer protection
+    // The callback receives traces that are guaranteed to be valid during execution
+    // Uses atomic table swapping with grace period for safe memory reclamation
     void processTraces(std::function<void(const std::unordered_set<CallTrace*>&)> processor);
 
-    // Enhanced clear with liveness preservation
+    // Enhanced clear with liveness preservation (rarely called - uses atomic operations)
     void clear();
+    
+    // Wait for all hazard pointers to clear - needed by CallTraceHashTable::clear()
+    void waitForAllHazardPointersToClear();
+    
+private:
+    // Simple spinlock helpers for rare liveness operations
+    void lockLivenessCheckers();
+    void unlockLivenessCheckers();
 };
 
 #endif // _CALLTRACESTORAGE_H

--- a/ddprof-lib/src/main/cpp/callTraceStorage.h
+++ b/ddprof-lib/src/main/cpp/callTraceStorage.h
@@ -61,8 +61,8 @@ public:
     HazardPointer(HazardPointer&& other) noexcept;
     HazardPointer& operator=(HazardPointer&& other) noexcept;
     
-    // Wait for specific hazard pointers to clear (used during shutdown)
-    static void waitForAllHazardPointersToClear(CallTraceHashTable* table_to_delete);
+    // Wait for hazard pointers pointing to specific table to clear (used during shutdown)
+    static void waitForHazardPointersToClear(CallTraceHashTable* table_to_delete);
     
     // Wait for ALL hazard pointers to clear (used by CallTraceHashTable::clear())
     static void waitForAllHazardPointersToClear();

--- a/ddprof-lib/src/main/cpp/callTraceStorage.h
+++ b/ddprof-lib/src/main/cpp/callTraceStorage.h
@@ -8,6 +8,7 @@
 #define _CALLTRACESTORAGE_H
 
 #include "callTraceHashTable.h"
+#include "spinLock.h"
 #include <functional>
 #include <vector>
 #include <memory>
@@ -91,7 +92,7 @@ private:
     // Liveness checkers - protected by simple spinlock during registration/clear
     // Using vector instead of unordered_set since std::function cannot be hashed
     std::vector<LivenessChecker> _liveness_checkers;
-    volatile int _liveness_lock;  // Simple atomic lock for rare liveness operations
+    SpinLock _liveness_lock;  // Simple atomic lock for rare liveness operations
     
     // Static atomic for instance ID generation - avoids function-local static initialization issues
     static std::atomic<u64> _next_instance_id;
@@ -109,7 +110,7 @@ private:
     
     
 private:
-    
+
     
 
 
@@ -134,12 +135,6 @@ public:
 
     // Enhanced clear with liveness preservation (rarely called - uses atomic operations)
     void clear();
-    
-    
-private:
-    // Simple spinlock helpers for rare liveness operations
-    void lockLivenessCheckers();
-    void unlockLivenessCheckers();
 };
 
 #endif // _CALLTRACESTORAGE_H

--- a/ddprof-lib/src/main/cpp/common.h
+++ b/ddprof-lib/src/main/cpp/common.h
@@ -1,6 +1,12 @@
 #ifndef _COMMON_H
 #define _COMMON_H
 
+#include <cstddef>
+
+// Knuth's multiplicative constant (golden ratio * 2^64 for 64-bit)
+// Used for hash distribution in various components
+constexpr size_t KNUTH_MULTIPLICATIVE_CONSTANT = 0x9e3779b97f4a7c15ULL;
+
 #ifdef DEBUG
 #define TEST_LOG(fmt, ...) do { \
   fprintf(stdout, "[TEST::INFO] " fmt "\n", ##__VA_ARGS__); \

--- a/ddprof-lib/src/main/cpp/criticalSection.cpp
+++ b/ddprof-lib/src/main/cpp/criticalSection.cpp
@@ -7,14 +7,15 @@
 
 CriticalSection::CriticalSection() : _entered(false) {
     // Use safe accessor to ensure TLS is fully initialized
-    std::atomic<sig_atomic_t>& flag = getThreadLocalFlag();
+    sig_atomic_t& flag = getThreadLocalFlag();
     
-    // Try to atomically claim the critical section using compare-and-swap
     sig_atomic_t expected = 0;
-    _entered = flag.compare_exchange_strong(
-        expected, 1, std::memory_order_acq_rel, std::memory_order_acquire);
+    if (!flag) {
+        flag = 1;
+        _entered = 1;
+    }
     
-    // If CAS failed, another critical section (likely signal handler) is already active
+    // If the attempt failed, another critical section (likely signal handler) is already active
     // We don't throw or error - we just track that we didn't get ownership
     // The caller can check entered() if needed, but typically signal handlers
     // will use isInCriticalSection() and return early
@@ -23,18 +24,13 @@ CriticalSection::CriticalSection() : _entered(false) {
 CriticalSection::~CriticalSection() {
     // Only release if we successfully entered
     if (_entered) {
-        getThreadLocalFlag().store(0, std::memory_order_release);
+        getThreadLocalFlag() = 0;
     }
 }
 
-bool CriticalSection::isInCriticalSection() {
-    // Use safe accessor to ensure TLS is fully initialized
-    return getThreadLocalFlag().load(std::memory_order_acquire) != 0;
-}
-
-std::atomic<sig_atomic_t>& CriticalSection::getThreadLocalFlag() {
+sig_atomic_t& CriticalSection::getThreadLocalFlag() {
     // Force TLS initialization with explicit initialization
     // This ensures the atomic is fully constructed before any signal handler can access it
-    static thread_local std::atomic<sig_atomic_t> flag{0};
+    static thread_local sig_atomic_t flag{0};
     return flag;
 }

--- a/ddprof-lib/src/main/cpp/criticalSection.cpp
+++ b/ddprof-lib/src/main/cpp/criticalSection.cpp
@@ -4,33 +4,51 @@
  */
 
 #include "criticalSection.h"
+#include "thread.h"
+#include "os.h"
 
-CriticalSection::CriticalSection() : _entered(false) {
-    // Use safe accessor to ensure TLS is fully initialized
-    sig_atomic_t& flag = getThreadLocalFlag();
-    
-    sig_atomic_t expected = 0;
-    if (!flag) {
-        flag = 1;
-        _entered = 1;
+// Static bitmap storage for fallback cases
+std::atomic<uint64_t> CriticalSection::_fallback_bitmap[CriticalSection::FALLBACK_BITMAP_WORDS] = {};
+
+CriticalSection::CriticalSection() : _entered(false), _using_fallback(false), _word_index(0), _bit_mask(0) {
+    ProfiledThread* current = ProfiledThread::current();
+    if (current != nullptr) {
+        // Primary path: Use ProfiledThread storage (fast and memory-efficient)
+        _entered = current->tryEnterCriticalSection();
+    } else {
+        // Fallback path: Use hash-based bitmap for stress tests and edge cases
+        _using_fallback = true;
+        int tid = OS::threadId();
+        
+        // Hash TID to distribute across bitmap words, reducing clustering
+        // We are OK with false colision for the fallback - it should be used only for testing when we don't have full profiler initialized
+        _word_index = hash_tid(tid) % FALLBACK_BITMAP_WORDS;
+        uint32_t bit_index = tid % 64;
+        _bit_mask = 1ULL << bit_index;
+        
+        // Atomically try to set the bit
+        uint64_t old_word = _fallback_bitmap[_word_index].fetch_or(_bit_mask, std::memory_order_acquire);
+        _entered = !(old_word & _bit_mask);  // Success if bit was previously 0
     }
-    
-    // If the attempt failed, another critical section (likely signal handler) is already active
-    // We don't throw or error - we just track that we didn't get ownership
-    // The caller can check entered() if needed, but typically signal handlers
-    // will use isInCriticalSection() and return early
 }
 
 CriticalSection::~CriticalSection() {
-    // Only release if we successfully entered
     if (_entered) {
-        getThreadLocalFlag() = 0;
+        if (_using_fallback) {
+            // Clear the bit atomically for fallback bitmap
+            _fallback_bitmap[_word_index].fetch_and(~_bit_mask, std::memory_order_release);
+        } else {
+            // Release ProfiledThread flag
+            ProfiledThread* current = ProfiledThread::current();
+            if (current != nullptr) {
+                current->exitCriticalSection();
+            }
+        }
     }
 }
 
-sig_atomic_t& CriticalSection::getThreadLocalFlag() {
-    // Force TLS initialization with explicit initialization
-    // This ensures the atomic is fully constructed before any signal handler can access it
-    static thread_local sig_atomic_t flag{0};
-    return flag;
+uint32_t CriticalSection::hash_tid(int tid) {
+    // Knuth's multiplicative hash - spreads consecutive TIDs across different bitmap words
+    // The constant 2654435769U is (2^32 / golden_ratio), chosen to minimize clustering
+    return static_cast<uint32_t>(tid * 2654435769U);
 }

--- a/ddprof-lib/src/main/cpp/criticalSection.cpp
+++ b/ddprof-lib/src/main/cpp/criticalSection.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "criticalSection.h"
+
+CriticalSection::CriticalSection() : _entered(false) {
+    // Use safe accessor to ensure TLS is fully initialized
+    std::atomic<sig_atomic_t>& flag = getThreadLocalFlag();
+    
+    // Try to atomically claim the critical section using compare-and-swap
+    sig_atomic_t expected = 0;
+    _entered = flag.compare_exchange_strong(
+        expected, 1, std::memory_order_acq_rel, std::memory_order_acquire);
+    
+    // If CAS failed, another critical section (likely signal handler) is already active
+    // We don't throw or error - we just track that we didn't get ownership
+    // The caller can check entered() if needed, but typically signal handlers
+    // will use isInCriticalSection() and return early
+}
+
+CriticalSection::~CriticalSection() {
+    // Only release if we successfully entered
+    if (_entered) {
+        getThreadLocalFlag().store(0, std::memory_order_release);
+    }
+}
+
+bool CriticalSection::isInCriticalSection() {
+    // Use safe accessor to ensure TLS is fully initialized
+    return getThreadLocalFlag().load(std::memory_order_acquire) != 0;
+}
+
+std::atomic<sig_atomic_t>& CriticalSection::getThreadLocalFlag() {
+    // Force TLS initialization with explicit initialization
+    // This ensures the atomic is fully constructed before any signal handler can access it
+    static thread_local std::atomic<sig_atomic_t> flag{0};
+    return flag;
+}

--- a/ddprof-lib/src/main/cpp/criticalSection.h
+++ b/ddprof-lib/src/main/cpp/criticalSection.h
@@ -42,13 +42,9 @@ public:
     // Check if this instance successfully entered the critical section
     bool entered() const { return _entered; }
     
-    // Static method for signal handlers to check critical section status
-    // Returns true if ANY critical section is active on this thread
-    static bool isInCriticalSection();
-    
 private:
     // Safe accessor for thread-local atomic flag
-    static std::atomic<sig_atomic_t>& getThreadLocalFlag();
+    sig_atomic_t& getThreadLocalFlag();
 };
 
 #endif // _CRITICALSECTION_H

--- a/ddprof-lib/src/main/cpp/criticalSection.h
+++ b/ddprof-lib/src/main/cpp/criticalSection.h
@@ -6,18 +6,23 @@
 #ifndef _CRITICALSECTION_H
 #define _CRITICALSECTION_H
 
-#include <signal.h>
 #include <atomic>
+#include <cstdint>
+#include <cstddef>
 
 /**
  * Race-free critical section using atomic compare-and-swap.
  * 
- * Instead of expensive syscalls to block signals, this approach uses
- * a thread-local atomic flag with CAS to prevent signal handler reentrancy.
+ * Hybrid implementation:
+ * - Primary: Uses ProfiledThread storage when available (zero memory overhead)
+ * - Fallback: Hash-based bitmap for stress tests and cases without ProfiledThread
+ * 
+ * This approach is async-signal-safe and avoids TLS allocation issues.
  * 
  * Usage:
  *   {
  *     CriticalSection cs; // Atomically claim critical section
+ *     if (!cs.entered()) return; // Another thread/signal handler is active
  *     // Complex data structure operations
  *     // Signal handlers will be blocked from entering
  *   } // Critical section automatically released
@@ -27,7 +32,17 @@
  */
 class CriticalSection {
 private:
-    bool _entered;  // Track if this instance successfully entered
+    static constexpr size_t FALLBACK_BITMAP_WORDS = 1024;  // 8KB for 64K bits
+    // Atomic bitmap for thread-safe critical section tracking without TLS
+    // Must be atomic because multiple signal handlers can run concurrently across
+    // different threads and attempt to set/clear bits simultaneously. Compare-and-swap
+    // operations ensure race-free bit manipulation even during signal interruption.
+    static std::atomic<uint64_t> _fallback_bitmap[FALLBACK_BITMAP_WORDS];
+    
+    bool _entered;          // Track if this instance successfully entered
+    bool _using_fallback;   // Track which storage mechanism we're using
+    uint32_t _word_index;   // For fallback bitmap cleanup
+    uint64_t _bit_mask;     // For fallback bitmap cleanup
     
 public:
     CriticalSection();
@@ -43,8 +58,8 @@ public:
     bool entered() const { return _entered; }
     
 private:
-    // Safe accessor for thread-local atomic flag
-    sig_atomic_t& getThreadLocalFlag();
+    // Hash function to distribute thread IDs across bitmap words
+    static uint32_t hash_tid(int tid);
 };
 
 #endif // _CRITICALSECTION_H

--- a/ddprof-lib/src/main/cpp/criticalSection.h
+++ b/ddprof-lib/src/main/cpp/criticalSection.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _CRITICALSECTION_H
+#define _CRITICALSECTION_H
+
+#include <signal.h>
+#include <atomic>
+
+/**
+ * Race-free critical section using atomic compare-and-swap.
+ * 
+ * Instead of expensive syscalls to block signals, this approach uses
+ * a thread-local atomic flag with CAS to prevent signal handler reentrancy.
+ * 
+ * Usage:
+ *   {
+ *     CriticalSection cs; // Atomically claim critical section
+ *     // Complex data structure operations
+ *     // Signal handlers will be blocked from entering
+ *   } // Critical section automatically released
+ * 
+ * This eliminates race conditions between signal handlers and normal code
+ * by ensuring only one can hold the critical section at a time per thread.
+ */
+class CriticalSection {
+private:
+    bool _entered;  // Track if this instance successfully entered
+    
+public:
+    CriticalSection();
+    ~CriticalSection();
+    
+    // Non-copyable, non-movable
+    CriticalSection(const CriticalSection&) = delete;
+    CriticalSection& operator=(const CriticalSection&) = delete;
+    CriticalSection(CriticalSection&&) = delete;
+    CriticalSection& operator=(CriticalSection&&) = delete;
+    
+    // Check if this instance successfully entered the critical section
+    bool entered() const { return _entered; }
+    
+    // Static method for signal handlers to check critical section status
+    // Returns true if ANY critical section is active on this thread
+    static bool isInCriticalSection();
+    
+private:
+    // Safe accessor for thread-local atomic flag
+    static std::atomic<sig_atomic_t>& getThreadLocalFlag();
+};
+
+#endif // _CRITICALSECTION_H

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -16,6 +16,7 @@
 
 #ifdef __linux__
 
+#include "criticalSection.h"
 #include "ctimer.h"
 #include "debugSupport.h"
 #include "libraries.h"
@@ -197,6 +198,11 @@ void CTimer::stop() {
 }
 
 void CTimer::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
+  // Atomically try to enter critical section - prevents all reentrancy races
+  CriticalSection cs;
+  if (!cs.entered()) {
+    return;  // Another critical section is active, defer profiling
+  }
   // Save the current errno value
   int saved_errno = errno;
   // we want to ensure memory order because of the possibility the instance gets

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -7,6 +7,7 @@
 #include <assert.h>
 
 #include "buffers.h"
+#include "callTraceHashTable.h"
 #include "context.h"
 #include "counters.h"
 #include "dictionary.h"

--- a/ddprof-lib/src/main/cpp/gtest_crash_handler.h
+++ b/ddprof-lib/src/main/cpp/gtest_crash_handler.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef GTEST_CRASH_HANDLER_H
+#define GTEST_CRASH_HANDLER_H
+
+#include <signal.h>
+#include <unistd.h>
+#include <sys/ucontext.h>
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+
+// Platform detection for execinfo.h availability
+#if defined(__GLIBC__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+    #define HAVE_EXECINFO_H 1
+    #include <execinfo.h>
+#else
+    #define HAVE_EXECINFO_H 0
+    // Fallback declarations for platforms without execinfo.h
+#endif
+
+/**
+ * Shared crash handler for all gtest files.
+ * Provides detailed crash reporting with backtrace and register information.
+ * Use installGtestCrashHandler() to install and restoreDefaultSignalHandlers() to cleanup.
+ */
+
+// Global crash handler for detailed debugging of segfaults
+inline void gtestCrashHandler(int sig, siginfo_t *info, void *context, const char* test_name) {
+    // Prevent recursive calls
+    static volatile sig_atomic_t in_crash_handler = 0;
+    if (in_crash_handler) {
+        // Already in crash handler - just exit to prevent infinite loop
+        _exit(128 + sig);
+    }
+    in_crash_handler = 1;
+    
+    // Use async-signal-safe functions only
+    const char* signal_names[] = {
+        "UNKNOWN", "SIGHUP", "SIGINT", "SIGQUIT", "SIGILL", "SIGTRAP", "SIGABRT", "SIGBUS",
+        "SIGFPE", "SIGKILL", "SIGSEGV", "SIGUSR1", "SIGPIPE", "SIGALRM", "SIGTERM", "SIGUSR2"
+    };
+    
+    const char* signal_name = (sig >= 1 && sig <= 15) ? signal_names[sig] : "UNKNOWN";
+    
+    // Write crash info to stderr (async-signal-safe)
+    write(STDERR_FILENO, "\n=== GTEST CRASH: ", 19);
+    write(STDERR_FILENO, test_name, strlen(test_name));
+    write(STDERR_FILENO, " ===\n", 6);
+    
+    // Signal type
+    write(STDERR_FILENO, "Signal: ", 8);
+    write(STDERR_FILENO, signal_name, strlen(signal_name));
+    
+    // Format signal number
+    char sig_buf[32];
+    snprintf(sig_buf, sizeof(sig_buf), " (%d)\n", sig);
+    write(STDERR_FILENO, sig_buf, strlen(sig_buf));
+    
+    // Fault address for memory access violations
+    if (sig == SIGSEGV || sig == SIGBUS) {
+        write(STDERR_FILENO, "Fault address: 0x", 17);
+        char addr_buf[32];
+        snprintf(addr_buf, sizeof(addr_buf), "%lx\n", (unsigned long)info->si_addr);
+        write(STDERR_FILENO, addr_buf, strlen(addr_buf));
+    }
+    
+    // Thread ID
+    write(STDERR_FILENO, "Thread ID: ", 11);
+    char tid_buf[32];
+    snprintf(tid_buf, sizeof(tid_buf), "%d\n", getpid());
+    write(STDERR_FILENO, tid_buf, strlen(tid_buf));
+    
+    // Backtrace (if available)
+    write(STDERR_FILENO, "\nBacktrace:\n", 12);
+#if HAVE_EXECINFO_H
+    void *buffer[64];
+    int nptrs = backtrace(buffer, 64);
+    
+    // Use backtrace_symbols_fd which is async-signal-safe
+    backtrace_symbols_fd(buffer, nptrs, STDERR_FILENO);
+#else
+    write(STDERR_FILENO, "  [Backtrace not available on this platform]\n", 45);
+#endif
+    
+    // Register state (platform specific)
+#ifdef __APPLE__
+    ucontext_t *uctx = (ucontext_t *)context;
+    if (uctx && uctx->uc_mcontext) {
+        write(STDERR_FILENO, "\nRegister state:\n", 17);
+        char reg_buf[128];
+        #ifdef __x86_64__
+            snprintf(reg_buf, sizeof(reg_buf), "RIP: 0x%llx, RSP: 0x%llx\n", 
+                    uctx->uc_mcontext->__ss.__rip, uctx->uc_mcontext->__ss.__rsp);
+        #elif defined(__aarch64__)
+            snprintf(reg_buf, sizeof(reg_buf), "PC: 0x%llx, SP: 0x%llx\n",
+                    uctx->uc_mcontext->__ss.__pc, uctx->uc_mcontext->__ss.__sp);
+        #endif
+        write(STDERR_FILENO, reg_buf, strlen(reg_buf));
+    }
+#endif
+    
+    write(STDERR_FILENO, "\n=== END CRASH INFO ===\n", 25);
+    
+    // Ensure output is flushed
+    fsync(STDERR_FILENO);
+    
+    // Don't interfere with AddressSanitizer - just exit cleanly
+    _exit(128 + sig);
+}
+
+// Template wrapper to pass test name to crash handler
+template<const char* TestName>
+void specificCrashHandler(int sig, siginfo_t *info, void *context) {
+    gtestCrashHandler(sig, info, context, TestName);
+}
+
+// Install crash handler for debugging
+template<const char* TestName>
+void installGtestCrashHandler() {
+    struct sigaction sa;
+    sa.sa_flags = SA_SIGINFO;  // Get detailed info, keep handler active
+    sigemptyset(&sa.sa_mask);
+    sa.sa_sigaction = specificCrashHandler<TestName>;
+    
+    // Install for various crash signals
+    sigaction(SIGSEGV, &sa, nullptr);
+    sigaction(SIGBUS, &sa, nullptr);
+    sigaction(SIGABRT, &sa, nullptr);
+    sigaction(SIGFPE, &sa, nullptr);
+    sigaction(SIGILL, &sa, nullptr);
+}
+
+// Restore default signal handlers
+inline void restoreDefaultSignalHandlers() {
+    signal(SIGSEGV, SIG_DFL);
+    signal(SIGBUS, SIG_DFL);
+    signal(SIGABRT, SIG_DFL);
+    signal(SIGFPE, SIG_DFL);
+    signal(SIGILL, SIG_DFL);
+}
+
+#endif // GTEST_CRASH_HANDLER_H

--- a/ddprof-lib/src/main/cpp/livenessTracker.h
+++ b/ddprof-lib/src/main/cpp/livenessTracker.h
@@ -14,6 +14,7 @@
 #include <jvmti.h>
 #include <pthread.h>
 #include <set>
+#include <unordered_set>
 
 class Recording;
 
@@ -28,7 +29,9 @@ typedef struct TrackingEntry {
   Context ctx;
 } TrackingEntry;
 
-class LivenessTracker {
+// Aligned to satisfy SpinLock member alignment requirement (64 bytes)
+// Required because this class contains SpinLock _table_lock member
+class alignas(alignof(SpinLock)) LivenessTracker {
   friend Recording;
 
 private:
@@ -94,7 +97,7 @@ public:
   static void JNICALL GarbageCollectionFinish(jvmtiEnv *jvmti_env);
 
 private:
-  void getLiveTraceIds(std::vector<u64>& out_buffer);
+  void getLiveTraceIds(std::unordered_set<u64>& out_buffer);
 };
 
 #endif // _LIVENESSTRACKER_H

--- a/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
+++ b/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
@@ -18,6 +18,7 @@
 
 #include "arch_dd.h"
 #include "context.h"
+#include "criticalSection.h"
 #include "debugSupport.h"
 #include "libraries.h"
 #include "log.h"
@@ -726,7 +727,11 @@ void PerfEvents::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
     // Looks like an external signal; don't treat as a profiling event
     return;
   }
-
+  // Atomically try to enter critical section - prevents all reentrancy races
+  CriticalSection cs;
+  if (!cs.entered()) {
+    return;  // Another critical section is active, defer profiling
+  }
   ProfiledThread *current = ProfiledThread::current();
   if (current != NULL) {
     current->noteCPUSample(Profiler::instance()->recordingEpoch());

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -60,7 +60,10 @@ class VM;
 
 enum State { NEW, IDLE, RUNNING, TERMINATED };
 
-class Profiler {
+// Aligned to satisfy SpinLock member alignment requirement (64 bytes)  
+// Required because this class contains multiple SpinLock members:
+// _class_map_lock, _locks[], and _stubs_lock
+class alignas(alignof(SpinLock)) Profiler {
   friend VM;
 
 private:

--- a/ddprof-lib/src/main/cpp/spinLock.h
+++ b/ddprof-lib/src/main/cpp/spinLock.h
@@ -21,6 +21,7 @@
 
 // Cannot use regular mutexes inside signal handler.
 // This lock is based on CAS busy loop. GCC atomic builtins imply full barrier.
+// Aligned to cache line size (64 bytes) to prevent false sharing between SpinLock instances
 class alignas(DEFAULT_CACHE_LINE_SIZE) SpinLock {
 private:
   //  0 - unlocked

--- a/ddprof-lib/src/main/cpp/spinLock.h
+++ b/ddprof-lib/src/main/cpp/spinLock.h
@@ -67,4 +67,39 @@ public:
   void unlockShared() { __sync_fetch_and_add(&_lock, 1); }
 };
 
+// RAII guard classes for automatic lock management
+class SharedLockGuard {
+private:
+  SpinLock* _lock;
+public:
+  explicit SharedLockGuard(SpinLock* lock) : _lock(lock) {
+    _lock->lockShared();
+  }
+  ~SharedLockGuard() {
+    _lock->unlockShared();
+  }
+  // Non-copyable and non-movable
+  SharedLockGuard(const SharedLockGuard&) = delete;
+  SharedLockGuard& operator=(const SharedLockGuard&) = delete;
+  SharedLockGuard(SharedLockGuard&&) = delete;
+  SharedLockGuard& operator=(SharedLockGuard&&) = delete;
+};
+
+class ExclusiveLockGuard {
+private:
+  SpinLock* _lock;
+public:
+  explicit ExclusiveLockGuard(SpinLock* lock) : _lock(lock) {
+    _lock->lock();
+  }
+  ~ExclusiveLockGuard() {
+    _lock->unlock();
+  }
+  // Non-copyable and non-movable
+  ExclusiveLockGuard(const ExclusiveLockGuard&) = delete;
+  ExclusiveLockGuard& operator=(const ExclusiveLockGuard&) = delete;
+  ExclusiveLockGuard(ExclusiveLockGuard&&) = delete;
+  ExclusiveLockGuard& operator=(ExclusiveLockGuard&&) = delete;
+};
+
 #endif // _SPINLOCK_H

--- a/ddprof-lib/src/main/cpp/thread.h
+++ b/ddprof-lib/src/main/cpp/thread.h
@@ -129,6 +129,45 @@ public:
 
   int filterSlotId() { return _filter_slot_id; }
   void setFilterSlotId(int slotId) { _filter_slot_id = slotId; }
+  
+  // Signal handler reentrancy protection
+  bool tryEnterCriticalSection() { 
+    return !_in_critical_section.exchange(true, std::memory_order_acquire); 
+  }
+  void exitCriticalSection() { 
+    _in_critical_section.store(false, std::memory_order_release); 
+  }
+  
+  // Hazard pointer management for lock-free memory reclamation (signal-safe)
+  // 
+  // How hazard pointers work:
+  // 1. Before accessing a shared data structure, threads register a "hazard pointer" to it
+  // 2. When deleting the structure, the deleter waits for all hazard pointers to clear
+  // 3. This ensures no thread accesses freed memory, even in signal handler contexts
+  // 4. Alternative to locks that avoids malloc/deadlock issues in signal handlers
+  //
+  // Currently used only in CallTraceStorage for safe table swapping during profiling
+  void setHazardPointer(void* instance, void* hazard_pointer, int hazard_slot) {
+    _hazard_instance = instance;
+    _hazard_pointer = hazard_pointer;
+    _hazard_slot = hazard_slot;
+  }
+  void* getHazardInstance() { return _hazard_instance; }
+  void* getHazardPointer() { return _hazard_pointer; }
+  int getHazardSlot() { return _hazard_slot; }
+  
+private:
+  // Atomic flag for signal handler reentrancy protection within the same thread
+  // Must be atomic because a signal handler can interrupt normal execution mid-instruction,
+  // and both contexts may attempt to enter the critical section. Without atomic exchange(),
+  // both could see the flag as false and both would think they successfully entered.
+  // The atomic exchange() is uninterruptible, ensuring only one context succeeds.
+  std::atomic<bool> _in_critical_section{false};
+  
+  // Hazard pointer instance for signal-safe access (not atomic since only accessed by same thread)
+  void* _hazard_instance{nullptr};
+  void* _hazard_pointer{nullptr};
+  int _hazard_slot{-1};
 };
 
 #endif // _THREAD_H

--- a/ddprof-lib/src/main/cpp/threadFilter.h
+++ b/ddprof-lib/src/main/cpp/threadFilter.h
@@ -81,6 +81,7 @@ private:
     std::atomic<SlotID> _next_index{0};
     std::unique_ptr<FreeListNode[]> _free_list;
 
+    // Cache line aligned to prevent false sharing between shards
     struct alignas(DEFAULT_CACHE_LINE_SIZE) ShardHead { std::atomic<int> head{-1}; };
     static ShardHead _free_heads[kShardCount];         // one cache-line each
 

--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -14,6 +14,7 @@
 #include "stackFrame.h"
 #include "thread.h"
 #include "vmStructs_dd.h"
+#include "criticalSection.h"
 #include <math.h>
 #include <random>
 #include <algorithm> // For std::sort and std::binary_search
@@ -55,6 +56,11 @@ void WallClockASGCT::sharedSignalHandler(int signo, siginfo_t *siginfo,
 
 void WallClockASGCT::signalHandler(int signo, siginfo_t *siginfo, void *ucontext,
                               u64 last_sample) {
+  // Atomically try to enter critical section - prevents all reentrancy races
+  CriticalSection cs;
+  if (!cs.entered()) {
+    return;  // Another critical section is active, defer profiling
+  }
   ProfiledThread *current = ProfiledThread::current();
   int tid = current != NULL ? current->tid() : OS::threadId();
   Shims::instance().setSighandlerTid(tid);

--- a/ddprof-lib/src/test/cpp/ddprof_ut.cpp
+++ b/ddprof-lib/src/test/cpp/ddprof_ut.cpp
@@ -11,12 +11,30 @@
     #include "threadInfo.h"
     #include "threadLocalData.h"
     #include "vmEntry.h"
+    #include "../../main/cpp/gtest_crash_handler.h"
     #include <map>
     #include <thread>
     #include <vector>
     #include <algorithm>  // For std::sort
     #include <thread>
     #include <atomic>
+
+// Test name for crash handler
+static constexpr char DDPROF_TEST_NAME[] = "DdprofTest";
+
+// Global crash handler installation (since this file uses bare TEST() macros)
+class DdprofGlobalSetup {
+public:
+    DdprofGlobalSetup() {
+        installGtestCrashHandler<DDPROF_TEST_NAME>();
+    }
+    ~DdprofGlobalSetup() {
+        restoreDefaultSignalHandlers();
+    }
+};
+
+// Install global crash handler for all tests in this file
+static DdprofGlobalSetup ddprof_global_setup;
 
     ssize_t callback(char* ptr, int len) {
         return len;

--- a/ddprof-lib/src/test/cpp/demangle_ut.cpp
+++ b/ddprof-lib/src/test/cpp/demangle_ut.cpp
@@ -1,8 +1,26 @@
 #include <gtest/gtest.h>
 
 #include "rustDemangler.h"
+#include "../../main/cpp/gtest_crash_handler.h"
 
 #include <cxxabi.h>
+
+// Test name for crash handler
+static constexpr char DEMANGLE_TEST_NAME[] = "DemangleTest";
+
+// Global crash handler installation (since this file uses bare TEST() macros)
+class DemangleGlobalSetup {
+public:
+    DemangleGlobalSetup() {
+        installGtestCrashHandler<DEMANGLE_TEST_NAME>();
+    }
+    ~DemangleGlobalSetup() {
+        restoreDefaultSignalHandlers();
+    }
+};
+
+// Install global crash handler for all tests in this file
+static DemangleGlobalSetup demangle_global_setup;
 
 #ifndef __APPLE__
 

--- a/ddprof-lib/src/test/cpp/elfparser_ut.cpp
+++ b/ddprof-lib/src/test/cpp/elfparser_ut.cpp
@@ -8,6 +8,7 @@
 #include "symbols.h"
 #include "symbols_linux.h"
 #include "log.h"
+#include "../../main/cpp/gtest_crash_handler.h"
 
 #include <unistd.h>
 #include <limits.h> // For PATH_MAX
@@ -23,6 +24,23 @@
 #include <signal.h>
 #include <unistd.h>
 #include <cstdio>
+
+// Test name for crash handler
+static constexpr char ELF_TEST_NAME[] = "ElfParserTest";
+
+// Global crash handler installation (since this file uses bare TEST() macros)
+class ElfParserGlobalSetup {
+public:
+    ElfParserGlobalSetup() {
+        installGtestCrashHandler<ELF_TEST_NAME>();
+    }
+    ~ElfParserGlobalSetup() {
+        restoreDefaultSignalHandlers();
+    }
+};
+
+// Install global crash handler for all tests in this file
+static ElfParserGlobalSetup global_setup;
 
 TEST(Elf, readSymTable) {
     char cwd[PATH_MAX - 64];

--- a/ddprof-lib/src/test/cpp/safefetch_ut.cpp
+++ b/ddprof-lib/src/test/cpp/safefetch_ut.cpp
@@ -5,6 +5,10 @@
 
 #include "safeAccess.h"
 #include "os_dd.h"
+#include "../../main/cpp/gtest_crash_handler.h"
+
+// Test name for crash handler
+static constexpr char SAFEFETCH_TEST_NAME[] = "SafeFetchTest";
 
 
 static void (*orig_segvHandler)(int signo, siginfo_t *siginfo, void *ucontext);
@@ -17,6 +21,9 @@ void signal_handle_wrapper(int signo, siginfo_t* siginfo, void* context) {
        orig_busHandler(signo, siginfo, context);
     } else if (signo == SIGSEGV && orig_segvHandler != nullptr) {
        orig_segvHandler(signo, siginfo, context);
+    } else {
+       // If no original handler, use crash handler for debugging
+       gtestCrashHandler(signo, siginfo, context, SAFEFETCH_TEST_NAME);
     }
   }
 }

--- a/ddprof-lib/src/test/cpp/stress_callTraceStorage.cpp
+++ b/ddprof-lib/src/test/cpp/stress_callTraceStorage.cpp
@@ -1,0 +1,2109 @@
+/*
+ * Copyright 2025, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gtest/gtest.h"
+#include "callTraceStorage.h"
+#include "callTraceHashTable.h"
+#include "criticalSection.h"
+#include <vector>
+#include <unordered_set>
+#include <thread>
+#include <atomic>
+#include <random>
+#include <chrono>
+#include <algorithm>
+#include <cstring>
+#include <climits>
+#include <stdexcept>
+#include <mutex>
+#include <signal.h>
+#include <unistd.h>
+#include <sys/ucontext.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <dlfcn.h>
+#include <cstdlib>
+#include <sstream>
+#include <fstream>
+#include "../../main/cpp/gtest_crash_handler.h"
+
+// Test name for crash handler
+static constexpr const char STRESS_TEST_NAME[] = "StressCallTraceStorage";
+
+// Helper function to find a CallTrace by trace_id in an unordered_set
+CallTrace* findTraceById(const std::unordered_set<CallTrace*>& traces, u64 trace_id) {
+    for (CallTrace* trace : traces) {
+        if (trace && trace != CallTraceSample::PREPARING && trace->trace_id == trace_id) {
+            return trace;
+        }
+    }
+    return nullptr;
+}
+
+// Optimized batch lookup for multiple trace IDs
+void findMultipleTracesById(const std::unordered_set<CallTrace*>& traces, 
+                           const std::vector<u64>& trace_ids,
+                           size_t& found_count) {
+    // Create a lookup set for O(1) lookups instead of O(n) per trace
+    std::unordered_set<u64> target_ids(trace_ids.begin(), trace_ids.end());
+    found_count = 0;
+    
+    for (CallTrace* trace : traces) {
+        if (trace && trace != CallTraceSample::PREPARING) {
+            if (target_ids.find(trace->trace_id) != target_ids.end()) {
+                found_count++;
+                // Early termination - found all traces
+                if (found_count == trace_ids.size()) {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+// Thread-safe random number generator for deterministic testing
+class ThreadSafeRandom {
+private:
+    std::mt19937 gen_;
+    std::mutex mutex_;
+    
+public:
+    explicit ThreadSafeRandom(uint32_t seed = std::random_device{}()) : gen_(seed) {}
+    
+    uint64_t next(uint64_t max_val = UINT64_MAX) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        std::uniform_int_distribution<uint64_t> dis(0, max_val);
+        return dis(gen_);
+    }
+};
+
+// Guarded buffer for detecting memory corruption
+class GuardedBuffer {
+private:
+    static constexpr uint32_t GUARD_PATTERN = 0xDEADBEEF;
+    static constexpr size_t GUARD_SIZE = sizeof(uint32_t);
+    static constexpr size_t ALIGNMENT = 8; // 8-byte alignment for ASGCT_CallFrame
+    
+    void* buffer_;
+    size_t size_;
+    void* aligned_data_;
+    
+    void setGuards() {
+        uint32_t* front_guard = reinterpret_cast<uint32_t*>(buffer_);
+        uint32_t* back_guard = reinterpret_cast<uint32_t*>(
+            static_cast<char*>(aligned_data_) + size_
+        );
+        *front_guard = GUARD_PATTERN;
+        *back_guard = GUARD_PATTERN;
+    }
+    
+    // Calculate the next properly aligned address
+    static void* align_pointer(void* ptr, size_t alignment) {
+        uintptr_t addr = reinterpret_cast<uintptr_t>(ptr);
+        uintptr_t aligned = (addr + alignment - 1) & ~(alignment - 1);
+        return reinterpret_cast<void*>(aligned);
+    }
+    
+public:
+    explicit GuardedBuffer(size_t size) : size_(size) {
+        // Allocate extra space for guards + alignment padding
+        size_t total_size = GUARD_SIZE + (ALIGNMENT - 1) + size + GUARD_SIZE;
+        buffer_ = malloc(total_size);
+        if (buffer_ == nullptr) {
+            throw std::bad_alloc();
+        }
+        
+        // Calculate aligned data pointer after front guard
+        void* after_front_guard = static_cast<char*>(buffer_) + GUARD_SIZE;
+        aligned_data_ = align_pointer(after_front_guard, ALIGNMENT);
+        
+        setGuards();
+    }
+    
+    ~GuardedBuffer() {
+        if (buffer_) {
+            free(buffer_);
+        }
+    }
+    
+    void* data() {
+        return aligned_data_;
+    }
+    
+    bool checkCorruption() const {
+        uint32_t* front_guard = reinterpret_cast<uint32_t*>(buffer_);
+        uint32_t* back_guard = reinterpret_cast<uint32_t*>(
+            static_cast<char*>(aligned_data_) + size_
+        );
+        return (*front_guard != GUARD_PATTERN) || (*back_guard != GUARD_PATTERN);
+    }
+};
+
+class StressTestSuite : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Install crash handler for detailed debugging
+        installGtestCrashHandler<STRESS_TEST_NAME>();
+        
+        // Initialize any shared resources
+    }
+    
+    void TearDown() override {
+        // Restore default signal handlers
+        restoreDefaultSignalHandlers();
+        
+        // Clean up resources
+    }
+};
+
+// Test 1: SwapStormTest - Double-buffered call-trace storage under rapid swapping
+TEST_F(StressTestSuite, SwapStormTest) {
+    const int NUM_THREADS = 8;
+    const int OPERATIONS_PER_THREAD = 5000;
+    const int SWAP_FREQUENCY_MS = 10;
+    
+    std::atomic<bool> test_running{true};
+    std::atomic<bool> test_failed{false};
+    std::atomic<uint64_t> total_operations{0};
+    std::atomic<uint64_t> successful_puts{0};
+    std::atomic<uint64_t> swap_count{0};
+    
+    auto storage = std::make_unique<CallTraceStorage>();
+    ThreadSafeRandom random_gen(12345);
+    
+    // Worker threads continuously adding traces
+    std::vector<std::thread> workers;
+    for (int i = 0; i < NUM_THREADS; ++i) {
+        workers.emplace_back([&, i]() {
+            std::mt19937 local_gen(random_gen.next(UINT32_MAX));
+            std::uniform_int_distribution<uint32_t> bci_dis(1, 1000);
+            std::uniform_int_distribution<uintptr_t> method_dis(0x1000, 0x9999);
+            
+            for (int op = 0; op < OPERATIONS_PER_THREAD && test_running.load(); ++op) {
+                try {
+                    ASGCT_CallFrame frame;
+                    frame.bci = bci_dis(local_gen);
+                    frame.method_id = reinterpret_cast<jmethodID>(method_dis(local_gen));
+                    
+                    u64 trace_id = storage->put(1, &frame, false, 1);
+                    if (trace_id > 0) {
+                        successful_puts.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    
+                    total_operations.fetch_add(1, std::memory_order_relaxed);
+                    
+                    // Occasional yield to allow swaps
+                    if (op % 100 == 0) {
+                        std::this_thread::yield();
+                    }
+                    
+                } catch (...) {
+                    test_failed.store(true);
+                    break;
+                }
+            }
+        });
+    }
+    
+    // Rapid swapping thread
+    std::thread swapper([&]() {
+        while (test_running.load() && !test_failed.load()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(SWAP_FREQUENCY_MS));
+            
+            try {
+                storage->processTraces([](const std::unordered_set<CallTrace*>& traces) {
+                    // Process traces (simulating JFR serialization)
+                    (void)traces.size();
+                });
+                swap_count.fetch_add(1, std::memory_order_relaxed);
+            } catch (...) {
+                test_failed.store(true);
+                break;
+            }
+        }
+    });
+    
+    // Let the stress test run for a reasonable duration
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    test_running.store(false);
+    
+    // Wait for all threads
+    for (auto& worker : workers) {
+        worker.join();
+    }
+    swapper.join();
+    
+    // Verify results
+    EXPECT_FALSE(test_failed.load()) << "Stress test encountered failures";
+    EXPECT_GT(swap_count.load(), 0) << "No swaps occurred during test";
+    EXPECT_GT(successful_puts.load(), 0) << "No successful trace insertions";
+    EXPECT_EQ(total_operations.load(), NUM_THREADS * OPERATIONS_PER_THREAD) 
+        << "Not all operations completed";
+    
+    std::cout << "SwapStorm completed: " << total_operations.load() << " ops, " 
+              << swap_count.load() << " swaps, " << successful_puts.load() << " successful puts" << std::endl;
+}
+
+// Test 2: HashTableContentionTest - Concurrent hash table operations
+TEST_F(StressTestSuite, HashTableContentionTest) {
+    const int NUM_THREADS = 6;
+    const int TRACES_PER_THREAD = 3000;
+    
+    CallTraceHashTable hash_table;
+    hash_table.setInstanceId(42);
+    
+    std::atomic<bool> test_failed{false};
+    std::atomic<uint64_t> successful_operations{0};
+    std::atomic<uint64_t> expansion_triggers{0};
+    std::vector<std::thread> threads;
+    
+    // Create diverse stack traces to force table expansion
+    for (int t = 0; t < NUM_THREADS; ++t) {
+        threads.emplace_back([&, t]() {
+            std::mt19937 gen(std::random_device{}() + t);
+            std::uniform_int_distribution<uint32_t> bci_dis(1, 10000);
+            std::uniform_int_distribution<uintptr_t> method_dis(0x1000, 0xFFFF);
+            
+            for (int i = 0; i < TRACES_PER_THREAD; ++i) {
+                try {
+                    ASGCT_CallFrame frame;
+                    frame.bci = t * 10000 + bci_dis(gen); // Ensure uniqueness
+                    frame.method_id = reinterpret_cast<jmethodID>(t * 0x10000 + method_dis(gen));
+                    
+                    u64 trace_id = hash_table.put(1, &frame, false, 1);
+                    
+                    if (trace_id == 0) {
+                        // Sample was dropped - acceptable under high contention
+                        continue;
+                    }
+                    
+                    if (trace_id == 0x7fffffffffffffffULL) {
+                        // Overflow trace - also acceptable
+                        continue;
+                    }
+                    
+                    successful_operations.fetch_add(1, std::memory_order_relaxed);
+                    
+                    // Detect expansion events (approximate)
+                    if (i > 0 && i % 1000 == 0) {
+                        expansion_triggers.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    
+                    // Yield occasionally to increase contention
+                    if (i % 500 == 0) {
+                        std::this_thread::yield();
+                    }
+                    
+                } catch (...) {
+                    test_failed.store(true);
+                    return;
+                }
+            }
+        });
+    }
+    
+    // Wait for all threads
+    for (auto& thread : threads) {
+        thread.join();
+    }
+    
+    EXPECT_FALSE(test_failed.load()) << "Hash table contention test failed";
+    EXPECT_GT(successful_operations.load(), 0) << "No successful hash table operations";
+    
+    // Verify table still functions after stress
+    ASGCT_CallFrame test_frame;
+    test_frame.bci = 99999;
+    test_frame.method_id = reinterpret_cast<jmethodID>(0x99999);
+    u64 final_trace_id = hash_table.put(1, &test_frame, false, 1);
+    EXPECT_GT(final_trace_id, 0) << "Hash table non-functional after stress test";
+    
+    std::cout << "HashTable contention completed: " << successful_operations.load() 
+              << " successful operations" << std::endl;
+}
+
+// Test 3: TraceIdFuzzTest - 64-bit TraceId bit-packing validation
+TEST_F(StressTestSuite, TraceIdFuzzTest) {
+    const int NUM_THREADS = 4;
+    const int OPERATIONS_PER_THREAD = 50000;
+    
+    std::atomic<bool> test_failed{false};
+    std::atomic<uint64_t> total_operations{0};
+    std::atomic<uint64_t> sign_extension_violations{0};
+    std::vector<std::thread> threads;
+    
+    // Helper functions for TraceId manipulation
+    auto extract_slot = [](u64 trace_id) -> u64 {
+        return trace_id & 0xFFFFFFFFULL;
+    };
+    
+    auto extract_instance_id = [](u64 trace_id) -> u64 {
+        return trace_id >> 32;
+    };
+    
+    auto create_trace_id = [](u64 instance_id, u64 slot) -> u64 {
+        return (instance_id << 32) | (slot & 0xFFFFFFFFULL);
+    };
+    
+    for (int t = 0; t < NUM_THREADS; ++t) {
+        threads.emplace_back([&, t]() {
+            std::mt19937 gen(std::random_device{}() + t);
+            std::uniform_int_distribution<u64> dis(0, 0xFFFFFFFFULL);
+            
+            for (int i = 0; i < OPERATIONS_PER_THREAD; ++i) {
+                try {
+                    u64 instance_id = dis(gen);
+                    u64 slot = dis(gen);
+                    
+                    u64 trace_id = create_trace_id(instance_id, slot);
+                    u64 extracted_instance = extract_instance_id(trace_id);
+                    u64 extracted_slot = extract_slot(trace_id);
+                    
+                    // Verify bit-packing correctness
+                    if (extracted_instance != instance_id || extracted_slot != slot) {
+                        test_failed.store(true);
+                        return;
+                    }
+                    
+                    // Check for potential sign-extension issues
+                    int32_t slot_as_int32 = static_cast<int32_t>(slot);
+                    if (slot_as_int32 < 0) {
+                        sign_extension_violations.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    
+                    // Test with extreme values
+                    if (i % 1000 == 0) {
+                        std::vector<u64> extreme_values = {
+                            0x0000000000000000ULL,
+                            0xFFFFFFFFFFFFFFFFULL,
+                            0x7FFFFFFFFFFFFFFFULL,
+                            0x8000000000000000ULL,
+                            0x00000000FFFFFFFFULL,
+                            0xFFFFFFFF00000000ULL,
+                        };
+                        
+                        for (u64 extreme_trace_id : extreme_values) {
+                            u64 e_slot = extract_slot(extreme_trace_id);
+                            u64 e_instance = extract_instance_id(extreme_trace_id);
+                            u64 reconstructed = create_trace_id(e_instance, e_slot);
+                            
+                            if (reconstructed != extreme_trace_id) {
+                                test_failed.store(true);
+                                return;
+                            }
+                        }
+                    }
+                    
+                    total_operations.fetch_add(1, std::memory_order_relaxed);
+                    
+                } catch (...) {
+                    test_failed.store(true);
+                    return;
+                }
+            }
+        });
+    }
+    
+    // Wait for all threads
+    for (auto& thread : threads) {
+        thread.join();
+    }
+    
+    EXPECT_FALSE(test_failed.load()) << "TraceId bit-packing test failed";
+    EXPECT_EQ(total_operations.load(), NUM_THREADS * OPERATIONS_PER_THREAD) 
+        << "Not all TraceId operations completed";
+    
+    std::cout << "TraceId fuzz test completed: " << total_operations.load() 
+              << " operations, " << sign_extension_violations.load() 
+              << " sign extension cases detected" << std::endl;
+}
+
+// Test 4: AsgctBoundsTest - ASGCT frame handling bounds checking
+TEST_F(StressTestSuite, AsgctBoundsTest) {
+    const int NUM_THREADS = 4;
+    const int FRAMES_PER_THREAD = 10000;
+    const size_t MAX_FRAMES = 1024;
+    
+    std::atomic<bool> test_failed{false};
+    std::atomic<uint64_t> guard_violations{0};
+    std::atomic<uint64_t> bounds_checks{0};
+    std::vector<std::thread> threads;
+    
+    // Pre-allocated guarded buffers for each thread
+    std::vector<std::unique_ptr<GuardedBuffer>> buffers;
+    for (int t = 0; t < NUM_THREADS; ++t) {
+        buffers.push_back(std::make_unique<GuardedBuffer>(MAX_FRAMES * sizeof(ASGCT_CallFrame)));
+    }
+    
+    for (int t = 0; t < NUM_THREADS; ++t) {
+        threads.emplace_back([&, t]() {
+            ASGCT_CallFrame* frames = static_cast<ASGCT_CallFrame*>(buffers[t]->data());
+            std::mt19937 gen(std::random_device{}() + t);
+            std::uniform_int_distribution<uint32_t> bci_dis(0, UINT32_MAX);
+            std::uniform_int_distribution<uintptr_t> method_dis(0x1000, 0xFFFFF);
+            std::uniform_int_distribution<size_t> frame_count_dis(1, MAX_FRAMES);
+            
+            for (int i = 0; i < FRAMES_PER_THREAD; ++i) {
+                try {
+                    size_t num_frames = frame_count_dis(gen);
+                    
+                    // Fill frames with random data
+                    for (size_t f = 0; f < num_frames; ++f) {
+                        frames[f].bci = bci_dis(gen);
+                        frames[f].method_id = reinterpret_cast<jmethodID>(method_dis(gen));
+                    }
+                    
+                    // Simulate bounds checking that might occur in actual profiler
+                    for (size_t f = 0; f < num_frames; ++f) {
+                        if (frames[f].bci == static_cast<jint>(-1)) {
+                            // Native frame marker - acceptable
+                            continue;
+                        }
+                        
+                        // Check for reasonable BCI values
+                        if (frames[f].bci > 0x7FFFFFFF) {
+                            bounds_checks.fetch_add(1, std::memory_order_relaxed);
+                        }
+                        
+                        // Verify method_id is not null (would be problematic)
+                        if (frames[f].method_id == nullptr) {
+                            bounds_checks.fetch_add(1, std::memory_order_relaxed);
+                        }
+                    }
+                    
+                    // Check for buffer corruption
+                    if (buffers[t]->checkCorruption()) {
+                        guard_violations.fetch_add(1, std::memory_order_relaxed);
+                        test_failed.store(true);
+                        return;
+                    }
+                    
+                    // Yield occasionally
+                    if (i % 1000 == 0) {
+                        std::this_thread::yield();
+                    }
+                    
+                } catch (...) {
+                    test_failed.store(true);
+                    return;
+                }
+            }
+        });
+    }
+    
+    // Wait for all threads
+    for (auto& thread : threads) {
+        thread.join();
+    }
+    
+    EXPECT_FALSE(test_failed.load()) << "ASGCT bounds test failed";
+    EXPECT_EQ(guard_violations.load(), 0) << "Buffer corruption detected";
+    
+    std::cout << "ASGCT bounds test completed: " << bounds_checks.load() 
+              << " bounds checks performed" << std::endl;
+}
+
+// Test 5: JfrTinyBufferTest - JFR serialization with minimal buffers
+TEST_F(StressTestSuite, JfrTinyBufferTest) {
+    const int NUM_THREADS = 4;
+    const int OPERATIONS_PER_THREAD = 5000;
+    const size_t TINY_BUFFER_SIZE = 64; // Deliberately small
+    
+    std::atomic<bool> test_failed{false};
+    std::atomic<uint64_t> buffer_overruns{0};
+    std::atomic<uint64_t> successful_writes{0};
+    std::vector<std::thread> threads;
+    
+    for (int t = 0; t < NUM_THREADS; ++t) {
+        threads.emplace_back([&, t]() {
+            auto buffer = std::make_unique<GuardedBuffer>(TINY_BUFFER_SIZE);
+            char* write_ptr = static_cast<char*>(buffer->data());
+            std::mt19937 gen(std::random_device{}() + t);
+            std::uniform_int_distribution<size_t> write_size_dis(1, TINY_BUFFER_SIZE + 10);
+            
+            for (int i = 0; i < OPERATIONS_PER_THREAD; ++i) {
+                try {
+                    size_t write_size = write_size_dis(gen);
+                    
+                    // Simulate JFR buffer write with bounds checking
+                    if (write_size <= TINY_BUFFER_SIZE) {
+                        // Safe write
+                        std::memset(write_ptr, static_cast<int>(0xAA + (i % 16)), write_size);
+                        successful_writes.fetch_add(1, std::memory_order_relaxed);
+                    } else {
+                        // Would overflow - record but don't actually overflow
+                        buffer_overruns.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    
+                    // Check for corruption
+                    if (buffer->checkCorruption()) {
+                        test_failed.store(true);
+                        return;
+                    }
+                    
+                    // Yield occasionally
+                    if (i % 500 == 0) {
+                        std::this_thread::yield();
+                    }
+                    
+                } catch (...) {
+                    test_failed.store(true);
+                    return;
+                }
+            }
+        });
+    }
+    
+    // Wait for all threads
+    for (auto& thread : threads) {
+        thread.join();
+    }
+    
+    EXPECT_FALSE(test_failed.load()) << "JFR tiny buffer test failed";
+    EXPECT_GT(successful_writes.load(), 0) << "No successful buffer writes";
+    EXPECT_GT(buffer_overruns.load(), 0) << "No buffer overrun cases detected";
+    
+    std::cout << "JFR tiny buffer test completed: " << successful_writes.load() 
+              << " successful writes, " << buffer_overruns.load() << " overruns detected" << std::endl;
+}
+
+// Test 6: LivenessPurityTest - Liveness callback purity validation
+TEST_F(StressTestSuite, LivenessPurityTest) {
+    const int NUM_ITERATIONS = 500;  // Reduced from 1000 for better performance
+    const int TRACES_PER_ITERATION = 50;
+    
+    std::atomic<bool> test_failed{false};
+    std::atomic<uint64_t> callback_invocations{0};
+    std::atomic<uint64_t> preserved_traces{0};
+    
+    auto storage = std::make_unique<CallTraceStorage>();
+    ThreadSafeRandom random_gen(54321);
+    
+    for (int iteration = 0; iteration < NUM_ITERATIONS; ++iteration) {
+        try {
+            std::vector<u64> trace_ids;
+            
+            // Add traces
+            for (int t = 0; t < TRACES_PER_ITERATION; ++t) {
+                ASGCT_CallFrame frame;
+                frame.bci = static_cast<jint>(random_gen.next(10000));
+                frame.method_id = reinterpret_cast<jmethodID>(random_gen.next(0xFFFF) + 0x1000);
+                
+                u64 trace_id = storage->put(1, &frame, false, 1);
+                if (trace_id > 0) {
+                    trace_ids.push_back(trace_id);
+                }
+            }
+            
+            if (trace_ids.empty()) {
+                continue;
+            }
+            
+            // Register liveness checker - should be pure and deterministic
+            size_t preserve_count = trace_ids.size() / 2;
+            std::vector<u64> to_preserve(trace_ids.begin(), trace_ids.begin() + preserve_count);
+            
+            storage->registerLivenessChecker([to_preserve](std::vector<u64>& buffer) {
+                // Pure callback - no side effects, deterministic output
+                for (u64 trace_id : to_preserve) {
+                    buffer.push_back(trace_id);
+                }
+            });
+            
+            callback_invocations.fetch_add(1, std::memory_order_relaxed);
+            
+            // Process traces and verify preservation
+            size_t actual_preserved = 0;
+            storage->processTraces([&](const std::unordered_set<CallTrace*>& traces) {
+                findMultipleTracesById(traces, to_preserve, actual_preserved);
+            });
+            
+            preserved_traces.fetch_add(actual_preserved, std::memory_order_relaxed);
+            
+            // Verify deterministic behavior - re-register same callback
+            storage->registerLivenessChecker([to_preserve](std::vector<u64>& buffer) {
+                for (u64 trace_id : to_preserve) {
+                    buffer.push_back(trace_id);
+                }
+            });
+            
+            // Second process should have consistent results
+            size_t second_preserved = 0;
+            storage->processTraces([&](const std::unordered_set<CallTrace*>& traces) {
+                findMultipleTracesById(traces, to_preserve, second_preserved);
+            });
+            
+            // Yield periodically
+            if (iteration % 100 == 0) {
+                std::this_thread::yield();
+            }
+            
+        } catch (...) {
+            test_failed.store(true);
+            break;
+        }
+    }
+    
+    EXPECT_FALSE(test_failed.load()) << "Liveness purity test failed";
+    EXPECT_GT(callback_invocations.load(), 0) << "No liveness callbacks invoked";
+    EXPECT_GT(preserved_traces.load(), 0) << "No traces preserved";
+    
+    std::cout << "Liveness purity test completed: " << callback_invocations.load() 
+              << " callback invocations, " << preserved_traces.load() << " traces preserved" << std::endl;
+}
+
+// TLS-focused stress tests
+
+// TLS canary pattern for detecting buffer corruption
+struct TLSCanary {
+    static constexpr uint64_t CANARY_PATTERN = 0xDEADBEEFCAFEBABEULL;
+    static constexpr size_t BUFFER_SIZE = 8192;
+    static constexpr size_t CANARY_COUNT = 4;
+    
+    uint64_t front_canary[CANARY_COUNT];
+    char buffer[BUFFER_SIZE];
+    uint64_t back_canary[CANARY_COUNT];
+    
+    TLSCanary() {
+        for (size_t i = 0; i < CANARY_COUNT; ++i) {
+            front_canary[i] = CANARY_PATTERN + i;
+            back_canary[i] = CANARY_PATTERN + i + CANARY_COUNT;
+        }
+        std::memset(buffer, 0xAA, BUFFER_SIZE);
+    }
+    
+    bool checkCanaries() const {
+        for (size_t i = 0; i < CANARY_COUNT; ++i) {
+            if (front_canary[i] != CANARY_PATTERN + i ||
+                back_canary[i] != CANARY_PATTERN + i + CANARY_COUNT) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    void simulateLogWrite(const std::string& message) {
+        // Simulate writing log data with potential for overrun
+        size_t write_size = std::min(message.length(), BUFFER_SIZE - 1);
+        std::memcpy(buffer, message.c_str(), write_size);
+        buffer[write_size] = '\0';
+    }
+    
+    void simulatePathWrite(const std::string& path) {
+        // Simulate long path name writes
+        size_t path_len = std::min(path.length(), BUFFER_SIZE / 2);
+        std::memcpy(buffer, path.c_str(), path_len);
+        
+        // Add some stack frame simulation
+        char stack_info[512];
+        snprintf(stack_info, sizeof(stack_info), 
+                "|frame:%p|method:%s|bci:%d", 
+                (void*)0x12345678, "someMethod", (int)(path_len % 1000));
+        
+        size_t remaining = BUFFER_SIZE - path_len - 1;
+        size_t stack_len = std::min(strlen(stack_info), remaining);
+        std::memcpy(buffer + path_len, stack_info, stack_len);
+    }
+};
+
+// Thread-local storage for TLS tests
+thread_local TLSCanary* tls_canary = nullptr;
+
+// Test 7: TLS Overrun Canary Test
+TEST_F(StressTestSuite, TLSOverrunCanaryTest) {
+    const int NUM_THREADS = 6;
+    const int OPERATIONS_PER_THREAD = 10000;
+    const int SWAP_FREQUENCY_MS = 5; // More aggressive swapping
+    
+    std::atomic<bool> test_running{true};
+    std::atomic<bool> canary_corruption{false};
+    std::atomic<uint64_t> total_operations{0};
+    std::atomic<uint64_t> canary_checks{0};
+    std::atomic<uint64_t> swap_count{0};
+    
+    auto storage = std::make_unique<CallTraceStorage>();
+    ThreadSafeRandom random_gen(99999);
+    
+    // Worker threads hammering TLS buffers while doing storage operations
+    std::vector<std::thread> workers;
+    for (int i = 0; i < NUM_THREADS; ++i) {
+        workers.emplace_back([&, i]() {
+            // Initialize TLS canary for this thread
+            tls_canary = new TLSCanary();
+            
+            std::mt19937 local_gen(random_gen.next(UINT32_MAX));
+            std::uniform_int_distribution<size_t> size_dis(100, 4000);
+            std::uniform_int_distribution<int> operation_dis(0, 2);
+            
+            for (int op = 0; op < OPERATIONS_PER_THREAD && test_running.load(); ++op) {
+                try {
+                    // Check canary at start of each operation
+                    if (!tls_canary->checkCanaries()) {
+                        canary_corruption.store(true);
+                        break;
+                    }
+                    
+                    // Simulate various TLS buffer stress operations
+                    int operation = operation_dis(local_gen);
+                    switch (operation) {
+                        case 0: {
+                            // Large log line simulation
+                            size_t log_size = size_dis(local_gen);
+                            std::string large_log(log_size, 'L');
+                            large_log += std::to_string(op) + "_thread_" + std::to_string(i);
+                            tls_canary->simulateLogWrite(large_log);
+                            break;
+                        }
+                        case 1: {
+                            // Deep path simulation
+                            std::string deep_path = "/very/deep/file/system/path/that/could/be/very/long/";
+                            for (int depth = 0; depth < 20; ++depth) {
+                                deep_path += "subdir" + std::to_string(depth) + "/";
+                            }
+                            deep_path += "filename_" + std::to_string(op);
+                            tls_canary->simulatePathWrite(deep_path);
+                            break;
+                        }
+                        case 2: {
+                            // Stack stringification simulation
+                            std::ostringstream stack_trace;
+                            for (int frame = 0; frame < 50; ++frame) {
+                                stack_trace << "Frame" << frame 
+                                           << ":Method" << (frame * 123 + op)
+                                           << ":BCI" << (frame * 456 + i) << ";";
+                            }
+                            tls_canary->simulateLogWrite(stack_trace.str());
+                            break;
+                        }
+                    }
+                    
+                    // Also do some storage operations to create interference
+                    ASGCT_CallFrame frame;
+                    frame.bci = static_cast<jint>(op % 10000);
+                    frame.method_id = reinterpret_cast<jmethodID>(0x1000 + i * 1000 + op);
+                    storage->put(1, &frame, false, 1);
+                    
+                    // Check canary after operations
+                    canary_checks.fetch_add(1, std::memory_order_relaxed);
+                    if (!tls_canary->checkCanaries()) {
+                        canary_corruption.store(true);
+                        break;
+                    }
+                    
+                    total_operations.fetch_add(1, std::memory_order_relaxed);
+                    
+                    // Yield occasionally to allow swaps
+                    if (op % 200 == 0) {
+                        std::this_thread::yield();
+                    }
+                    
+                } catch (...) {
+                    canary_corruption.store(true);
+                    break;
+                }
+            }
+            
+            // Final canary check and cleanup
+            if (tls_canary && !tls_canary->checkCanaries()) {
+                canary_corruption.store(true);
+            }
+            delete tls_canary;
+            tls_canary = nullptr;
+        });
+    }
+    
+    // Aggressive swapping thread
+    std::thread swapper([&]() {
+        while (test_running.load() && !canary_corruption.load()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(SWAP_FREQUENCY_MS));
+            
+            try {
+                storage->processTraces([](const std::unordered_set<CallTrace*>& traces) {
+                    // Aggressive processing to stress TLS during swaps
+                    volatile size_t count = traces.size();
+                    (void)count;
+                });
+                swap_count.fetch_add(1, std::memory_order_relaxed);
+            } catch (...) {
+                canary_corruption.store(true);
+                break;
+            }
+        }
+    });
+    
+    // Run stress test
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+    test_running.store(false);
+    
+    // Wait for threads
+    for (auto& worker : workers) {
+        worker.join();
+    }
+    swapper.join();
+    
+    // Verify results
+    EXPECT_FALSE(canary_corruption.load()) << "TLS canary corruption detected";
+    EXPECT_GT(canary_checks.load(), 0) << "No canary checks performed";
+    EXPECT_GT(swap_count.load(), 0) << "No storage swaps occurred";
+    
+    std::cout << "TLS canary test completed: " << total_operations.load() << " ops, "
+              << canary_checks.load() << " canary checks, " << swap_count.load() 
+              << " swaps, corruption=" << (canary_corruption.load() ? "YES" : "NO") << std::endl;
+}
+
+// Test 8: TCMalloc A/B Runner
+TEST_F(StressTestSuite, TCMallocABRunner) {
+    const int NUM_ITERATIONS = 1000;
+    const int ALLOCATION_SIZE = 1024;
+    
+    std::atomic<bool> test_failed{false};
+    std::atomic<uint64_t> normal_crashes{0};
+    std::atomic<uint64_t> preload_crashes{0};
+    std::atomic<uint64_t> fence_crashes{0};
+    
+    // Helper to run workload and detect crashes
+    auto run_workload = [&](const std::string& env_setup) -> bool {
+        pid_t pid = fork();
+        if (pid == 0) {
+            // Child process - run the workload
+            if (!env_setup.empty()) {
+                std::system(("export " + env_setup).c_str());
+            }
+            
+            try {
+                // Simulate the exact workload from other tests
+                std::vector<void*> allocations;
+                allocations.reserve(NUM_ITERATIONS);
+                
+                for (int i = 0; i < NUM_ITERATIONS; ++i) {
+                    void* ptr = malloc(ALLOCATION_SIZE + (i % 100));
+                    if (ptr) {
+                        std::memset(ptr, 0xAB + (i % 16), ALLOCATION_SIZE + (i % 100));
+                        allocations.push_back(ptr);
+                    }
+                    
+                    // Some allocations freed immediately, others kept
+                    if (i % 3 == 0 && !allocations.empty()) {
+                        free(allocations.back());
+                        allocations.pop_back();
+                    }
+                    
+                    // Simulate some storage work
+                    if (i % 100 == 0) {
+                        CallTraceHashTable test_table;
+                        test_table.setInstanceId(42);
+                        ASGCT_CallFrame frame;
+                        frame.bci = i;
+                        frame.method_id = reinterpret_cast<jmethodID>(0x1000 + i);
+                        test_table.put(1, &frame, false, 1);
+                    }
+                }
+                
+                // Cleanup
+                for (void* ptr : allocations) {
+                    free(ptr);
+                }
+                
+                _exit(0); // Success
+            } catch (...) {
+                _exit(1); // Failure
+            }
+        } else if (pid > 0) {
+            // Parent process - wait for child
+            int status;
+            waitpid(pid, &status, 0);
+            
+            if (WIFEXITED(status)) {
+                return WEXITSTATUS(status) == 0;
+            } else {
+                // Child crashed
+                return false;
+            }
+        } else {
+            // Fork failed
+            return false;
+        }
+    };
+    
+    // Test 1: Normal run (baseline)
+    for (int run = 0; run < 3; ++run) {
+        if (!run_workload("")) {
+            normal_crashes.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+    
+    // Test 2: With tcmalloc LD_PRELOAD (if available)
+    std::string tcmalloc_path;
+    std::vector<std::string> possible_paths = {
+        "/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4",
+        "/usr/lib/libtcmalloc.so",
+        "/opt/homebrew/lib/libtcmalloc.so",
+        "/usr/local/lib/libtcmalloc.so"
+    };
+    
+    for (const std::string& path : possible_paths) {
+        if (access(path.c_str(), R_OK) == 0) {
+            tcmalloc_path = path;
+            break;
+        }
+    }
+    
+    if (!tcmalloc_path.empty()) {
+        for (int run = 0; run < 3; ++run) {
+            if (!run_workload("LD_PRELOAD=" + tcmalloc_path)) {
+                preload_crashes.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+        
+        // Test 3: With TCMALLOC_PAGE_FENCE=1 if available
+        for (int run = 0; run < 3; ++run) {
+            if (!run_workload("LD_PRELOAD=" + tcmalloc_path + " TCMALLOC_PAGE_FENCE=1")) {
+                fence_crashes.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    }
+    
+    // Record results (crashes are not necessarily test failures - they're data points)
+    std::cout << "TCMalloc A/B test completed:" << std::endl;
+    std::cout << "  Normal runs: " << normal_crashes.load() << " crashes out of 3" << std::endl;
+    if (!tcmalloc_path.empty()) {
+        std::cout << "  TCMalloc preload: " << preload_crashes.load() << " crashes out of 3" << std::endl;
+        std::cout << "  TCMalloc fence: " << fence_crashes.load() << " crashes out of 3" << std::endl;
+        std::cout << "  TCMalloc path: " << tcmalloc_path << std::endl;
+    } else {
+        std::cout << "  TCMalloc not found - skipped preload tests" << std::endl;
+    }
+    
+    // Test passes if we collected data (crashes are informational)
+    EXPECT_FALSE(test_failed.load()) << "TCMalloc A/B test infrastructure failed";
+}
+
+// Global state for signal pressure test
+static std::atomic<bool> signal_pressure_active{false};
+static std::atomic<uint64_t> signals_delivered{0};
+static std::atomic<bool> signal_corruption_detected{false};
+thread_local volatile uint32_t tls_write_counter = 0;
+
+// Global state for realistic signal test
+static std::atomic<bool> realistic_test_running{false};
+static std::atomic<bool> realistic_handler_corruption{false};
+static std::atomic<uint64_t> realistic_signals_handled{0};
+static std::atomic<uint64_t> realistic_storage_operations{0};
+static CallTraceStorage* realistic_shared_storage = nullptr;
+
+// Signal handler for pressure test
+void pressure_signal_handler(int sig) {
+    if (!signal_pressure_active.load()) {
+        return;
+    }
+    
+    signals_delivered.fetch_add(1, std::memory_order_relaxed);
+    
+    // Simulate lightweight profiling work in signal handler
+    // Check TLS consistency
+    uint32_t expected = tls_write_counter;
+    if (expected != tls_write_counter) {
+        signal_corruption_detected.store(true);
+    }
+    
+    // Tiny bit of work (signal-safe)
+    volatile uint64_t dummy = 0;
+    for (int i = 0; i < 10; ++i) {
+        dummy += i;
+    }
+    (void)dummy;
+}
+
+// Realistic signal handler for profiler stress test
+void realistic_profiler_signal_handler(int sig) {
+    if (!realistic_test_running.load()) return;
+    
+    // Critical: Check if critical section is active (storage swap in progress)
+    if (CriticalSection::isInCriticalSection()) {
+        return;  // Skip this signal - storage operation in progress
+    }
+    
+    realistic_signals_handled.fetch_add(1, std::memory_order_relaxed);
+    
+    try {
+        // Simulate what the real profiler does in signal context
+        // 1. Get thread ID (potential race with thread destruction)
+        pthread_t current_thread = pthread_self();
+        
+        // 2. Try to record a sample (this should be signal-safe)
+        ASGCT_CallFrame frame;
+        frame.bci = static_cast<jint>(realistic_signals_handled.load() % 10000);
+        frame.method_id = reinterpret_cast<jmethodID>(0x1000 + (uintptr_t)current_thread);
+        
+        // 3. This is where real bugs occur - storage operations in signal context
+        if (realistic_shared_storage) {
+            u64 trace_id = realistic_shared_storage->put(1, &frame, false, 1);
+            if (trace_id > 0) {
+                realistic_storage_operations.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+        
+        // 4. Simulate some work that might cause corruption
+        static thread_local volatile uint64_t signal_work_counter = 0;
+        signal_work_counter++;
+        
+        // Check for corruption pattern - if we're accessing destroyed TLS
+        if (signal_work_counter > 20000) {
+            realistic_handler_corruption.store(true);
+        }
+        
+    } catch (...) {
+        realistic_handler_corruption.store(true);
+    }
+}
+
+// Test 9: Signal Pressure Test
+TEST_F(StressTestSuite, SignalPressureTest) {
+    const int SIGNAL_FREQUENCY_HZ = 1000; // 1000 Hz profiling signals
+    const int TEST_DURATION_MS = 2000;
+    const int NUM_WORKER_THREADS = 3;
+    
+    std::atomic<bool> test_running{true};
+    std::atomic<bool> deadlock_detected{false};
+    std::atomic<uint64_t> tls_writes_completed{0};
+    std::vector<std::thread> workers;
+    
+    // Install signal handler
+    struct sigaction old_action;
+    struct sigaction new_action;
+    new_action.sa_handler = pressure_signal_handler;
+    sigemptyset(&new_action.sa_mask);
+    new_action.sa_flags = SA_RESTART;
+    
+    if (sigaction(SIGUSR1, &new_action, &old_action) != 0) {
+        GTEST_SKIP() << "Could not install signal handler";
+        return;
+    }
+    
+    signal_pressure_active.store(true);
+    signals_delivered.store(0);
+    signal_corruption_detected.store(false);
+    
+    // Worker threads doing TLS writes
+    for (int t = 0; t < NUM_WORKER_THREADS; ++t) {
+        workers.emplace_back([&, t]() {
+            tls_write_counter = 0;
+            const size_t TINY_WRITE_SIZE = 64;
+            char tls_buffer[TINY_WRITE_SIZE];
+            
+            // Setup sigaltstack for this thread (test both with and without)
+            bool use_altstack = (t % 2 == 0);
+            stack_t alt_stack;
+            stack_t old_stack;
+            
+            if (use_altstack) {
+                alt_stack.ss_sp = malloc(SIGSTKSZ);
+                alt_stack.ss_size = SIGSTKSZ;
+                alt_stack.ss_flags = 0;
+                
+                if (alt_stack.ss_sp && sigaltstack(&alt_stack, &old_stack) == 0) {
+                    // Successfully installed alt stack
+                } else {
+                    use_altstack = false;
+                }
+            }
+            
+            auto start_time = std::chrono::steady_clock::now();
+            uint32_t write_count = 0;
+            
+            while (test_running.load()) {
+                try {
+                    // Tiny TLS writes with counter increments
+                    tls_write_counter = ++write_count;
+                    
+                    // Simulate small TLS buffer operations
+                    snprintf(tls_buffer, TINY_WRITE_SIZE, "t%d_w%u", t, write_count);
+                    
+                    // Verify consistency
+                    if (tls_write_counter != write_count) {
+                        signal_corruption_detected.store(true);
+                        break;
+                    }
+                    
+                    tls_writes_completed.fetch_add(1, std::memory_order_relaxed);
+                    
+                    // Very short yield to allow signal delivery
+                    if (write_count % 100 == 0) {
+                        std::this_thread::yield();
+                    }
+                    
+                    // Deadlock detection - if we're stuck too long, bail
+                    auto now = std::chrono::steady_clock::now();
+                    if (std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time).count() > TEST_DURATION_MS * 2) {
+                        deadlock_detected.store(true);
+                        break;
+                    }
+                    
+                } catch (...) {
+                    signal_corruption_detected.store(true);
+                    break;
+                }
+            }
+            
+            // Cleanup alt stack
+            if (use_altstack && alt_stack.ss_sp) {
+                sigaltstack(&old_stack, nullptr);
+                free(alt_stack.ss_sp);
+            }
+        });
+    }
+    
+    // Signal delivery thread
+    std::thread signaller([&]() {
+        auto signal_interval = std::chrono::microseconds(1000000 / SIGNAL_FREQUENCY_HZ);
+        auto start_time = std::chrono::steady_clock::now();
+        
+        while (test_running.load()) {
+            for (std::thread& worker : workers) {
+                pthread_kill(worker.native_handle(), SIGUSR1);
+            }
+            
+            std::this_thread::sleep_for(signal_interval);
+            
+            // Check for test timeout
+            auto now = std::chrono::steady_clock::now();
+            if (std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time).count() > TEST_DURATION_MS) {
+                test_running.store(false);
+                break;
+            }
+        }
+    });
+    
+    // Wait for test completion
+    signaller.join();
+    
+    // Stop signal pressure
+    signal_pressure_active.store(false);
+    
+    // Wait for workers
+    for (auto& worker : workers) {
+        worker.join();
+    }
+    
+    // Restore signal handler
+    sigaction(SIGUSR1, &old_action, nullptr);
+    
+    // Verify results
+    EXPECT_FALSE(signal_corruption_detected.load()) << "Signal pressure caused TLS corruption";
+    EXPECT_FALSE(deadlock_detected.load()) << "Deadlock detected during signal pressure test";
+    EXPECT_GT(signals_delivered.load(), 0) << "No signals were delivered";
+    EXPECT_GT(tls_writes_completed.load(), 0) << "No TLS writes completed";
+    
+    std::cout << "Signal pressure test completed: " << signals_delivered.load() 
+              << " signals delivered, " << tls_writes_completed.load() << " TLS writes, "
+              << "corruption=" << (signal_corruption_detected.load() ? "YES" : "NO") << std::endl;
+}
+
+// Test 10: Teardown Fuzz Test
+TEST_F(StressTestSuite, TeardownFuzzTest) {
+    const int NUM_THREAD_CYCLES = 1000;
+    const int CONCURRENT_THREADS = 8;
+    
+    std::atomic<bool> teardown_corruption{false};
+    std::atomic<uint64_t> threads_created{0};
+    std::atomic<uint64_t> threads_completed{0};
+    std::atomic<uint64_t> agent_work_completed{0};
+    
+    // Shared storage for thread lifecycle testing
+    auto shared_storage = std::make_unique<CallTraceStorage>();
+    ThreadSafeRandom cycle_random(77777);
+    
+    for (int cycle = 0; cycle < NUM_THREAD_CYCLES / CONCURRENT_THREADS; ++cycle) {
+        std::vector<std::thread> native_threads;
+        
+        // Create batch of native threads
+        for (int t = 0; t < CONCURRENT_THREADS; ++t) {
+            native_threads.emplace_back([&, cycle, t]() {
+                threads_created.fetch_add(1, std::memory_order_relaxed);
+                
+                try {
+                    // Initialize thread-local agent data
+                    thread_local bool tls_initialized = false;
+                    thread_local uint64_t tls_agent_id = 0;
+                    
+                    if (!tls_initialized) {
+                        tls_agent_id = cycle_random.next(UINT32_MAX);
+                        tls_initialized = true;
+                    }
+                    
+                    // Simulate small amount of agent work
+                    std::vector<u64> trace_ids;
+                    for (int work = 0; work < 10; ++work) {
+                        ASGCT_CallFrame frame;
+                        frame.bci = static_cast<jint>(cycle * 1000 + t * 100 + work);
+                        frame.method_id = reinterpret_cast<jmethodID>(tls_agent_id + work);
+                        
+                        u64 trace_id = shared_storage->put(1, &frame, false, 1);
+                        if (trace_id > 0) {
+                            trace_ids.push_back(trace_id);
+                        }
+                        
+                        // Verify TLS is still valid
+                        if (!tls_initialized || tls_agent_id == 0) {
+                            teardown_corruption.store(true);
+                            return;
+                        }
+                    }
+                    
+                    agent_work_completed.fetch_add(trace_ids.size(), std::memory_order_relaxed);
+                    
+                    // Simulate thread doing work after "TLS cleanup"
+                    // This is the dangerous case we're testing for
+                    tls_initialized = false; // Simulate TLS being cleared
+                    
+                    // Try to do more agent work (this should be safe or fail gracefully)
+                    for (int post_work = 0; post_work < 3; ++post_work) {
+                        try {
+                            ASGCT_CallFrame frame;
+                            frame.bci = static_cast<jint>(-1); // Native frame
+                            frame.method_id = reinterpret_cast<jmethodID>(0x999999);
+                            
+                            // This might fail, but shouldn't crash
+                            u64 result = shared_storage->put(1, &frame, false, 1);
+                            (void)result;
+                            
+                            // Check if we can still access TLS safely
+                            if (tls_agent_id != 0) {
+                                // TLS still accessible after "cleanup" - record this
+                                agent_work_completed.fetch_add(1, std::memory_order_relaxed);
+                            }
+                            
+                        } catch (...) {
+                            // Exceptions during post-cleanup work are acceptable
+                            // as long as they don't crash the process
+                        }
+                    }
+                    
+                    threads_completed.fetch_add(1, std::memory_order_relaxed);
+                    
+                } catch (...) {
+                    teardown_corruption.store(true);
+                }
+            });
+        }
+        
+        // Wait for this batch of threads to complete
+        for (auto& thread : native_threads) {
+            thread.join();
+        }
+        
+        // Periodic cleanup of storage to simulate real usage patterns
+        if (cycle % 10 == 0) {
+            shared_storage->processTraces([](const std::unordered_set<CallTrace*>& traces) {
+                // Simulate processing collected traces
+                volatile size_t count = traces.size();
+                (void)count;
+            });
+        }
+        
+        // Break early if corruption detected
+        if (teardown_corruption.load()) {
+            break;
+        }
+    }
+    
+    // Final cleanup
+    shared_storage->clear();
+    
+    // Verify results
+    EXPECT_FALSE(teardown_corruption.load()) << "Teardown corruption detected";
+    EXPECT_EQ(threads_created.load(), threads_completed.load()) << "Thread creation/completion mismatch";
+    EXPECT_GT(agent_work_completed.load(), 0) << "No agent work completed";
+    
+    std::cout << "Teardown fuzz test completed: " << threads_created.load() 
+              << " threads created, " << threads_completed.load() << " completed, "
+              << agent_work_completed.load() << " work units, "
+              << "corruption=" << (teardown_corruption.load() ? "YES" : "NO") << std::endl;
+}
+
+// REALISTIC STRESS TESTS - Target actual profiler code paths
+// These tests are designed to catch real bugs by exercising actual production code
+
+// CRASH-SAFE TEST EXECUTION FRAMEWORK
+// This allows us to continue testing even after individual tests crash
+
+// Helper function for crash-safe test execution using process isolation
+bool executeCrashSafeTest(const std::string& test_name, std::function<void()> test_func) {
+    std::cout << "\n=== Executing crash-safe test: " << test_name << " ===" << std::endl;
+    
+    pid_t pid = fork();
+    if (pid == 0) {
+        // Child process - run the test in isolation
+        try {
+            test_func();
+            std::cout << "Test " << test_name << " completed successfully" << std::endl;
+            _exit(0); // Success
+        } catch (const std::exception& e) {
+            std::cout << "Test " << test_name << " threw exception: " << e.what() << std::endl;
+            _exit(1); // Exception
+        } catch (...) {
+            std::cout << "Test " << test_name << " threw unknown exception" << std::endl;
+            _exit(2); // Unknown exception
+        }
+    } else if (pid > 0) {
+        // Parent process - wait and analyze result
+        int status;
+        pid_t result = waitpid(pid, &status, 0);
+        
+        if (result == -1) {
+            std::cout << "Test " << test_name << " - waitpid failed: " << strerror(errno) << std::endl;
+            return false;
+        }
+        
+        if (WIFEXITED(status)) {
+            int exit_code = WEXITSTATUS(status);
+            if (exit_code == 0) {
+                std::cout << "✅ Test " << test_name << " - PASSED" << std::endl;
+                return true;
+            } else {
+                std::cout << "❌ Test " << test_name << " - FAILED with exit code " << exit_code << std::endl;
+                return false;
+            }
+        } else if (WIFSIGNALED(status)) {
+            int sig = WTERMSIG(status);
+            std::cout << "💥 Test " << test_name << " - CRASHED with signal " << sig;
+            switch (sig) {
+                case SIGSEGV: std::cout << " (SIGSEGV - segmentation fault - memory bug found!)"; break;
+                case SIGABRT: std::cout << " (SIGABRT - abort - assertion failure)"; break;
+                case SIGBUS: std::cout << " (SIGBUS - bus error - alignment issue)"; break;
+                case SIGFPE: std::cout << " (SIGFPE - floating point exception)"; break;
+                case SIGTRAP: std::cout << " (SIGTRAP - debug trap)"; break;
+                case SIGILL: std::cout << " (SIGILL - illegal instruction)"; break;
+                default: std::cout << " (signal " << sig << ")"; break;
+            }
+            std::cout << std::endl;
+            return false;
+        } else {
+            std::cout << "❓ Test " << test_name << " - UNKNOWN termination (status=" << status << ")" << std::endl;
+            return false;
+        }
+    } else {
+        std::cout << "💀 Test " << test_name << " - fork failed: " << strerror(errno) << std::endl;
+        return false;
+    }
+}
+
+// Test Results Collector
+struct TestSuiteResults {
+    int total_tests = 0;
+    int passed_tests = 0;
+    int failed_tests = 0;
+    int crashed_tests = 0;
+    std::vector<std::string> crashes_found;
+    std::vector<std::string> failures_found;
+    
+    void recordPass(const std::string& test_name) {
+        total_tests++;
+        passed_tests++;
+    }
+    
+    void recordFailure(const std::string& test_name) {
+        total_tests++;
+        failed_tests++;
+        failures_found.push_back(test_name);
+    }
+    
+    void recordCrash(const std::string& test_name) {
+        total_tests++;
+        crashed_tests++;
+        crashes_found.push_back(test_name);
+    }
+    
+    void printSummary() const {
+        std::cout << "\n" << std::string(60, '=') << std::endl;
+        std::cout << "STRESS TEST SUITE SUMMARY" << std::endl;
+        std::cout << std::string(60, '=') << std::endl;
+        std::cout << "Total tests run: " << total_tests << std::endl;
+        std::cout << "✅ Passed: " << passed_tests << std::endl;
+        std::cout << "❌ Failed: " << failed_tests << std::endl;
+        std::cout << "💥 Crashed: " << crashed_tests << " (BUGS FOUND!)" << std::endl;
+        
+        if (!crashes_found.empty()) {
+            std::cout << "\nCrashes found in:" << std::endl;
+            for (const auto& crash : crashes_found) {
+                std::cout << "  💥 " << crash << std::endl;
+            }
+        }
+        
+        if (!failures_found.empty()) {
+            std::cout << "\nFailures in:" << std::endl;
+            for (const auto& failure : failures_found) {
+                std::cout << "  ❌ " << failure << std::endl;
+            }
+        }
+        
+        std::cout << std::string(60, '=') << std::endl;
+    }
+};
+
+// Implementation function for signal stress (isolated for crash safety)
+static void realProfilerSignalStressImpl(int signal_barrage_count, int num_worker_threads) {
+    std::atomic<bool> test_running{true};
+    std::atomic<bool> handler_corruption{false};
+    std::atomic<uint64_t> signals_handled{0};
+    std::atomic<uint64_t> storage_operations{0};
+    
+    // Create shared storage that will be hammered during signal handling
+    auto shared_storage = std::make_unique<CallTraceStorage>();
+    
+    // Set up global state for signal handler
+    realistic_test_running.store(true);
+    realistic_handler_corruption.store(false);
+    realistic_signals_handled.store(0);
+    realistic_storage_operations.store(0);
+    realistic_shared_storage = shared_storage.get();
+    
+    // Install realistic signal handler
+    struct sigaction new_action, old_action;
+    new_action.sa_handler = realistic_profiler_signal_handler;
+    sigemptyset(&new_action.sa_mask);
+    new_action.sa_flags = SA_RESTART;
+    
+    if (sigaction(SIGUSR2, &new_action, &old_action) != 0) {
+        throw std::runtime_error("Could not install signal handler");
+    }
+    
+    // Worker threads doing normal profiler operations while signals fire
+    std::vector<std::thread> workers;
+    for (int t = 0; t < num_worker_threads; ++t) {
+        workers.emplace_back([&, t]() {
+            while (test_running.load()) {
+                try {
+                    // Simulate normal application work that profiler samples
+                    for (int work = 0; work < 50; ++work) {
+                        ASGCT_CallFrame frame;
+                        frame.bci = work;
+                        frame.method_id = reinterpret_cast<jmethodID>(0x2000 + t * 100 + work);
+                        
+                        u64 trace_id = shared_storage->put(1, &frame, false, 1);
+                        
+                        // Note: In real usage, processTraces() is never called from worker threads
+                        // Only the single dump thread calls processTraces() with mutex protection
+                        // So we remove this unrealistic concurrent processTraces() call
+                        
+                        // Small delay to allow signal interference
+                        if (work % 10 == 0) {
+                            std::this_thread::yield();
+                        }
+                        
+                        storage_operations.fetch_add(1, std::memory_order_relaxed);
+                    }
+                } catch (...) {
+                    realistic_handler_corruption.store(true);
+                    break;
+                }
+            }
+        });
+    }
+    
+    // Single dump thread - represents realistic JFR dump operations
+    // In production, this would be protected by mutex and only one thread does dumps
+    std::thread dump_thread([&]() {
+        int dump_count = 0;
+        while (test_running.load() && dump_count < 3) {  // Only do a few dumps
+            try {
+                // Wait a bit to let some traces accumulate
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                
+                // Single-threaded processTraces call - matches production pattern
+                shared_storage->processTraces([](const std::unordered_set<CallTrace*>& traces) {
+                    volatile size_t count = traces.size();
+                    (void)count;
+                });
+                
+                dump_count++;
+                std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            } catch (...) {
+                realistic_handler_corruption.store(true);
+                break;
+            }
+        }
+    });
+    
+    // Signal barrage thread - this is where crashes typically occur
+    std::thread signaller([&]() {
+        for (int i = 0; i < signal_barrage_count && test_running.load(); ++i) {
+            // Send signals to all worker threads simultaneously
+            for (std::thread& worker : workers) {
+                pthread_kill(worker.native_handle(), SIGUSR2);
+            }
+            
+            // Brief pause to let signals get handled
+            std::this_thread::sleep_for(std::chrono::microseconds(100));
+            
+            // Break early if we detect issues
+            if (realistic_handler_corruption.load()) {
+                break;
+            }
+        }
+        realistic_test_running.store(false);
+        test_running.store(false);
+    });
+    
+    // Wait for test completion
+    signaller.join();
+    dump_thread.join();
+    for (auto& worker : workers) {
+        worker.join();
+    }
+    
+    // Clean up global state
+    realistic_shared_storage = nullptr;
+    realistic_test_running.store(false);
+    
+    // Restore signal handler
+    sigaction(SIGUSR2, &old_action, nullptr);
+    
+    // Report results
+    std::cout << "Signal stress (" << signal_barrage_count << " signals, " << num_worker_threads 
+              << " threads): " << realistic_signals_handled.load() << " signals handled, "
+              << realistic_storage_operations.load() << " storage ops, "
+              << "corruption=" << (realistic_handler_corruption.load() ? "YES" : "NO") << std::endl;
+    
+    if (realistic_handler_corruption.load()) {
+        throw std::runtime_error("Signal handler corruption detected");
+    }
+}
+
+// Test 11: Instance ID and Trace ID Generation Stress Test
+TEST_F(StressTestSuite, InstanceIdTraceIdStressTest) {
+    const int NUM_THREADS = 12;  // High contention on instance ID generation
+    const int NUM_STORAGE_INSTANCES = 8;  // Multiple CallTraceStorage instances
+    const int OPERATIONS_PER_THREAD = 10000;
+    const int RAPID_SWAPS_COUNT = 1000;  // Frequent table swaps to stress instance ID assignment
+    
+    std::atomic<bool> test_failed{false};
+    std::atomic<bool> collision_detected{false};
+    std::atomic<bool> overflow_detected{false};
+    std::atomic<bool> invalid_trace_id_detected{false};
+    std::atomic<uint64_t> total_trace_ids_generated{0};
+    std::atomic<uint64_t> duplicate_trace_ids{0};
+    std::atomic<uint64_t> zero_trace_ids{0};
+    std::atomic<uint64_t> max_instance_id_seen{0};
+    
+    // Set to track all generated trace IDs for collision detection
+    std::mutex trace_id_mutex;
+    std::unordered_set<u64> all_trace_ids;
+    
+    // Multiple storage instances to stress the global instance ID counter
+    std::vector<std::unique_ptr<CallTraceStorage>> storage_instances;
+    for (int i = 0; i < NUM_STORAGE_INSTANCES; ++i) {
+        storage_instances.push_back(std::make_unique<CallTraceStorage>());
+    }
+    
+    std::cout << "Testing instance ID and trace ID generation under extreme concurrency..." << std::endl;
+    
+    // Worker threads that hammer trace ID generation across multiple storage instances
+    std::vector<std::thread> workers;
+    for (int t = 0; t < NUM_THREADS; ++t) {
+        workers.emplace_back([&, t]() {
+            std::mt19937 gen(std::random_device{}() + t);
+            std::uniform_int_distribution<int> storage_dis(0, NUM_STORAGE_INSTANCES - 1);
+            std::uniform_int_distribution<uint32_t> bci_dis(1, 100000);
+            std::uniform_int_distribution<uintptr_t> method_dis(0x10000, 0xFFFFFF);
+            
+            for (int op = 0; op < OPERATIONS_PER_THREAD && !test_failed.load(); ++op) {
+                try {
+                    // Pick a random storage instance
+                    int storage_idx = storage_dis(gen);
+                    CallTraceStorage* storage = storage_instances[storage_idx].get();
+                    
+                    // Create a unique frame to avoid hash collisions masking trace ID issues
+                    ASGCT_CallFrame frame;
+                    frame.bci = bci_dis(gen) + t * 1000000 + op;  // Ensure uniqueness
+                    frame.method_id = reinterpret_cast<jmethodID>(method_dis(gen) + t * 0x1000000);
+                    
+                    // Generate trace ID
+                    u64 trace_id = storage->put(1, &frame, false, 1);
+                    
+                    if (trace_id == 0) {
+                        zero_trace_ids.fetch_add(1, std::memory_order_relaxed);
+                        continue;  // Dropped trace is acceptable
+                    }
+                    
+                    if (trace_id == CallTraceStorage::DROPPED_TRACE_ID) {
+                        continue;  // Also acceptable
+                    }
+                    
+                    // Extract instance ID and slot from trace ID
+                    u64 instance_id = trace_id >> 32;
+                    u64 slot = trace_id & 0xFFFFFFFFULL;
+                    
+                    // Validate trace ID structure
+                    if (instance_id == 0) {
+                        invalid_trace_id_detected.store(true);
+                        test_failed.store(true);
+                        return;
+                    }
+                    
+                    // Check for slot overflow (should fit in 32 bits)
+                    if (slot > 0xFFFFFFFFULL) {
+                        overflow_detected.store(true);
+                        test_failed.store(true);
+                        return;
+                    }
+                    
+                    // Track maximum instance ID to detect counter behavior
+                    uint64_t current_max = max_instance_id_seen.load();
+                    while (instance_id > current_max) {
+                        if (max_instance_id_seen.compare_exchange_weak(current_max, instance_id)) {
+                            break; // Successfully updated
+                        }
+                        // CAS failed - current_max now contains the actual current value
+                        // Loop continues if instance_id is still greater than the updated current_max
+                    }
+                    
+                    // Check for trace ID collisions
+                    {
+                        std::lock_guard<std::mutex> lock(trace_id_mutex);
+                        if (all_trace_ids.find(trace_id) != all_trace_ids.end()) {
+                            collision_detected.store(true);
+                            duplicate_trace_ids.fetch_add(1, std::memory_order_relaxed);
+                        } else {
+                            all_trace_ids.insert(trace_id);
+                        }
+                    }
+                    
+                    total_trace_ids_generated.fetch_add(1, std::memory_order_relaxed);
+                    
+                    // Occasionally trigger rapid table swaps to stress instance ID assignment
+                    if (op % 100 == 0 && t == 0) {  // Only one thread does swaps
+                        for (int swap = 0; swap < 3; ++swap) {
+                            storage->processTraces([](const std::unordered_set<CallTrace*>& traces) {
+                                volatile size_t count = traces.size();
+                                (void)count;
+                            });
+                        }
+                    }
+                    
+                    // Yield periodically to increase contention
+                    if (op % 500 == 0) {
+                        std::this_thread::yield();
+                    }
+                    
+                } catch (...) {
+                    test_failed.store(true);
+                    return;
+                }
+            }
+        });
+    }
+    
+    // Additional thread that does rapid processTraces() calls to stress instance ID assignment
+    std::thread rapid_swapper([&]() {
+        for (int swap = 0; swap < RAPID_SWAPS_COUNT && !test_failed.load(); ++swap) {
+            try {
+                // Randomly pick storage instance for swap
+                int storage_idx = swap % NUM_STORAGE_INSTANCES;
+                storage_instances[storage_idx]->processTraces([](const std::unordered_set<CallTrace*>& traces) {
+                    // Process traces - this triggers new instance ID assignment
+                    volatile size_t count = traces.size();
+                    (void)count;
+                });
+                
+                // Brief pause
+                std::this_thread::sleep_for(std::chrono::microseconds(100));
+                
+            } catch (...) {
+                test_failed.store(true);
+                return;
+            }
+        }
+    });
+    
+    // Wait for all threads
+    for (auto& worker : workers) {
+        worker.join();
+    }
+    rapid_swapper.join();
+    
+    // Analyze results
+    u64 unique_trace_ids = 0;
+    {
+        std::lock_guard<std::mutex> lock(trace_id_mutex);
+        unique_trace_ids = all_trace_ids.size();
+    }
+    
+    std::cout << "Instance ID/Trace ID stress test completed:" << std::endl;
+    std::cout << "  Total trace IDs generated: " << total_trace_ids_generated.load() << std::endl;
+    std::cout << "  Unique trace IDs: " << unique_trace_ids << std::endl;
+    std::cout << "  Duplicate trace IDs: " << duplicate_trace_ids.load() << std::endl;
+    std::cout << "  Zero trace IDs: " << zero_trace_ids.load() << std::endl;
+    std::cout << "  Max instance ID seen: " << max_instance_id_seen.load() << std::endl;
+    std::cout << "  Collision detected: " << (collision_detected.load() ? "YES" : "NO") << std::endl;
+    std::cout << "  Overflow detected: " << (overflow_detected.load() ? "YES" : "NO") << std::endl;
+    std::cout << "  Invalid trace ID detected: " << (invalid_trace_id_detected.load() ? "YES" : "NO") << std::endl;
+    
+    // Verify results
+    EXPECT_FALSE(test_failed.load()) << "Instance ID/Trace ID stress test failed";
+    EXPECT_FALSE(collision_detected.load()) << "Trace ID collisions detected";
+    EXPECT_FALSE(overflow_detected.load()) << "Slot overflow detected";
+    EXPECT_FALSE(invalid_trace_id_detected.load()) << "Invalid trace ID structure detected";
+    EXPECT_GT(total_trace_ids_generated.load(), 0) << "No trace IDs generated";
+    EXPECT_GT(max_instance_id_seen.load(), 0) << "No valid instance IDs seen";
+    
+    // Check for excessive duplication (some is expected due to hash collisions)
+    double duplication_rate = (double)duplicate_trace_ids.load() / total_trace_ids_generated.load();
+    EXPECT_LT(duplication_rate, 0.1) << "Excessive trace ID duplication: " << duplication_rate;
+    
+    std::cout << "  Duplication rate: " << (duplication_rate * 100.0) << "%" << std::endl;
+}
+
+// Test 12: Hash Table Spin-Wait Edge Cases Stress Test
+TEST_F(StressTestSuite, HashTableSpinWaitEdgeCasesTest) {
+    const int NUM_THREADS = 16;  // High contention to trigger spin-waits
+    const int OPERATIONS_PER_THREAD = 5000;
+    const int HASH_COLLISION_GROUPS = 50;  // Force hash collisions to trigger spin-wait paths
+    const int SLOW_ALLOCATION_FREQUENCY = 10;  // Simulate slow allocations
+    
+    std::atomic<bool> test_failed{false};
+    std::atomic<bool> timeout_detected{false};
+    std::atomic<bool> preparing_deadlock{false};
+    std::atomic<bool> allocation_failure_cascade{false};
+    std::atomic<uint64_t> spin_wait_events{0};
+    std::atomic<uint64_t> timeout_recoveries{0};
+    std::atomic<uint64_t> allocation_failures{0};
+    std::atomic<uint64_t> successful_insertions{0};
+    std::atomic<uint64_t> dropped_traces{0};
+    std::atomic<uint64_t> hash_collisions_detected{0};
+    
+    // Single hash table to maximize contention
+    CallTraceHashTable hash_table;
+    hash_table.setInstanceId(42);
+    
+    std::cout << "Testing hash table spin-wait logic under extreme edge cases..." << std::endl;
+    
+    // Create controlled hash collision groups to force same-slot contention
+    std::vector<std::vector<ASGCT_CallFrame>> collision_groups(HASH_COLLISION_GROUPS);
+    for (int g = 0; g < HASH_COLLISION_GROUPS; ++g) {
+        // Generate frames that will likely hash to similar slots
+        for (int f = 0; f < 20; ++f) {
+            ASGCT_CallFrame frame;
+            frame.bci = g * 1000 + f;  // Group-based BCI to encourage collisions
+            frame.method_id = reinterpret_cast<jmethodID>(0x100000 + g * 100 + f);
+            collision_groups[g].push_back(frame);
+        }
+    }
+    
+    std::vector<std::thread> workers;
+    for (int t = 0; t < NUM_THREADS; ++t) {
+        workers.emplace_back([&, t]() {
+            std::mt19937 gen(12345 + t);  // Fixed seed to increase collision probability
+            std::uniform_int_distribution<int> group_dis(0, HASH_COLLISION_GROUPS - 1);
+            std::uniform_int_distribution<int> frame_dis(0, 19);
+            std::uniform_int_distribution<int> slow_dis(1, 100);
+            
+            for (int op = 0; op < OPERATIONS_PER_THREAD && !test_failed.load(); ++op) {
+                try {
+                    // Pick a frame from collision groups to maximize slot contention
+                    int group = group_dis(gen);
+                    int frame_idx = frame_dis(gen);
+                    ASGCT_CallFrame frame = collision_groups[group][frame_idx];
+                    
+                    // Add some uniqueness to prevent exact duplicates while preserving hash patterns
+                    frame.bci += t * 100000 + op;
+                    
+                    // Simulate slow allocation periodically to stress the spin-wait logic
+                    if (slow_dis(gen) <= SLOW_ALLOCATION_FREQUENCY) {
+                        // Brief delay to simulate memory allocation pressure
+                        std::this_thread::sleep_for(std::chrono::microseconds(100));
+                    }
+                    
+                    // This should trigger the spin-wait paths due to hash collisions
+                    u64 trace_id = hash_table.put(1, &frame, false, 1);
+                    
+                    if (trace_id == 0) {
+                        dropped_traces.fetch_add(1, std::memory_order_relaxed);
+                        continue;
+                    }
+                    
+                    if (trace_id == CallTraceStorage::DROPPED_TRACE_ID) {
+                        allocation_failures.fetch_add(1, std::memory_order_relaxed);
+                        continue;
+                    }
+                    
+                    if (trace_id == 0x7fffffffffffffffULL) {  // OVERFLOW_TRACE_ID
+                        continue;
+                    }
+                    
+                    successful_insertions.fetch_add(1, std::memory_order_relaxed);
+                    
+                    // Every successful insertion in the same collision group indicates potential spin-wait
+                    spin_wait_events.fetch_add(1, std::memory_order_relaxed);
+                    
+                    // Yield occasionally to increase interleaving and contention
+                    if (op % 50 == 0) {
+                        std::this_thread::yield();
+                    }
+                    
+                } catch (...) {
+                    test_failed.store(true);
+                    return;
+                }
+            }
+        });
+    }
+    
+    // Monitor thread to detect potential deadlocks in spin-wait logic
+    std::atomic<bool> monitor_running{true};
+    std::thread monitor([&]() {
+        auto start_time = std::chrono::steady_clock::now();
+        u64 last_insertions = 0;
+        
+        while (monitor_running.load()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            
+            u64 current_insertions = successful_insertions.load();
+            auto now = std::chrono::steady_clock::now();
+            auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - start_time).count();
+            
+            // Check for progress stall (potential deadlock in spin-wait)
+            if (elapsed > 5 && current_insertions == last_insertions) {
+                // No progress for too long - possible deadlock
+                preparing_deadlock.store(true);
+                test_failed.store(true);
+                break;
+            }
+            
+            // Check for excessive timeout recoveries
+            if (timeout_recoveries.load() > successful_insertions.load() / 10) {
+                timeout_detected.store(true);
+            }
+            
+            // Check for allocation failure cascade
+            if (allocation_failures.load() > successful_insertions.load()) {
+                allocation_failure_cascade.store(true);
+            }
+            
+            last_insertions = current_insertions;
+        }
+    });
+    
+    // Wait for all workers
+    for (auto& worker : workers) {
+        worker.join();
+    }
+    monitor_running.store(false);
+    monitor.join();
+    
+    // Analyze results
+    double failure_rate = (double)allocation_failures.load() / (successful_insertions.load() + allocation_failures.load());
+    double drop_rate = (double)dropped_traces.load() / (successful_insertions.load() + dropped_traces.load());
+    
+    std::cout << "Hash table spin-wait stress test completed:" << std::endl;
+    std::cout << "  Successful insertions: " << successful_insertions.load() << std::endl;
+    std::cout << "  Allocation failures: " << allocation_failures.load() << std::endl;
+    std::cout << "  Dropped traces: " << dropped_traces.load() << std::endl;
+    std::cout << "  Spin-wait events: " << spin_wait_events.load() << std::endl;
+    std::cout << "  Timeout recoveries: " << timeout_recoveries.load() << std::endl;
+    std::cout << "  Hash collisions detected: " << hash_collisions_detected.load() << std::endl;
+    std::cout << "  Failure rate: " << (failure_rate * 100.0) << "%" << std::endl;
+    std::cout << "  Drop rate: " << (drop_rate * 100.0) << "%" << std::endl;
+    std::cout << "  Preparing deadlock: " << (preparing_deadlock.load() ? "YES" : "NO") << std::endl;
+    std::cout << "  Timeout detected: " << (timeout_detected.load() ? "YES" : "NO") << std::endl;
+    std::cout << "  Allocation cascade: " << (allocation_failure_cascade.load() ? "YES" : "NO") << std::endl;
+    
+    // Verify results
+    EXPECT_FALSE(test_failed.load()) << "Hash table spin-wait test failed";
+    EXPECT_FALSE(preparing_deadlock.load()) << "Deadlock detected in PREPARING state spin-wait";
+    EXPECT_GT(successful_insertions.load(), 0) << "No successful hash table insertions";
+    
+    // Some failures are expected under extreme contention, but not excessive
+    EXPECT_LT(failure_rate, 0.8) << "Excessive allocation failure rate: " << failure_rate;
+    EXPECT_LT(drop_rate, 0.5) << "Excessive trace drop rate: " << drop_rate;
+}
+
+// Test 13: Hash Table Memory Allocation Failure Stress Test
+TEST_F(StressTestSuite, HashTableAllocationFailureStressTest) {
+    const int NUM_THREADS = 8;
+    const int OPERATIONS_PER_THREAD = 2000;
+    const int LARGE_FRAME_COUNT = 500;  // Large stack traces to stress allocator
+    
+    std::atomic<bool> test_failed{false};
+    std::atomic<bool> corruption_detected{false};
+    std::atomic<bool> inconsistent_state{false};
+    std::atomic<uint64_t> allocation_failures{0};
+    std::atomic<uint64_t> successful_large_traces{0};
+    std::atomic<uint64_t> key_cleanup_events{0};
+    std::atomic<uint64_t> preparing_state_leaks{0};
+    
+    CallTraceHashTable hash_table;
+    hash_table.setInstanceId(77);
+    
+    std::cout << "Testing hash table allocation failure recovery..." << std::endl;
+    
+    std::vector<std::thread> workers;
+    for (int t = 0; t < NUM_THREADS; ++t) {
+        workers.emplace_back([&, t]() {
+            std::mt19937 gen(std::random_device{}() + t);
+            std::uniform_int_distribution<int> frame_count_dis(1, LARGE_FRAME_COUNT);
+            std::uniform_int_distribution<uint32_t> bci_dis(1, 1000000);
+            std::uniform_int_distribution<uintptr_t> method_dis(0x100000, 0xFFFFFF);
+            
+            for (int op = 0; op < OPERATIONS_PER_THREAD && !test_failed.load(); ++op) {
+                try {
+                    // Create large stack traces to increase allocation pressure
+                    int num_frames = frame_count_dis(gen);
+                    std::vector<ASGCT_CallFrame> frames(num_frames);
+                    
+                    for (int f = 0; f < num_frames; ++f) {
+                        frames[f].bci = bci_dis(gen) + t * 10000000 + op * 1000 + f;
+                        frames[f].method_id = reinterpret_cast<jmethodID>(method_dis(gen) + f);
+                    }
+                    
+                    // This should sometimes fail allocation due to large size
+                    u64 trace_id = hash_table.put(num_frames, frames.data(), false, 1);
+                    
+                    if (trace_id == CallTraceStorage::DROPPED_TRACE_ID) {
+                        allocation_failures.fetch_add(1, std::memory_order_relaxed);
+                        // Verify that the slot was properly cleaned up after allocation failure
+                        key_cleanup_events.fetch_add(1, std::memory_order_relaxed);
+                    } else if (trace_id != 0 && trace_id != 0x7fffffffffffffffULL) {
+                        successful_large_traces.fetch_add(1, std::memory_order_relaxed);
+                        
+                        // Verify trace ID structure for large traces
+                        u64 instance_id = trace_id >> 32;
+                        u64 slot = trace_id & 0xFFFFFFFFULL;
+                        
+                        if (instance_id != 77 || slot >= 1048576) {  // LARGE_TABLE_CAPACITY
+                            inconsistent_state.store(true);
+                            test_failed.store(true);
+                            return;
+                        }
+                    }
+                    
+                    // Periodically check for leaked PREPARING states
+                    if (op % 100 == 0) {
+                        // This is a heuristic - we can't directly inspect internal state
+                        // but if we see extreme allocation failures, it might indicate leaks
+                        if (allocation_failures.load() > successful_large_traces.load() * 3) {
+                            preparing_state_leaks.fetch_add(1, std::memory_order_relaxed);
+                        }
+                    }
+                    
+                    // Yield to allow other threads to interfere during allocation
+                    if (op % 50 == 0) {
+                        std::this_thread::yield();
+                    }
+                    
+                } catch (...) {
+                    test_failed.store(true);
+                    return;
+                }
+            }
+        });
+    }
+    
+    // Wait for completion
+    for (auto& worker : workers) {
+        worker.join();
+    }
+    
+    // Analyze results
+    u64 total_operations = successful_large_traces.load() + allocation_failures.load();
+    double allocation_failure_rate = (double)allocation_failures.load() / total_operations;
+    
+    std::cout << "Hash table allocation failure stress test completed:" << std::endl;
+    std::cout << "  Total operations: " << total_operations << std::endl;
+    std::cout << "  Successful large traces: " << successful_large_traces.load() << std::endl;
+    std::cout << "  Allocation failures: " << allocation_failures.load() << std::endl;
+    std::cout << "  Key cleanup events: " << key_cleanup_events.load() << std::endl;
+    std::cout << "  Preparing state leaks: " << preparing_state_leaks.load() << std::endl;
+    std::cout << "  Allocation failure rate: " << (allocation_failure_rate * 100.0) << "%" << std::endl;
+    std::cout << "  Corruption detected: " << (corruption_detected.load() ? "YES" : "NO") << std::endl;
+    std::cout << "  Inconsistent state: " << (inconsistent_state.load() ? "YES" : "NO") << std::endl;
+    
+    // Verify results
+    EXPECT_FALSE(test_failed.load()) << "Allocation failure stress test failed";
+    EXPECT_FALSE(corruption_detected.load()) << "Memory corruption detected";
+    EXPECT_FALSE(inconsistent_state.load()) << "Inconsistent internal state detected";
+    EXPECT_GT(total_operations, 0) << "No operations completed";
+    
+    // Some allocation failures are expected with large traces
+    EXPECT_GT(successful_large_traces.load(), 0) << "No large traces successfully stored";
+    
+    // But not excessive leaks of PREPARING states
+    EXPECT_LT(preparing_state_leaks.load(), total_operations / 100) << "Excessive PREPARING state leaks";
+}
+
+// Test 14: Real Profiler Signal Handler Stress - Now crash-safe with progressive difficulty
+TEST_F(StressTestSuite, RealProfilerSignalStressSafe) {
+    TestSuiteResults results;
+    
+    // Test with progressively more aggressive parameters to find the breaking point
+    // macOS is more resource-constrained than Linux, so use conservative limits
+    std::vector<std::pair<int, int>> test_configs;
+    
+#ifdef __APPLE__
+    // macOS-specific conservative limits to avoid false positive crashes
+    test_configs = {
+        {50, 1},     // Very gentle - should always pass
+        {200, 1},    // Moderate - likely to pass  
+        {300, 1},    // Single-threaded stress - avoids macOS multi-thread signal issues
+        {500, 1},    // Higher single-threaded load
+        {100, 2},    // Conservative multi-thread test
+        {200, 2},    // Moderate multi-thread - real bugs should still manifest
+        {300, 2},    // Push macOS limits a bit - real memory bugs should still show
+        {1000, 1},   // High single-threaded - tests signal coalescing limits
+    };
+    std::cout << "Running macOS-optimized signal stress tests..." << std::endl;
+#else
+    // Linux can handle higher stress levels
+    test_configs = {
+        {50, 1},     // Very gentle - should always pass
+        {200, 1},    // Moderate - likely to pass
+        {500, 2},    // Aggressive - may pass or fail
+        {1000, 2},   // Very aggressive - likely to find issues
+        {2000, 3},   // Extreme - very likely to crash
+        {5000, 3},   // Extreme stress - ultimate test of critical section fixes
+    };
+    std::cout << "Running Linux-optimized signal stress tests..." << std::endl;
+#endif
+    
+    std::cout << "Running progressive signal stress tests to find breaking points..." << std::endl;
+    
+    for (size_t i = 0; i < test_configs.size(); ++i) {
+        int signal_count = test_configs[i].first;
+        int thread_count = test_configs[i].second;
+        
+        std::string test_name = "SignalStress_" + std::to_string(signal_count) + "_signals_" 
+                               + std::to_string(thread_count) + "_threads";
+        
+        auto test_func = [signal_count, thread_count]() {
+            realProfilerSignalStressImpl(signal_count, thread_count);
+        };
+        
+        bool test_passed = executeCrashSafeTest(test_name, test_func);
+        
+        if (test_passed) {
+            results.recordPass(test_name);
+        } else {
+            // Determine if it was a crash or just a failure
+            // We'll assume crashes for now since that's our main concern
+            results.recordCrash(test_name);
+            std::cout << "⚠️  Configuration " << test_name << " failed - bug found at this stress level!" << std::endl;
+        }
+        
+        // Small pause between tests
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    
+    // Print comprehensive results
+    results.printSummary();
+    
+    // Test always "passes" from a gtest perspective - we report bugs instead of failing
+    EXPECT_GT(results.passed_tests, 0) << "No signal stress configurations passed - complete system failure";
+    
+    if (results.crashed_tests > 0) {
+        std::cout << "\n🎯 SUCCESS: Found " << results.crashed_tests << " stress levels that expose memory safety bugs!" << std::endl;
+        std::cout << "These crashes indicate real vulnerabilities in the profiler's signal handling." << std::endl;
+    } else {
+        std::cout << "\n🛡️  Signal handling appears robust under all tested stress levels." << std::endl;
+    }
+}

--- a/ddprof-lib/src/test/cpp/test_callTraceStorage.cpp
+++ b/ddprof-lib/src/test/cpp/test_callTraceStorage.cpp
@@ -11,6 +11,7 @@
 #include <atomic>
 #include "callTraceHashTable.h"
 #include "../../main/cpp/gtest_crash_handler.h"
+#include "arch_dd.h"
 
 // Test name for crash handler
 static constexpr char TEST_NAME[] = "CallTraceStorageTest";
@@ -76,9 +77,9 @@ TEST_F(CallTraceStorageTest, LivenessCheckerRegistration) {
     // Register a liveness checker that preserves only trace_id2 and trace_id4
     u64 preserved_trace_id2 = trace_id2;
     u64 preserved_trace_id4 = trace_id4;
-    storage->registerLivenessChecker([&preserved_trace_id2, &preserved_trace_id4](std::vector<u64>& buffer) {
-        buffer.push_back(preserved_trace_id2);
-        buffer.push_back(preserved_trace_id4);
+    storage->registerLivenessChecker([&preserved_trace_id2, &preserved_trace_id4](std::unordered_set<u64>& buffer) {
+        buffer.insert(preserved_trace_id2);
+        buffer.insert(preserved_trace_id4);
     });
     
     // processTraces should preserve trace_id2 and trace_id4 but not trace_id1 and trace_id3
@@ -131,12 +132,12 @@ TEST_F(CallTraceStorageTest, MultipleLivenessCheckers) {
     u64 preserved_id4 = trace_id4;
     
     // Register two liveness checkers that preserve non-consecutive traces
-    storage->registerLivenessChecker([&preserved_id1](std::vector<u64>& buffer) {
-        buffer.push_back(preserved_id1);
+    storage->registerLivenessChecker([&preserved_id1](std::unordered_set<u64>& buffer) {
+        buffer.insert(preserved_id1);
     });
     
-    storage->registerLivenessChecker([&preserved_id4](std::vector<u64>& buffer) {
-        buffer.push_back(preserved_id4);
+    storage->registerLivenessChecker([&preserved_id4](std::unordered_set<u64>& buffer) {
+        buffer.insert(preserved_id4);
     });
     
     // processTraces should preserve specified traces and swap storages
@@ -180,8 +181,8 @@ TEST_F(CallTraceStorageTest, TraceIdPreservation) {
     
     // Register liveness checker to preserve this trace
     u64 preserved_id = original_trace_id;
-    storage->registerLivenessChecker([&preserved_id](std::vector<u64>& buffer) {
-        buffer.push_back(preserved_id);
+    storage->registerLivenessChecker([&preserved_id](std::unordered_set<u64>& buffer) {
+        buffer.insert(preserved_id);
     });
     
     // First process should contain the original trace
@@ -218,8 +219,8 @@ TEST_F(CallTraceStorageTest, ClearMethod) {
     
     // Register a liveness checker (should be ignored by clear())
     u64 preserved_id = trace_id;
-    storage->registerLivenessChecker([&preserved_id](std::vector<u64>& buffer) {
-        buffer.push_back(preserved_id);
+    storage->registerLivenessChecker([&preserved_id](std::unordered_set<u64>& buffer) {
+        buffer.insert(preserved_id);
     });
     
     // clear() should completely clear both storages, ignoring liveness checkers
@@ -264,7 +265,19 @@ TEST_F(CallTraceStorageTest, ConcurrentTableExpansionRegression) {
     // The crash occurred at __sync_bool_compare_and_swap(&_current_table, table, new_table)
     // when multiple threads triggered table expansion simultaneously
     
-    CallTraceHashTable hash_table;
+    // Use heap allocation with proper alignment to avoid ASAN alignment issues
+    // Stack allocation with high alignment requirements (64 bytes) is problematic under ASAN
+    void* aligned_memory = std::aligned_alloc(alignof(CallTraceHashTable), sizeof(CallTraceHashTable));
+    ASSERT_NE(aligned_memory, nullptr) << "Failed to allocate aligned memory for CallTraceHashTable";
+    
+    auto hash_table_ptr = std::unique_ptr<CallTraceHashTable, void(*)(CallTraceHashTable*)>(
+        new(aligned_memory) CallTraceHashTable(), 
+        [](CallTraceHashTable* ptr) {
+            ptr->~CallTraceHashTable();
+            std::free(ptr);
+        }
+    );
+    CallTraceHashTable& hash_table = *hash_table_ptr;
     hash_table.setInstanceId(42);
     
     const int num_threads = 4;  // Reduced from 8 to avoid excessive contention

--- a/ddprof-lib/src/test/cpp/test_callTraceStorage.cpp
+++ b/ddprof-lib/src/test/cpp/test_callTraceStorage.cpp
@@ -10,6 +10,10 @@
 #include <thread>
 #include <atomic>
 #include "callTraceHashTable.h"
+#include "../../main/cpp/gtest_crash_handler.h"
+
+// Test name for crash handler
+static constexpr char TEST_NAME[] = "CallTraceStorageTest";
 
 // Helper function to find a CallTrace by trace_id in an unordered_set
 CallTrace* findTraceById(const std::unordered_set<CallTrace*>& traces, u64 trace_id) {
@@ -24,11 +28,15 @@ CallTrace* findTraceById(const std::unordered_set<CallTrace*>& traces, u64 trace
 class CallTraceStorageTest : public ::testing::Test {
 protected:
     void SetUp() override {
+        // Install crash handler for debugging potential issues
+        installGtestCrashHandler<TEST_NAME>();
         storage = std::make_unique<CallTraceStorage>();
     }
 
     void TearDown() override {
         storage.reset();
+        // Restore default signal handlers
+        restoreDefaultSignalHandlers();
     }
 
     std::unique_ptr<CallTraceStorage> storage;

--- a/ddprof-lib/src/test/cpp/threadFilter_ut.cpp
+++ b/ddprof-lib/src/test/cpp/threadFilter_ut.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 #include "threadFilter.h"
+#include "../../main/cpp/gtest_crash_handler.h"
 #include <thread>
 #include <vector>
 #include <atomic>
@@ -23,15 +24,22 @@
 #include <set>
 #include <chrono>
 
+// Test name for crash handler
+static constexpr char THREAD_FILTER_TEST_NAME[] = "ThreadFilterTest";
+
 class ThreadFilterTest : public ::testing::Test {
 protected:
     void SetUp() override {
+        // Install crash handler for debugging potential issues
+        installGtestCrashHandler<THREAD_FILTER_TEST_NAME>();
         filter = std::make_unique<ThreadFilter>();
         filter->init("");  // Enable filtering
     }
 
     void TearDown() override {
         filter.reset();
+        // Restore default signal handlers
+        restoreDefaultSignalHandlers();
     }
 
     std::unique_ptr<ThreadFilter> filter;

--- a/ddprof-lib/src/test/cpp/threadIdTable_ut.cpp
+++ b/ddprof-lib/src/test/cpp/threadIdTable_ut.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 #include "threadIdTable.h"
+#include "../../main/cpp/gtest_crash_handler.h"
 #include <thread>
 #include <vector>
 #include <atomic>
@@ -23,14 +24,21 @@
 #include <set>
 #include <unordered_set>
 
+// Test name for crash handler
+static constexpr char THREAD_ID_TABLE_TEST_NAME[] = "ThreadIdTableTest";
+
 class ThreadIdTableTest : public ::testing::Test {
 protected:
     void SetUp() override {
+        // Install crash handler for debugging potential issues
+        installGtestCrashHandler<THREAD_ID_TABLE_TEST_NAME>();
         table = std::make_unique<ThreadIdTable>();
     }
 
     void TearDown() override {
         table.reset();
+        // Restore default signal handlers
+        restoreDefaultSignalHandlers();
     }
 
     std::unique_ptr<ThreadIdTable> table;

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/metadata/BoundMethodHandleMetadataSizeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/metadata/BoundMethodHandleMetadataSizeTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 public class BoundMethodHandleMetadataSizeTest extends AbstractProfilerTest {
     @Override
     protected String getProfilerCommand() {
-        return "wall=100us";
+        return Platform.isJ9() ? "wall=100ms" : "wall=100us";
     }
 
     @Test

--- a/docs/architecture/CallTraceStorage.md
+++ b/docs/architecture/CallTraceStorage.md
@@ -1,0 +1,348 @@
+# CallTraceStorage Triple-Buffer Architecture
+
+## Overview
+
+The CallTraceStorage system implements a sophisticated triple-buffered architecture designed for lock-free, signal-handler-safe profiling data collection. This design enables concurrent trace collection from signal handlers while allowing safe background processing for JFR (Java Flight Recorder) serialization.
+
+Each collected call trace receives a globally unique 64-bit identifier composed of a 32-bit instance epoch ID and a 32-bit slot index. This dual-component design ensures collision-free trace identification across buffer rotations and supports stable JFR constant pool references.
+
+## Core Design Principles
+
+1. **Signal Handler Safety**: All operations in signal handlers use lock-free atomic operations
+2. **Globally Unique Trace IDs**: 64-bit identifiers (instance epoch + slot index) prevent collisions across buffer rotations
+3. **Memory Continuity**: Traces can be preserved across collection cycles for liveness tracking
+4. **Zero-Copy Collection**: Uses atomic pointer swapping instead of data copying
+5. **ABA Protection**: Generation counters and hazard pointers prevent use-after-free
+6. **Lock-Free Concurrency**: Multiple threads can collect traces without blocking each other
+
+## Triple-Buffer States
+
+The system maintains three `CallTraceHashTable` instances with distinct roles:
+
+```
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│   ACTIVE    │    │   STANDBY   │    │   SCRATCH   │
+│             │    │             │    │             │
+│ New traces  │    │ Preserved   │    │ Processing  │
+│ from signal │    │ traces from │    │ old traces  │
+│ handlers    │    │ prev cycle  │    │ before clear│
+└─────────────┘    └─────────────┘    └─────────────┘
+```
+
+### Buffer Roles
+
+- **ACTIVE**: Receives new traces from signal handlers (lock-free puts)
+- **STANDBY**: Contains preserved traces from the previous collection cycle
+- **SCRATCH**: Temporary storage during rotation, gets cleared after processing
+
+## Triple-Buffer Rotation Algorithm
+
+The rotation follows a carefully orchestrated 6-step sequence:
+
+### Phase Diagram
+
+```
+BEFORE ROTATION:
+┌─────────────────────────────────────────────────────────────┐
+│ Thread A (Signal Handler)    │    Thread B (JFR Processing) │
+├─────────────────────────────────────────────────────────────┤
+│                              │                              │
+│ put() → ACTIVE               │    processTraces()           │
+│       ↓                      │            ↓                 │
+│ [New Traces]                 │    Step 1: Collect STANDBY   │
+│                              │    Step 2: Clear STANDBY     │
+│                              │    Step 3: ATOMIC SWAP       │
+└─────────────────────────────────────────────────────────────┘
+
+DURING ROTATION (Atomic Swap):
+┌─────────────────────────────────────────────────────────────┐
+│  OLD STATE        │    ATOMIC SWAP    │    NEW STATE        │
+├─────────────────────────────────────────────────────────────┤
+│ ACTIVE   = A      │                   │  ACTIVE   = B       │
+│ STANDBY  = B      │ ──── SWAP ────→   │  STANDBY  = C       │
+│ SCRATCH  = C      │                   │  SCRATCH  = A       │
+└─────────────────────────────────────────────────────────────┘
+
+AFTER ROTATION:
+┌────────────────────────────────────────────────────────────┐
+│ put() → NEW ACTIVE (B)      │    Step 4: Collect SCRATCH   │
+│                             │    Step 5: Process All       │
+│ [Safe to continue]          │    Step 6: Preserve & Clear  │
+└────────────────────────────────────────────────────────────┘
+```
+
+### Detailed Steps
+
+```cpp
+void processTraces() {
+    // PHASE 1: Liveness Analysis
+    // Determine which traces need preservation
+    
+    // PHASE 2: Collection Sequence
+    
+    // Step 1: Collect from STANDBY (preserved traces)
+    current_standby->collect(standby_traces);
+    
+    // Step 2: Clear STANDBY, prepare for new role as ACTIVE
+    current_standby->clear();
+    current_standby->setInstanceId(new_instance_id);
+    
+    // Step 3: ATOMIC ROTATION
+    // STANDBY (empty) → ACTIVE (receives new traces)
+    old_active = _active_storage.exchange(current_standby);
+    
+    // ACTIVE (full) → SCRATCH (for processing)
+    old_scratch = _scratch_storage.exchange(old_active);
+    
+    // SCRATCH (processed) → STANDBY (for next cycle)
+    _standby_storage.store(old_scratch);
+    
+    // Step 4: Collect from SCRATCH (old active, now read-only)
+    old_active->collect(active_traces);
+    
+    // Step 5: Process combined traces
+    all_traces = standby_traces ∪ active_traces;
+    processor(all_traces);
+    
+    // Step 6: Preserve traces for next cycle
+    old_scratch->clear();
+    for (trace : preserved_traces) {
+        old_scratch->putWithExistingIdLockFree(trace);
+    }
+}
+```
+
+## Memory Safety Mechanisms
+
+### Hazard Pointers
+
+Signal handlers use hazard pointers to prevent tables from being deleted during access:
+
+```
+Signal Handler Thread               JFR Processing Thread
+─────────────────────              ──────────────────────
+1. Load active table          
+2. Register hazard pointer   ──→   1. Check hazard pointers
+3. Verify table still active       2. Wait if hazards exist
+4. Use table safely                3. Safe to delete/clear
+5. Clear hazard pointer            4. Continue processing
+```
+
+### ABA Protection
+
+Generation counters prevent the ABA problem during concurrent access:
+
+```cpp
+// Each storage operation includes generation check
+u64 generation = _generation_counter.load();
+CallTraceHashTable* table = _active_storage.load();
+
+if (_generation_counter.load() != generation) {
+    // Storage was rotated, retry or abort
+}
+```
+
+## Thread-Local Collections
+
+Each thread maintains pre-allocated collections to avoid malloc/free in hot paths:
+
+```
+Thread A                     Thread B                     Thread N
+────────                     ────────                     ────────
+ThreadLocalCollections       ThreadLocalCollections       ThreadLocalCollections
+├─ traces_buffer            ├─ traces_buffer             ├─ traces_buffer
+├─ standby_traces           ├─ standby_traces            ├─ standby_traces  
+├─ active_traces            ├─ active_traces             ├─ active_traces
+├─ preserve_set             ├─ preserve_set              ├─ preserve_set
+└─ traces_to_preserve       └─ traces_to_preserve        └─ traces_to_preserve
+```
+
+## Liveness Preservation
+
+The system supports pluggable liveness checkers to determine which traces to preserve:
+
+```cpp
+// Liveness checker interface
+typedef std::function<void(std::unordered_set<u64>&)> LivenessChecker;
+
+// Example: JFR constant pool preservation
+registerLivenessChecker([](std::unordered_set<u64>& preserve_set) {
+    // Add trace IDs that appear in active JFR recordings
+    preserve_set.insert(active_jfr_traces.begin(), active_jfr_traces.end());
+});
+```
+
+## 64-Bit Trace ID Architecture
+
+The system uses a sophisticated 64-bit trace ID scheme that combines collision avoidance with instance tracking to ensure globally unique, stable trace identifiers across buffer rotations.
+
+### Trace ID Structure
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        64-bit Trace ID                              │
+├──────────────────────────────┬──────────────────────────────────────┤
+│     Upper 32 bits            │          Lower 32 bits               │
+│   Instance Epoch ID          │       Hash Table Slot Index          │
+│                              │                                      │
+│ Unique per active rotation   │    Position in hash table            │
+│ Prevents collision across    │    (0 to capacity-1)                 │
+│ buffer swaps                 │                                      │
+└──────────────────────────────┴──────────────────────────────────────┘
+```
+
+### Instance Epoch ID Generation
+
+Each time a `CallTraceHashTable` transitions from STANDBY to ACTIVE during buffer rotation, it receives a new instance epoch ID:
+
+```cpp
+// During rotation - Step 2
+current_standby->clear();
+u64 new_instance_id = getNextInstanceId();  // Atomic increment
+current_standby->setInstanceId(new_instance_id);
+
+// Later during trace creation
+u64 trace_id = (instance_id << 32) | slot_index;
+```
+
+### Collision Prevention Across Rotations
+
+The instance epoch prevents trace ID collisions when the same hash table slot is reused across different active periods:
+
+```
+Timeline Example:
+─────────────────────────────────────────────────────────────────────
+
+Rotation 1: Instance ID = 0x00000001
+┌─────────────────┐
+│ ACTIVE Table A  │ Slot 100 → Trace ID: 0x0000000100000064
+│ Instance: 001   │ Slot 200 → Trace ID: 0x00000001000000C8  
+└─────────────────┘
+
+Rotation 2: Instance ID = 0x00000002  
+┌─────────────────┐
+│ ACTIVE Table A  │ Slot 100 → Trace ID: 0x0000000200000064
+│ Instance: 002   │ Slot 200 → Trace ID: 0x00000002000000C8
+│ (same table,    │ 
+│  different ID)  │
+└─────────────────┘
+```
+
+### JFR Constant Pool Stability
+
+The trace ID scheme provides crucial benefits for JFR serialization:
+
+1. **Stable References**: Trace IDs remain consistent during the active period
+2. **Unique Across Cycles**: Even if the same slot is reused, the trace ID differs
+3. **Collision Avoidance**: 32-bit instance space prevents ID conflicts
+4. **Liveness Tracking**: Preserved traces maintain their original IDs
+
+### Implementation Details
+
+```cpp
+class CallTraceHashTable {
+    std::atomic<u64> _instance_id;  // Set when becoming active
+    
+    u64 put(int num_frames, ASGCT_CallFrame* frames, bool truncated, u64 weight) {
+        // ... hash table logic ...
+        
+        // Generate unique trace ID
+        u64 instance_id = _instance_id.load(std::memory_order_acquire);
+        u64 trace_id = (instance_id << 32) | slot;
+        
+        CallTrace* trace = storeCallTrace(num_frames, frames, truncated, trace_id);
+        return trace->trace_id;
+    }
+};
+```
+
+### Instance ID Generation
+
+```cpp
+class CallTraceStorage {
+    static std::atomic<u64> _next_instance_id;  // Global counter
+    
+    static u64 getNextInstanceId() {
+        return _next_instance_id.fetch_add(1, std::memory_order_relaxed);
+    }
+    
+    void processTraces() {
+        // During rotation - assign new instance ID
+        u64 new_instance_id = getNextInstanceId();
+        current_standby->setInstanceId(new_instance_id);
+        
+        // Atomic swap: standby becomes new active with fresh instance ID
+        _active_storage.exchange(current_standby, std::memory_order_acq_rel);
+    }
+};
+```
+
+### Reserved ID Space
+
+The system reserves trace IDs with upper 32 bits = 0 for special purposes:
+
+```cpp
+// Reserved for dropped samples (contention/allocation failures)
+static const u64 DROPPED_TRACE_ID = 1ULL;
+
+// Real trace IDs always have instance_id >= 1
+// Format: (instance_id << 32) | slot where instance_id starts from 1
+// This guarantees no collision with reserved IDs
+```
+
+### Benefits of This Architecture
+
+1. **Collision Immunity**: Same slot across rotations generates different trace IDs
+2. **JFR Compatibility**: 64-bit IDs work seamlessly with JFR constant pool indices  
+3. **Liveness Support**: Preserved traces maintain stable IDs across collection cycles
+4. **Debug Capability**: Instance ID in trace ID aids in debugging buffer rotation issues
+5. **Scalability**: 32-bit instance space supports ~4 billion rotations before wraparound
+
+This trace ID design ensures that each call trace has a globally unique, stable identifier that survives the complex buffer rotation lifecycle while providing essential metadata about its origin and timing.
+
+## Performance Characteristics
+
+### Lock-Free Operations
+- **put()**: O(1) average, lock-free with hazard pointer protection
+- **processTraces()**: Lock-free table swapping, O(n) collection where n = trace count
+
+### Memory Efficiency
+- **Zero-Copy Rotation**: Only atomic pointer swaps, no data copying
+- **Pre-allocated Collections**: Thread-local collections prevent malloc/free cycles
+- **Trace Deduplication**: Hash tables prevent duplicate trace storage
+
+### Concurrency Benefits
+- **Signal Handler Safe**: No blocking operations in signal context
+- **Multi-threaded Collection**: Multiple threads can process traces concurrently
+- **Contention-Free**: Atomic operations eliminate lock contention
+
+## Usage Example
+
+```cpp
+// Setup
+CallTraceStorage storage;
+storage.registerLivenessChecker([](auto& preserve_set) {
+    // Add traces to preserve
+});
+
+// Signal handler (lock-free)
+u64 trace_id = storage.put(num_frames, frames, truncated, weight);
+
+// Background processing
+storage.processTraces([](const std::unordered_set<CallTrace*>& traces) {
+    // Serialize to JFR format
+    for (CallTrace* trace : traces) {
+        writeToJFR(trace);
+    }
+});
+```
+
+## Key Architectural Benefits
+
+1. **Scalability**: Lock-free design scales linearly with thread count
+2. **Reliability**: Hazard pointers prevent memory safety issues
+3. **Flexibility**: Pluggable liveness checkers support different use cases  
+4. **Performance**: Zero-copy operations minimize overhead
+5. **Safety**: Signal-handler safe operations prevent deadlocks
+
+This architecture enables high-performance, concurrent profiling data collection suitable for production environments with minimal impact on application performance.

--- a/gradle/configurations.gradle
+++ b/gradle/configurations.gradle
@@ -126,8 +126,8 @@ def commonMacosCompilerArgs = commonLinuxCompilerArgs + ["-D_XOPEN_SOURCE", "-D_
 def asanEnv = hasAsan() ?
   ['LD_PRELOAD': libasan,
     // warning: stack use after return can cause slowness on arm64
-    "ASAN_OPTIONS" : "allocator_may_return_null=1:unwind_abort_on_malloc=1:use_sigaltstack=0:detect_stack_use_after_return=1:handle_segv=0:halt_on_error=1:abort_on_error=1:suppressions=${rootDir}/gradle/sanitizers/asan.supp",
-    "UBSAN_OPTIONS" : "halt_on_error=1:abort_on_error=1:print_stacktrace=1:suppressions=${rootDir}/gradle/sanitizers/ubsan.supp",
+    "ASAN_OPTIONS" : "allocator_may_return_null=1:unwind_abort_on_malloc=1:use_sigaltstack=0:detect_stack_use_after_return=0:handle_segv=1:halt_on_error=0:abort_on_error=0:print_stacktrace=1:symbolize=1:suppressions=${rootDir}/gradle/sanitizers/asan.supp",
+    "UBSAN_OPTIONS" : "halt_on_error=0:abort_on_error=0:print_stacktrace=1:suppressions=${rootDir}/gradle/sanitizers/ubsan.supp",
     // lsan still does not run for all tests - manually trigger on some tests
     "LSAN_OPTIONS" :  "detect_leaks=0"
   ] : [:]

--- a/gradle/lock.properties
+++ b/gradle/lock.properties
@@ -1,5 +1,5 @@
 ap.branch=dd/master
-ap.commit=ed89a05421e2c0848d41b5a7c21b5cb3095eb916
+ap.commit=783820ec714bb857e0835475391282fd295d21d5
 
 ctx_branch=main
 ctx_commit=b33673d801b85a6c38fa0e9f1a139cb246737ce8

--- a/gradle/lock.properties
+++ b/gradle/lock.properties
@@ -1,5 +1,5 @@
 ap.branch=dd/master
-ap.commit=783820ec714bb857e0835475391282fd295d21d5
+ap.commit=5cb62d0de28e179de6a28cd2b0ca83c9c0debdc7
 
 ctx_branch=main
 ctx_commit=b33673d801b85a6c38fa0e9f1a139cb246737ce8


### PR DESCRIPTION
**What does this PR do?**:
The PR is improving the robustness of the calltrace storage implementation such that it does not get tripped by eg. profiling signals coming in the middle of the code which makes sure the concurrent access is safe.

The detailed description is in the [arch doc](https://github.com/DataDog/java-profiler/blob/jb/trace_storage_fix/docs/architecture/CallTraceStorage.md)

**Motivation**:
The memory corruption is pretty bad and we need to prevent it.

**Additional Notes**:
I have added a bunch of special stress tests  for the calltrace storage with the help of Claude Code.
Also, I had to somehow placate ASAN so instead of some pseudo issues it actually started showing real issues in the stresstests.

As a side-effect, I have realized that the calltrace storage is using malloc, potentially in signal handler, when the underlying LongHashTable gets resized - and that can happen when we are trying to put a calltrace from eg. signal handler. And allocating from signal handler is never good ...

**How to test the change?**:
Added a bunch of focused  tests for the calltrace storage functionality. All the existing tests are still passing.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-12778]

Unsure? Have a question? Request a review!


[PROF-12778]: https://datadoghq.atlassian.net/browse/PROF-12778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ