### PR TITLE
Make jmh task to honor $JAVA_TEST_HOME variable

### DIFF
--- a/ddprof-stresstest/build.gradle
+++ b/ddprof-stresstest/build.gradle
@@ -23,6 +23,11 @@ sourceSets {
 }
 
 jmh {
+  def javaHome = System.getenv("JAVA_TEST_HOME")
+  if (javaHome == null) {
+    javaHome = System.getenv("JAVA_HOME")
+  }
+  jvm = "${javaHome}/bin/java"
   iterations = 3
   timeOnIteration = '3s'
   warmup = '1s'


### PR DESCRIPTION
**What does this PR do?**:
Allows jmh task to pick up $JAVA_TEST_HOME environment variable.

**Motivation**:
Allows jmh task to pick up $JAVA_TEST_HOME environment variable, to be consistent with other tasks.


**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
- Set $JAVA_TEST_HOME to different JDK versions
- Run `gradlew jmh` task
- Check output message and make sure the correct JDK is used.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
