### PR TITLE
[PROF-12966] Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you need a full-fledged Java profiler head back to [async-profiler](https://g
    - On Alpine: `apk add gtest-dev`
 6. clang-format 11 (for code formatting)
    - On Ubuntu/Debian: `sudo apt install clang-format-11`
-   - On macOS: `brew install clang-format-11`
+   - On macOS: `brew install clang-format@11`
    - On Alpine: `apk add clang-format-11`
 
 ### Building the Project


### PR DESCRIPTION
**What does this PR do?**:
Fix a mistake in the instructions on how to install clang-format.

**Motivation**:
I followed the instructions on my first day at Datadog and found that this step was not working. It'll help future onboarding to have the correct instructions there.

**How to test the change?**:
Docs-only.

**For Datadog employees**:
- [x] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-12966]


[PROF-12966]: https://datadoghq.atlassian.net/browse/PROF-12966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ