### PR TITLE
Remove assertions that can fail with -Ddd.profiling.start-force-first=false

### DIFF
--- a/ddprof-lib/src/main/cpp/javaApi.cpp
+++ b/ddprof-lib/src/main/cpp/javaApi.cpp
@@ -131,7 +131,6 @@ Java_com_datadoghq_profiler_JavaProfiler_filterThreadAdd0(JNIEnv *env,
                                                           jobject unused) {
   ProfiledThread *current = ProfiledThread::current();
   if (unlikely(current == nullptr)) {
-    assert(false);
     return;
   }
   int tid = current->tid();
@@ -162,7 +161,6 @@ Java_com_datadoghq_profiler_JavaProfiler_filterThreadRemove0(JNIEnv *env,
                                                              jobject unused) {
   ProfiledThread *current = ProfiledThread::current();
   if (unlikely(current == nullptr)) {
-    assert(false);
     return;
   }
   int tid = current->tid();
@@ -189,7 +187,6 @@ Java_com_datadoghq_profiler_JavaProfiler_filterThread0(JNIEnv *env,
                                                        jboolean enable) {
   ProfiledThread *current = ProfiledThread::current();
   if (unlikely(current == nullptr)) {
-    assert(false);
     return;
   }
   int tid = current->tid();


### PR DESCRIPTION
**What does this PR do?**:
Remove assertions that can fail when -Ddd.profiling.start-force-first=false

**Motivation**:
Remove incorrect assertions that prevent debug build from working under certain circumstance.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
