### PR TITLE
Remove unused ThreadFilter.filterThread0() method

### DIFF
--- a/ddprof-lib/src/main/cpp/javaApi.cpp
+++ b/ddprof-lib/src/main/cpp/javaApi.cpp
@@ -182,49 +182,6 @@ Java_com_datadoghq_profiler_JavaProfiler_filterThreadRemove0(JNIEnv *env,
   thread_filter->remove(slot_id);
 }
 
-// Backward compatibility for existing code
-extern "C" DLLEXPORT void JNICALL
-Java_com_datadoghq_profiler_JavaProfiler_filterThread0(JNIEnv *env,
-                                                       jobject unused,
-                                                       jboolean enable) {
-  ProfiledThread *current = ProfiledThread::current();
-  if (unlikely(current == nullptr)) {
-    assert(false);
-    return;
-  }
-  int tid = current->tid();
-  if (unlikely(tid < 0)) {
-    return;
-  }
-  ThreadFilter *thread_filter = Profiler::instance()->threadFilter();
-  if (unlikely(!thread_filter->enabled())) {
-    return;
-  }
-  
-  int slot_id = current->filterSlotId();
-  if (unlikely(slot_id == -1)) {
-    if (enable) {
-      // Thread doesn't have a slot ID yet, so register it
-      assert(thread_filter->enabled() && "ThreadFilter should be enabled when trying to register thread");
-      slot_id = thread_filter->registerThread();
-      current->setFilterSlotId(slot_id);
-    } else {
-      // Thread doesn't have a slot ID yet - nothing to remove
-      return;
-    }
-  }
-  
-  if (unlikely(slot_id == -1)) {
-    return;  // Failed to register thread
-  }
-  
-  if (enable) {
-    thread_filter->add(tid, slot_id);
-  } else {
-    thread_filter->remove(slot_id);
-  }
-}
-
 extern "C" DLLEXPORT jobject JNICALL
 Java_com_datadoghq_profiler_JavaProfiler_getContextPage0(JNIEnv *env,
                                                          jobject unused,

--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
@@ -472,8 +472,6 @@ public final class JavaProfiler {
 
     private native void filterThreadAdd0();
     private native void filterThreadRemove0();
-    // Backward compatibility for existing code
-    private native void filterThread0(boolean enable);
 
     private static native int getTid0();
     private static native ByteBuffer getContextPage0(int tid);


### PR DESCRIPTION
**What does this PR do?**:
Remove unused `ThreadFilter.filterThread0()` method.

**Motivation**:
Cleanup, remove dead code.

**Additional Notes**:
Ivo caught this during code review: https://github.com/DataDog/java-profiler/pull/282#discussion_r2469282753

**How to test the change?**:
No compilation error.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
