### PR TITLE
Misused posix_memalign results in memory leak and returning wrong lib index

### DIFF
--- a/ddprof-lib/src/main/cpp/arch_dd.h
+++ b/ddprof-lib/src/main/cpp/arch_dd.h
@@ -6,6 +6,8 @@
 #define COMMA ,
 
 #include <stddef.h>
+#include <stdlib.h>
+#include <cassert>
 
 constexpr int DEFAULT_CACHE_LINE_SIZE = 64;
 
@@ -41,6 +43,30 @@ static inline T loadAcquire(volatile T& var) {
 template <typename T>
 static inline void storeRelease(volatile T& var, T value) {
   return __atomic_store_n(&var, value, __ATOMIC_RELEASE);
+}
+
+inline bool is_power_of_2(size_t size) {
+    return size > 0 && (size & (size - 1)) == 0;
+}
+
+template <typename T>
+inline bool is_aligned(const T* ptr, size_t alignment) noexcept {
+    assert(is_power_of_2(alignment));
+    // Convert the pointer to an integer type
+    auto iptr = reinterpret_cast<uintptr_t>(ptr);
+
+    // Check if the integer value is a multiple of the alignment
+    return (iptr & ~(alignment - 1) == 0);
+}
+
+inline size_t align_down(size_t size, size_t alignment) noexcept {
+    assert(is_power_of_2(alignment));
+    return size & ~(alignment - 1);
+}
+
+inline size_t align_up(size_t size, size_t alignment) noexcept {
+    assert(is_power_of_2(alignment));
+    return align_down(size + alignment - 1, alignment);
 }
 
 #endif // _ARCH_DD_H

--- a/ddprof-lib/src/main/cpp/arch_dd.h
+++ b/ddprof-lib/src/main/cpp/arch_dd.h
@@ -6,8 +6,6 @@
 #define COMMA ,
 
 #include <stddef.h>
-#include <stdlib.h>
-#include <cassert>
 
 constexpr int DEFAULT_CACHE_LINE_SIZE = 64;
 
@@ -43,30 +41,6 @@ static inline T loadAcquire(volatile T& var) {
 template <typename T>
 static inline void storeRelease(volatile T& var, T value) {
   return __atomic_store_n(&var, value, __ATOMIC_RELEASE);
-}
-
-inline bool is_power_of_2(size_t size) {
-    return size > 0 && (size & (size - 1)) == 0;
-}
-
-template <typename T>
-inline bool is_aligned(const T* ptr, size_t alignment) noexcept {
-    assert(is_power_of_2(alignment));
-    // Convert the pointer to an integer type
-    auto iptr = reinterpret_cast<uintptr_t>(ptr);
-
-    // Check if the integer value is a multiple of the alignment
-    return (iptr & ~(alignment - 1) == 0);
-}
-
-inline size_t align_down(size_t size, size_t alignment) noexcept {
-    assert(is_power_of_2(alignment));
-    return size & ~(alignment - 1);
-}
-
-inline size_t align_up(size_t size, size_t alignment) noexcept {
-    assert(is_power_of_2(alignment));
-    return align_down(size + alignment - 1, alignment);
 }
 
 #endif // _ARCH_DD_H

--- a/ddprof-lib/src/main/cpp/codeCache.cpp
+++ b/ddprof-lib/src/main/cpp/codeCache.cpp
@@ -12,7 +12,8 @@
 #include <sys/mman.h>
 
 char *NativeFunc::create(const char *name, short lib_index) {
-  NativeFunc *f = (NativeFunc *)malloc(sizeof(NativeFunc) + 1 + strlen(name));
+  size_t size = align_up(sizeof(NativeFunc) + 1 + strlen(name), sizeof(NativeFunc*));
+  NativeFunc *f = (NativeFunc *)aligned_alloc(sizeof(NativeFunc*), size);
   f->_lib_index = lib_index;
   f->_mark = 0;
   // cppcheck-suppress memleak

--- a/ddprof-lib/src/main/cpp/codeCache.cpp
+++ b/ddprof-lib/src/main/cpp/codeCache.cpp
@@ -6,6 +6,7 @@
 #include "codeCache.h"
 #include "dwarf_dd.h"
 #include "os_dd.h"
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>

--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -6,7 +6,7 @@
 #ifndef _CODECACHE_H
 #define _CODECACHE_H
 
-#include "arch_dd.h"
+#include "utils.h"
 
 #include <jvmti.h>
 #include <stdlib.h>

--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -6,6 +6,8 @@
 #ifndef _CODECACHE_H
 #define _CODECACHE_H
 
+#include "arch_dd.h"
+
 #include <jvmti.h>
 #include <stdlib.h>
 #include <string.h>
@@ -62,7 +64,7 @@ public:
 
   static short libIndex(const char *name) {
     NativeFunc* func = from(name);
-    if (posix_memalign((void**)(&func), sizeof(NativeFunc*), sizeof(NativeFunc)) != 0) {
+    if (!is_aligned(func, sizeof(func))) {
       return -1;
     }
     return func->_lib_index;

--- a/ddprof-lib/src/main/cpp/utils.h
+++ b/ddprof-lib/src/main/cpp/utils.h
@@ -2,7 +2,7 @@
 #define _UTILS_H
 
 #include <cassert>
-#include <stdlib.h>
+#include <cstdint>
 
 inline bool is_power_of_2(size_t size) {
     return size > 0 && (size & (size - 1)) == 0;

--- a/ddprof-lib/src/main/cpp/utils.h
+++ b/ddprof-lib/src/main/cpp/utils.h
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <cstddef>
 
 inline bool is_power_of_2(size_t size) {
     return size > 0 && (size & (size - 1)) == 0;

--- a/ddprof-lib/src/main/cpp/utils.h
+++ b/ddprof-lib/src/main/cpp/utils.h
@@ -1,0 +1,34 @@
+#ifndef _UTILS_H
+#define _UTILS_H
+
+#include <cassert>
+#include <stdlib.h>
+
+inline bool is_power_of_2(size_t size) {
+    return size > 0 && (size & (size - 1)) == 0;
+}
+
+template <typename T>
+inline bool is_aligned(const T* ptr, size_t alignment) noexcept {
+    assert(is_power_of_2(alignment));
+    // Convert the pointer to an integer type
+    auto iptr = reinterpret_cast<uintptr_t>(ptr);
+
+    // Check if the integer value is a multiple of the alignment
+    return (iptr & ~(alignment - 1) == 0);
+}
+
+inline size_t align_down(size_t size, size_t alignment) noexcept {
+    assert(is_power_of_2(alignment));
+    return size & ~(alignment - 1);
+}
+
+inline size_t align_up(size_t size, size_t alignment) noexcept {
+    assert(is_power_of_2(alignment));
+    return align_down(size + alignment - 1, alignment);
+}
+
+
+
+
+#endif // _UTILS_H


### PR DESCRIPTION
**What does this PR do?**:
Fix misused call to `posix_memalign`

**Motivation**:
Misused call results memory leak and overwriting `func` variable that leads to return wrong lib index.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
- .`/gradlew testdebug` and `./gradlew testrelease`
- Ran stress tests

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-13084](https://datadoghq.atlassian.net/browse/PROF-13084)

Unsure? Have a question? Request a review!


[PROF-13084]: https://datadoghq.atlassian.net/browse/PROF-13084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ