### PR TITLE
Remove 'Unsafe' use from Java prof

### DIFF
--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
@@ -16,6 +16,8 @@
 
 package com.datadoghq.profiler;
 
+import sun.misc.Unsafe;
+
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
@@ -32,6 +34,21 @@ import java.util.Map;
  * libjavaProfiler.so.
  */
 public final class JavaProfiler {
+    static final Unsafe UNSAFE;
+    static {
+        Unsafe unsafe = null;
+        // a safety and testing valve to disable unsafe access
+        if (!Boolean.getBoolean("ddprof.disable_unsafe")) {
+            try {
+                Field f = Unsafe.class.getDeclaredField("theUnsafe");
+                f.setAccessible(true);
+                unsafe = (Unsafe) f.get(null);
+            } catch (Exception ignore) {
+            }
+        }
+        UNSAFE = unsafe;
+    }
+
     static final class TSCFrequencyHolder {
         /**
          * TSC frequency required to convert ticks into seconds

--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/JavaProfiler.java
@@ -16,8 +16,6 @@
 
 package com.datadoghq.profiler;
 
-import sun.misc.Unsafe;
-
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
@@ -34,21 +32,6 @@ import java.util.Map;
  * libjavaProfiler.so.
  */
 public final class JavaProfiler {
-    static final Unsafe UNSAFE;
-    static {
-        Unsafe unsafe = null;
-        // a safety and testing valve to disable unsafe access
-        if (!Boolean.getBoolean("ddprof.disable_unsafe")) {
-            try {
-                Field f = Unsafe.class.getDeclaredField("theUnsafe");
-                f.setAccessible(true);
-                unsafe = (Unsafe) f.get(null);
-            } catch (Exception ignore) {
-            }
-        }
-        UNSAFE = unsafe;
-    }
-
     static final class TSCFrequencyHolder {
         /**
          * TSC frequency required to convert ticks into seconds
@@ -129,13 +112,7 @@ public final class JavaProfiler {
         if (this.contextStorage == null) {
             int maxPages = getMaxContextPages0();
             if (maxPages > 0) {
-                if (UNSAFE != null) {
-                    contextBaseOffsets = new long[maxPages];
-                    // be sure to choose an illegal address as a sentinel value
-                    Arrays.fill(contextBaseOffsets, Long.MIN_VALUE);
-                } else {
-                    contextStorage = new ByteBuffer[maxPages];
-                }
+                contextStorage = new ByteBuffer[maxPages];
             }
         }
     }
@@ -229,26 +206,7 @@ public final class JavaProfiler {
      */
     public void setContext(long spanId, long rootSpanId) {
         int tid = TID.get();
-        if (UNSAFE != null) {
-            setContextUnsafe(tid, spanId, rootSpanId);
-        } else {
-            setContextByteBuffer(tid, spanId, rootSpanId);
-        }
-    }
-
-    private void setContextUnsafe(int tid, long spanId, long rootSpanId) {
-        if (contextBaseOffsets == null) {
-            return;
-        }
-        long pageOffset = getPageUnsafe(tid);
-        if (pageOffset == 0) {
-            return;
-        }
-        int index = (tid % PAGE_SIZE) * CONTEXT_SIZE;
-        long base = pageOffset + index;
-        UNSAFE.putLong(base + SPAN_OFFSET, spanId);
-        UNSAFE.putLong(base + ROOT_SPAN_OFFSET, rootSpanId);
-        UNSAFE.putLong(base + CHECKSUM_OFFSET, spanId ^ rootSpanId);
+        setContextByteBuffer(tid, spanId, rootSpanId);
     }
 
     private void setContextByteBuffer(int tid, long spanId, long rootSpanId) {
@@ -281,15 +239,6 @@ public final class JavaProfiler {
         return page;
     }
 
-    private long getPageUnsafe(int tid) {
-        int pageIndex = tid / PAGE_SIZE;
-        long offset = contextBaseOffsets[pageIndex];
-        if (offset == Long.MIN_VALUE) {
-            contextBaseOffsets[pageIndex] = offset = getContextPageOffset0(tid);
-        }
-        return offset;
-    }
-
     /**
      * Clears context identifier for current thread.
      */
@@ -304,22 +253,7 @@ public final class JavaProfiler {
      */
     public void setContextValue(int offset, int value) {
         int tid = TID.get();
-        if (UNSAFE != null) {
-            setContextUnsafe(tid, offset, value);
-        } else {
-            setContextByteBuffer(tid, offset, value);
-        }
-    }
-
-    private void setContextUnsafe(int tid, int offset, int value) {
-        if (contextBaseOffsets == null) {
-            return;
-        }
-        long pageOffset = getPageUnsafe(tid);
-        if (pageOffset == 0) {
-            return;
-        }
-        UNSAFE.putInt(pageOffset + addressOf(tid, offset), value);
+        setContextByteBuffer(tid, offset, value);
     }
 
     public void setContextByteBuffer(int tid, int offset, int value) {
@@ -335,26 +269,7 @@ public final class JavaProfiler {
 
     void copyTags(int[] snapshot) {
         int tid = TID.get();
-        if (UNSAFE != null) {
-            copyTagsUnsafe(tid, snapshot);
-        } else {
-            copyTagsByteBuffer(tid, snapshot);
-        }
-    }
-
-    void copyTagsUnsafe(int tid, int[] snapshot) {
-        if (contextBaseOffsets == null) {
-            return;
-        }
-        long pageOffset = getPageUnsafe(tid);
-        if (pageOffset == 0) {
-            return;
-        }
-        long address = pageOffset + addressOf(tid, 0);
-        for (int i = 0; i < snapshot.length; i++) {
-            snapshot[i] = UNSAFE.getInt(address);
-            address += Integer.BYTES;
-        }
+        copyTagsByteBuffer(tid, snapshot);
     }
 
     void copyTagsByteBuffer(int tid, int[] snapshot) {


### PR DESCRIPTION
**What does this PR do?**:
Remove `Unsafe` usage from Java profiler

**Motivation**:
`sun.misc.Unsafe` has been depreciated in JDK24 and for JDK 26 or later, the access will be more restricted. In preparation of JDK 26 support, Java profiler eliminates the dependency on `Unsafe`

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
- Compilation without errors
- Pass profiler tests.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-13056](https://datadoghq.atlassian.net/browse/PROF-13056)

Unsure? Have a question? Request a review!


[PROF-13056]: https://datadoghq.atlassian.net/browse/PROF-13056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ