### PR TITLE
Backport critical fixes to 1.34.4

### DIFF
--- a/ddprof-lib/src/main/cpp/callTraceHashTable.cpp
+++ b/ddprof-lib/src/main/cpp/callTraceHashTable.cpp
@@ -102,10 +102,10 @@ CallTraceHashTable::~CallTraceHashTable() {
 }
 
 
-void CallTraceHashTable::clear() {
-  // Wait for all hazard pointers to clear before deallocation to prevent races
+ChunkList CallTraceHashTable::clearTableOnly() {
+  // Wait for all hazard pointers to clear before detaching chunks
   HazardPointer::waitForAllHazardPointersToClear();
-  
+
   // Clear previous chain pointers to prevent traversal during deallocation
   for (LongHashTable *table = _table; table != nullptr; table = table->prev()) {
     LongHashTable *prev_table = table->prev();
@@ -113,13 +113,21 @@ void CallTraceHashTable::clear() {
       table->setPrev(nullptr);  // Clear link before deallocation
     }
   }
-  
-  // Now safe to deallocate all memory
-  _allocator.clear();
-  
-  // Reinitialize with fresh table
+
+  // Detach chunks for deferred deallocation - keeps trace memory alive
+  ChunkList detached_chunks = _allocator.detachChunks();
+
+  // Reinitialize with fresh table (using the new chunk from detachChunks)
   _table = LongHashTable::allocate(nullptr, INITIAL_CAPACITY, &_allocator);
   _overflow = 0;
+
+  return detached_chunks;
+}
+
+void CallTraceHashTable::clear() {
+  // Clear table and immediately free chunks (original behavior)
+  ChunkList chunks = clearTableOnly();
+  LinearAllocator::freeChunks(chunks);
 }
 
 // Adaptation of MurmurHash64A by Austin Appleby

--- a/ddprof-lib/src/main/cpp/callTraceHashTable.h
+++ b/ddprof-lib/src/main/cpp/callTraceHashTable.h
@@ -79,6 +79,19 @@ public:
   ~CallTraceHashTable();
 
   void clear();
+
+  /**
+   * Resets the hash table structure but defers memory deallocation.
+   * Returns a ChunkList containing the detached memory chunks.
+   * The caller must call LinearAllocator::freeChunks() on the returned
+   * ChunkList after processing is complete.
+   *
+   * This is used to fix use-after-free in processTraces(): the table
+   * structure is reset immediately (allowing rotation), but trace memory
+   * remains valid until the processor finishes accessing it.
+   */
+  ChunkList clearTableOnly();
+
   void collect(std::unordered_set<CallTrace *> &traces, std::function<void(CallTrace*)> trace_hook = nullptr);
 
   u64 put(int num_frames, ASGCT_CallFrame *frames, bool truncated, u64 weight);

--- a/ddprof-lib/src/main/cpp/codeCache.cpp
+++ b/ddprof-lib/src/main/cpp/codeCache.cpp
@@ -6,13 +6,15 @@
 #include "codeCache.h"
 #include "dwarf_dd.h"
 #include "os_dd.h"
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 
 char *NativeFunc::create(const char *name, short lib_index) {
-  NativeFunc *f = (NativeFunc *)malloc(sizeof(NativeFunc) + 1 + strlen(name));
+  size_t size = align_up(sizeof(NativeFunc) + 1 + strlen(name), sizeof(NativeFunc*));
+  NativeFunc *f = (NativeFunc *)aligned_alloc(sizeof(NativeFunc*), size);
   f->_lib_index = lib_index;
   f->_mark = 0;
   // cppcheck-suppress memleak

--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -6,6 +6,8 @@
 #ifndef _CODECACHE_H
 #define _CODECACHE_H
 
+#include "utils.h"
+
 #include <jvmti.h>
 #include <stdlib.h>
 #include <string.h>
@@ -62,7 +64,7 @@ public:
 
   static short libIndex(const char *name) {
     NativeFunc* func = from(name);
-    if (posix_memalign((void**)(&func), sizeof(NativeFunc*), sizeof(NativeFunc)) != 0) {
+    if (!is_aligned(func, sizeof(func))) {
       return -1;
     }
     return func->_lib_index;

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -40,8 +40,6 @@
 #include <vector>
 #include <unistd.h>
 
-static SpinLock _rec_lock(0);
-
 static const char *const SETTING_RING[] = {NULL, "kernel", "user", "any"};
 static const char *const SETTING_CSTACK[] = {NULL, "no", "fp", "dwarf", "lbr"};
 
@@ -1484,62 +1482,57 @@ Error FlightRecorder::newRecording(bool reset) {
     return Error("Could not open Flight Recorder output file");
   }
 
-  // Given some of reads are not protected by _rec_lock,
-  // we want to publish _rec with full fence, so that read
-  // side cannot see partially initialized recording.
-  Recording* tmp = new Recording(fd, _args);
-  __atomic_store_n(&_rec, tmp, __ATOMIC_SEQ_CST);
+  _rec = new Recording(fd, _args);
   return Error::OK;
 }
 
 void FlightRecorder::stop() {
   ExclusiveLockGuard locker(&_rec_lock);
-  if (_rec != NULL) {
-    volatile Recording *tmp = _rec;
+  Recording* rec = _rec;
+  if (rec != nullptr) {
     // NULL first, deallocate later
-    __atomic_store_n(&_rec, nullptr, __ATOMIC_RELAXED);
-    delete tmp;
+    _rec = nullptr;
+    delete rec;
   }
 }
 
 Error FlightRecorder::dump(const char *filename, const int length) {
   ExclusiveLockGuard locker(&_rec_lock);
-  if (_rec != NULL) {
+  Recording* rec = _rec;
+  if (rec != nullptr) {
     if (_filename.length() != length ||
         strncmp(filename, _filename.c_str(), length) != 0) {
       // if the filename to dump the recording to is specified move the current
       // working file there
       int copy_fd = open(filename, O_CREAT | O_RDWR | O_TRUNC, 0644);
-      _rec->switchChunk(copy_fd);
+      rec->switchChunk(copy_fd);
       close(copy_fd);
-    } else {
-      return Error(
-          "Can not dump recording to itself. Provide a different file name!");
+      return Error::OK;
     }
-
-    return Error::OK;
-  } else {
-    return Error("No active recording");
+    return Error(
+      "Can not dump recording to itself. Provide a different file name!");
   }
+  return Error("No active recording");
 }
 
 void FlightRecorder::flush() {
   ExclusiveLockGuard locker(&_rec_lock);
-  if (_rec != NULL) {
-    jvmtiEnv *jvmti = VM::jvmti();
-    JNIEnv *env = VM::jni();
+  Recording* rec = _rec;
+  if (rec != nullptr) {
+    jvmtiEnv* jvmti = VM::jvmti();
+    JNIEnv* env = VM::jni();
 
-    jclass **classes = NULL;
+    jclass** classes = NULL;
     jint count = 0;
     // obtaining the class list will create local refs to all loaded classes,
     // effectively preventing them from being unloaded while flushing
     jvmtiError err = jvmti->GetLoadedClasses(&count, classes);
-    _rec->switchChunk(-1);
+    rec->switchChunk(-1);
     if (!err) {
       // deallocate all loaded classes
       for (int i = 0; i < count; i++) {
-        env->DeleteLocalRef((jobject)classes[i]);
-        jvmti->Deallocate((unsigned char *)classes[i]);
+        env->DeleteLocalRef((jobject) classes[i]);
+        jvmti->Deallocate((unsigned char*) classes[i]);
       }
     }
   }
@@ -1547,96 +1540,119 @@ void FlightRecorder::flush() {
 
 void FlightRecorder::wallClockEpoch(int lock_index,
                                     WallClockEpochEvent *event) {
-  if (_rec != NULL) {
-    Buffer *buf = _rec->buffer(lock_index);
-    _rec->recordWallClockEpoch(buf, event);
+  OptionalSharedLockGuard locker(&_rec_lock);
+  if (locker.ownsLock()) {
+    Recording* rec = _rec;
+    if (rec != nullptr) {
+      Buffer *buf = rec->buffer(lock_index);
+      rec->recordWallClockEpoch(buf, event);
+    }
   }
 }
 
 void FlightRecorder::recordTraceRoot(int lock_index, int tid,
                                      TraceRootEvent *event) {
-  if (_rec != NULL) {
-    Buffer *buf = _rec->buffer(lock_index);
-    _rec->recordTraceRoot(buf, tid, event);
+  OptionalSharedLockGuard locker(&_rec_lock);
+  if (locker.ownsLock()) {
+    Recording* rec = _rec;
+    if (rec != nullptr) {
+      Buffer *buf = rec->buffer(lock_index);
+      rec->recordTraceRoot(buf, tid, event);
+    }
   }
 }
 
 void FlightRecorder::recordQueueTime(int lock_index, int tid,
                                      QueueTimeEvent *event) {
-  if (_rec != NULL) {
-    Buffer *buf = _rec->buffer(lock_index);
-    _rec->recordQueueTime(buf, tid, event);
+  OptionalSharedLockGuard locker(&_rec_lock);
+  if (locker.ownsLock()) {
+    Recording* rec = _rec;
+    if (rec != nullptr) {
+      Buffer *buf = rec->buffer(lock_index);
+      rec->recordQueueTime(buf, tid, event);
+    }
   }
 }
 
 void FlightRecorder::recordDatadogSetting(int lock_index, int length,
                                           const char *name, const char *value,
                                           const char *unit) {
-  if (_rec != NULL) {
-    Buffer *buf = _rec->buffer(lock_index);
-    _rec->writeDatadogSetting(buf, length, name, value, unit);
+  OptionalSharedLockGuard locker(&_rec_lock);
+  if (locker.ownsLock()) {
+    Recording* rec = _rec;
+    if (rec != nullptr) {
+      Buffer *buf = rec->buffer(lock_index);
+      rec->writeDatadogSetting(buf, length, name, value, unit);
+    }
   }
 }
 
 void FlightRecorder::recordHeapUsage(int lock_index, long value, bool live) {
-  if (_rec != NULL) {
-    Buffer *buf = _rec->buffer(lock_index);
-    _rec->writeHeapUsage(buf, value, live);
+  OptionalSharedLockGuard locker(&_rec_lock);
+  if (locker.ownsLock()) {
+    Recording* rec = _rec;
+    if (rec != nullptr) {
+      Buffer *buf = rec->buffer(lock_index);
+      rec->writeHeapUsage(buf, value, live);
+    }
   }
 }
 
 void FlightRecorder::recordEvent(int lock_index, int tid, u64 call_trace_id,
                                  int event_type, Event *event) {
-  if (_rec != NULL) {
-    RecordingBuffer *buf = _rec->buffer(lock_index);
-    switch (event_type) {
-    case 0:
-      _rec->recordExecutionSample(buf, tid, call_trace_id,
+  OptionalSharedLockGuard locker(&_rec_lock);
+  if (locker.ownsLock()) {
+    Recording* rec = _rec;
+    if (rec != nullptr) {
+      RecordingBuffer *buf = rec->buffer(lock_index);
+      switch (event_type) {
+      case 0:
+          rec->recordExecutionSample(buf, tid, call_trace_id,
+                                     (ExecutionEvent *)event);
+          break;
+        case BCI_WALL:
+          rec->recordMethodSample(buf, tid, call_trace_id,
                                   (ExecutionEvent *)event);
-      break;
-    case BCI_WALL:
-      _rec->recordMethodSample(buf, tid, call_trace_id,
-                               (ExecutionEvent *)event);
-      break;
-    case BCI_ALLOC:
-      _rec->recordAllocation(buf, tid, call_trace_id, (AllocEvent *)event);
-      break;
-    case BCI_LIVENESS:
-      _rec->recordHeapLiveObject(buf, tid, call_trace_id,
-                                 (ObjectLivenessEvent *)event);
-      break;
-    case BCI_LOCK:
-      _rec->recordMonitorBlocked(buf, tid, call_trace_id, (LockEvent *)event);
-      break;
-    case BCI_PARK:
-      _rec->recordThreadPark(buf, tid, call_trace_id, (LockEvent *)event);
-      break;
-    }
-    _rec->flushIfNeeded(buf);
-    _rec->addThread(lock_index, tid);
+          break;
+        case BCI_ALLOC:
+          rec->recordAllocation(buf, tid, call_trace_id, (AllocEvent *)event);
+          break;
+        case BCI_LIVENESS:
+          rec->recordHeapLiveObject(buf, tid, call_trace_id,
+                                    (ObjectLivenessEvent *)event);
+          break;
+        case BCI_LOCK:
+          rec->recordMonitorBlocked(buf, tid, call_trace_id, (LockEvent *)event);
+          break;
+        case BCI_PARK:
+          rec->recordThreadPark(buf, tid, call_trace_id, (LockEvent *)event);
+          break;
+        }
+        rec->flushIfNeeded(buf);
+        rec->addThread(lock_index, tid);
+      }
   }
 }
 
 void FlightRecorder::recordLog(LogLevel level, const char *message,
                                size_t len) {
-  if (!_rec_lock.tryLockShared()) {
-    // No active recording
-    return;
+  OptionalSharedLockGuard locker(&_rec_lock);
+  if (locker.ownsLock()) {
+    Recording* rec = _rec;
+    if (rec != nullptr) {
+      if (len > MAX_STRING_LENGTH)
+        len = MAX_STRING_LENGTH;
+      // cppcheck-suppress obsoleteFunctions
+      Buffer *buf = (Buffer *)alloca(len + 40);
+      buf->reset();
+
+      int start = buf->skip(5);
+      buf->putVar64(T_LOG);
+      buf->putVar64(TSC::ticks());
+      buf->putVar64(level);
+      buf->putUtf8(message, len);
+      buf->putVar32(start, buf->offset() - start);
+      _rec->flush(buf);
+    }
   }
-
-  if (len > MAX_STRING_LENGTH)
-    len = MAX_STRING_LENGTH;
-  // cppcheck-suppress obsoleteFunctions
-  Buffer *buf = (Buffer *)alloca(len + 40);
-  buf->reset();
-
-  int start = buf->skip(5);
-  buf->putVar64(T_LOG);
-  buf->putVar64(TSC::ticks());
-  buf->putVar64(level);
-  buf->putUtf8(message, len);
-  buf->putVar32(start, buf->offset() - start);
-  _rec->flush(buf);
-
-  _rec_lock.unlockShared();
 }

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -291,7 +291,9 @@ class FlightRecorder {
 private:
   std::string _filename;
   Arguments _args;
-  Recording* volatile _rec;
+
+  SpinLock _rec_lock;
+  Recording* _rec;
 
   Error newRecording(bool reset);
 

--- a/ddprof-lib/src/main/cpp/safeAccess.h
+++ b/ddprof-lib/src/main/cpp/safeAccess.h
@@ -45,11 +45,11 @@ public:
 
   static bool handle_safefetch(int sig, void* context);
 
-  static inline void *load(void **ptr) {
+  static inline void *load(void **ptr, void* default_value = nullptr) {
     return loadPtr(ptr, nullptr);
   }
 
-  static inline u32 load32(u32 *ptr, u32 default_value) {
+  static inline u32 load32(u32 *ptr, u32 default_value = 0) {
     int res = safefetch32_impl((int*)ptr, (int)default_value);
     return static_cast<u32>(res);
   }

--- a/ddprof-lib/src/main/cpp/utils.h
+++ b/ddprof-lib/src/main/cpp/utils.h
@@ -1,0 +1,35 @@
+#ifndef _UTILS_H
+#define _UTILS_H
+
+#include <cassert>
+#include <cstdint>
+#include <cstddef>
+
+inline bool is_power_of_2(size_t size) {
+    return size > 0 && (size & (size - 1)) == 0;
+}
+
+template <typename T>
+inline bool is_aligned(const T* ptr, size_t alignment) noexcept {
+    assert(is_power_of_2(alignment));
+    // Convert the pointer to an integer type
+    auto iptr = reinterpret_cast<uintptr_t>(ptr);
+
+    // Check if the integer value is a multiple of the alignment
+    return (iptr & ~(alignment - 1) == 0);
+}
+
+inline size_t align_down(size_t size, size_t alignment) noexcept {
+    assert(is_power_of_2(alignment));
+    return size & ~(alignment - 1);
+}
+
+inline size_t align_up(size_t size, size_t alignment) noexcept {
+    assert(is_power_of_2(alignment));
+    return align_down(size + alignment - 1, alignment);
+}
+
+
+
+
+#endif // _UTILS_H


### PR DESCRIPTION
Backport critical fixes for 1.34.4

Unfortunately, the TLS priming related changes I did earlier did cause performance overhead - it is addressed in https://github.com/DataDog/java-profiler/pull/303 but I would prefer delaying 1.35.0 until we have run all the changes there for a while and have the crash and deadlock preventing fixes be a part of 1.34.4