### PR TITLE
Shorten jmh task execution time

### DIFF
--- a/ddprof-stresstest/build.gradle
+++ b/ddprof-stresstest/build.gradle
@@ -27,7 +27,6 @@ jmh {
     timeOnIteration = '3s'
     warmup = '1s'
     warmupIterations = 3
-    jvmArgsAppend = ['-XX:+CriticalJNINatives']
 }
 
 jmhJar {

--- a/ddprof-stresstest/build.gradle
+++ b/ddprof-stresstest/build.gradle
@@ -22,6 +22,14 @@ sourceSets {
   }
 }
 
+jmh {
+    iterations = 3
+    timeOnIteration = '3s'
+    warmup = '1s'
+    warmupIterations = 3
+    jvmArgsAppend = ['-XX:+CriticalJNINatives']
+}
+
 jmhJar {
   manifest {
     attributes(

--- a/ddprof-stresstest/build.gradle
+++ b/ddprof-stresstest/build.gradle
@@ -23,10 +23,10 @@ sourceSets {
 }
 
 jmh {
-    iterations = 3
-    timeOnIteration = '3s'
-    warmup = '1s'
-    warmupIterations = 3
+  iterations = 3
+  timeOnIteration = '3s'
+  warmup = '1s'
+  warmupIterations = 3
 }
 
 jmhJar {


### PR DESCRIPTION
**What does this PR do?**:

Shorten jmh task execution time to a more manageable duration 

**Motivation**:
Current jmh task takes about 4 hours and 18 minutes to complete on my 8 cores/16 threads, 3GHZ machine, because each benchmark composes 5 warmup iterations and 5 measurement iterations, each iteration takes 10s, and each benchmark is executed 5 times.

Long execution time does not necessary result in more accurate numbers, but limits its utilization.

This change shorten the execution time by reducing warmup and measurement iterations to 3, always reducing warmup to 1s per iteration and measurement to 3s per iteration, total execution time down to about 30 minutes.


**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
Run benchmark with command line:
`gradlew jmh`

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
