### PR TITLE
WalkVM crash in dd-java-agent v1.56.0

### DIFF
--- a/ddprof-lib/src/main/cpp/safeAccess.h
+++ b/ddprof-lib/src/main/cpp/safeAccess.h
@@ -45,11 +45,11 @@ public:
 
   static bool handle_safefetch(int sig, void* context);
 
-  static inline void *load(void **ptr) {
+  static inline void *load(void **ptr, void* default_value = nullptr) {
     return loadPtr(ptr, nullptr);
   }
 
-  static inline u32 load32(u32 *ptr, u32 default_value) {
+  static inline u32 load32(u32 *ptr, u32 default_value = 0) {
     int res = safefetch32_impl((int*)ptr, (int)default_value);
     return static_cast<u32>(res);
   }


### PR DESCRIPTION
**What does this PR do?**:
Provide default values for `SafeAccess::load()` and `SafeAccess::load32()`

**Motivation**:
Upstream changed `SafeAccess::load()` and `SafeAccess::load32()` APIs with default values, that result in breaking Java profiler. 


**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
- debug and release test
- stress tests

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-13105](https://datadoghq.atlassian.net/browse/PROF-13105)

Unsure? Have a question? Request a review!


[PROF-13105]: https://datadoghq.atlassian.net/browse/PROF-13105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ