### PR TITLE
Fix another hidden use-after-free in CallTraceStorage

### DIFF
--- a/ddprof-lib/src/main/cpp/callTraceHashTable.cpp
+++ b/ddprof-lib/src/main/cpp/callTraceHashTable.cpp
@@ -102,10 +102,10 @@ CallTraceHashTable::~CallTraceHashTable() {
 }
 
 
-void CallTraceHashTable::clear() {
-  // Wait for all hazard pointers to clear before deallocation to prevent races
+ChunkList CallTraceHashTable::clearTableOnly() {
+  // Wait for all hazard pointers to clear before detaching chunks
   HazardPointer::waitForAllHazardPointersToClear();
-  
+
   // Clear previous chain pointers to prevent traversal during deallocation
   for (LongHashTable *table = _table; table != nullptr; table = table->prev()) {
     LongHashTable *prev_table = table->prev();
@@ -113,13 +113,21 @@ void CallTraceHashTable::clear() {
       table->setPrev(nullptr);  // Clear link before deallocation
     }
   }
-  
-  // Now safe to deallocate all memory
-  _allocator.clear();
-  
-  // Reinitialize with fresh table
+
+  // Detach chunks for deferred deallocation - keeps trace memory alive
+  ChunkList detached_chunks = _allocator.detachChunks();
+
+  // Reinitialize with fresh table (using the new chunk from detachChunks)
   _table = LongHashTable::allocate(nullptr, INITIAL_CAPACITY, &_allocator);
   _overflow = 0;
+
+  return detached_chunks;
+}
+
+void CallTraceHashTable::clear() {
+  // Clear table and immediately free chunks (original behavior)
+  ChunkList chunks = clearTableOnly();
+  LinearAllocator::freeChunks(chunks);
 }
 
 // Adaptation of MurmurHash64A by Austin Appleby

--- a/ddprof-lib/src/main/cpp/callTraceHashTable.h
+++ b/ddprof-lib/src/main/cpp/callTraceHashTable.h
@@ -79,6 +79,19 @@ public:
   ~CallTraceHashTable();
 
   void clear();
+
+  /**
+   * Resets the hash table structure but defers memory deallocation.
+   * Returns a ChunkList containing the detached memory chunks.
+   * The caller must call LinearAllocator::freeChunks() on the returned
+   * ChunkList after processing is complete.
+   *
+   * This is used to fix use-after-free in processTraces(): the table
+   * structure is reset immediately (allowing rotation), but trace memory
+   * remains valid until the processor finishes accessing it.
+   */
+  ChunkList clearTableOnly();
+
   void collect(std::unordered_set<CallTrace *> &traces, std::function<void(CallTrace*)> trace_hook = nullptr);
 
   u64 put(int num_frames, ASGCT_CallFrame *frames, bool truncated, u64 weight);


### PR DESCRIPTION
**What does this PR do?**:
Here we address the (almost certain) last use-after-free bug in `CallTraceStorage` implementation

**Additional Notes**:
The gist of the fix is to make the `LinearAllocator` cleanup 2-phased - first just reset the allocator to start handing out new chunks and actually deallocate the previously used chunks only when it is safe, after the all the collected traces had been processed.

I have generated the reproducer test, hence the more verbose comments, but I think they might be useful for history keeping. The test is using ASAN poisoning and will reliably crash when run under ASAN.

**How to test the change?**:
Added a new gtest which is supposed to be run under ASAN.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-13156]

Unsure? Have a question? Request a review!


[PROF-13156]: https://datadoghq.atlassian.net/browse/PROF-13156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ