### PR TITLE
Always prepare reports

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -124,7 +124,7 @@ jobs:
           name: failures-glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64
           path: failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
       - name: Prepare reports
-        if: steps.set_enabled.outputs.enabled == 'true'
+        if: always() && steps.set_enabled.outputs.enabled == 'true'
         run: |
           .github/scripts/prepare_reports.sh
       - name: Upload unwinding reports
@@ -247,7 +247,7 @@ jobs:
           name: failures-musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64
           path: failures_musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
       - name: Prepare reports
-        if: steps.set_enabled.outputs.enabled == 'true'
+        if: always()
         run: |
           .github/scripts/prepare_reports.sh
       - name: Upload unwinding reports
@@ -378,7 +378,7 @@ jobs:
           name: failures-glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
           path: failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
       - name: Prepare reports
-        if: steps.set_enabled.outputs.enabled == 'true'
+        if: always() && steps.set_enabled.outputs.enabled == 'true'
         run: |
           .github/scripts/prepare_reports.sh
       - name: Upload unwinding reports
@@ -480,7 +480,7 @@ jobs:
            name: failures-musl-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
            path: failures_musl-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
        - name: Prepare reports
-         if: steps.set_enabled.outputs.enabled == 'true'
+         if: always()
          run: |
            .github/scripts/prepare_reports.sh
        - name: Upload unwinding reports


### PR DESCRIPTION
A trivial fix to always prepare reports.

The test reports are uploaded only on failure but they were generated only on success (default condition).

_Note:_ The perf regression was introduced in TLS priming and #303 is working on dealing with it

---
Unsure? Have a question? Request a review!
