### PR TITLE
Instrument native threads

### DIFF
--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -226,12 +226,16 @@ public:
 
   CodeCache *operator[](int index) { return _libs[index]; }
 
-  int count() { return __atomic_load_n(&_count, __ATOMIC_ACQUIRE); }
+  int count() const { return __atomic_load_n(&_count, __ATOMIC_ACQUIRE); }
 
   void add(CodeCache *lib) {
     int index = __atomic_load_n(&_count, __ATOMIC_ACQUIRE);
     _libs[index] = lib;
     __atomic_store_n(&_count, index + 1, __ATOMIC_RELEASE);
+  }
+
+  CodeCache* at(int index) const {
+    return _libs[index];
   }
 
   long long memoryUsage() {

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -88,12 +88,13 @@ static Error patch_libraries() {
 
   const CodeCacheArray& native_libs = Libraries::instance()->native_libs();
   int count = 0;
-  size_t size = count * sizeof(PatchEntry);
+  int num_of_libs = native_libs.count();
+  size_t size = num_of_libs * sizeof(PatchEntry);
   patched_entries = (PatchEntry*)malloc(size);
   memset((void*)patched_entries, 0, size);
   TEST_LOG("Patching libraries");
 
-  for (int index = 0; index < native_libs.count(); index++) {
+  for (int index = 0; index < num_of_libs; index++) {
      CodeCache* lib = native_libs.at(index);
      // Don't patch self
      if (strcmp(lib->name(), info.dli_fname) == 0) {

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -142,10 +142,10 @@ static int pthread_setspecific_hook(pthread_key_t key, const void *value) {
   }
 }
 
-static Error patch_libraries_for_J9() {
+static Error patch_libraries_for_J9_or_musl() {
    CodeCache *lib = Libraries::instance()->findJvmLibrary("libj9thr");
    if (lib == nullptr) {
-     return Error("Cannot find J9 library to patch");
+     lib = VMStructs::libjvm();
    }
    void** func_location = lib->findImport(im_pthread_setspecific);
    if (func_location != nullptr) {
@@ -161,10 +161,10 @@ static Error patch_libraries_for_J9() {
 }
 
 static Error patch_libraries() {
-  if (VM::isHotspot() || VM::isZing()) {
+  if ((VM::isHotspot() || VM::isZing()) && !OS::isMusl()) {
     return patch_libraries_for_hotspot_or_zing();
   } else {
-    return patch_libraries_for_J9();
+    return patch_libraries_for_J9_or_musl();
   }
 }
 

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -138,9 +138,6 @@ static int pthread_setspecific_hook(pthread_key_t key, const void *value) {
 
 static Error patch_libraries_for_J9_or_musl() {
    CodeCache *lib = Libraries::instance()->findJvmLibrary("libj9thr");
-   if (lib == nullptr) {
-     lib = VMStructs::libjvm();
-   }
    void** func_location = lib->findImport(im_pthread_setspecific);
    if (func_location != nullptr) {
        patched_entries = (PatchEntry*)malloc(sizeof(PatchEntry));

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -118,7 +118,7 @@ static void unpatch_libraries() {
   int count = __atomic_load_n(&num_of_entries, __ATOMIC_RELAXED);
   PatchEntry* tmp = patched_entries;
   patched_entries = nullptr;
-  __atomic_store_n(&entry_count, 0, __ATOMIC_SEQ_CST);
+  __atomic_store_n(&num_of_entries, 0, __ATOMIC_SEQ_CST);
 
   for (int index = 0; index < count; index++) {
      if (tmp[index]._location != nullptr) {

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -33,15 +33,9 @@
 #define SIGEV_THREAD_ID 4
 #endif
 
-typedef int (*func_pthread_setspecific)(pthread_key_t key, const void *value);
-
 typedef void* (*func_start_routine)(void*);
-typedef int (*func_pthread_create)(pthread_t* thread,
-                                   const pthread_attr_t* attr,
-                                   func_start_routine start_routine,
-                                   void* arg);
 
-//  Patching libraries' pthread_create() @plt entries
+// Patch libraries' @plt entries
 typedef struct _patchEntry {
     // library's @plt location
     void** _location;

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -104,12 +104,12 @@ static Error patch_libraries_for_hotspot_or_zing() {
      }
 
      void** pthread_create_location = (void**)lib->findImport(im_pthread_create);
-     if (pthread_create_addr != nullptr) {
+     if (pthread_create_location != nullptr) {
        TEST_LOG("Patching %s", lib->name());
 
        patched_entries[count]._location = pthread_create_location;
        patched_entries[count]._func = (void*)__atomic_load_n(pthread_create_location, __ATOMIC_RELAXED);
-        __atomic_store_n(pthread_create_addr, (void*)pthread_create_hook, __ATOMIC_RELAXED);
+        __atomic_store_n(pthread_create_location, (void*)pthread_create_hook, __ATOMIC_RELAXED);
         count++;
      }
   }

--- a/ddprof-lib/src/main/cpp/libraries.h
+++ b/ddprof-lib/src/main/cpp/libraries.h
@@ -24,6 +24,10 @@ class Libraries {
     return &instance;
   }
 
+  const CodeCacheArray& native_libs() const {
+    return _native_libs;
+  }
+
   // Delete copy constructor and assignment operator to prevent copies
   Libraries(const Libraries&) = delete;
   Libraries& operator=(const Libraries&) = delete;

--- a/ddprof-lib/src/main/cpp/utils.h
+++ b/ddprof-lib/src/main/cpp/utils.h
@@ -16,12 +16,12 @@ inline bool is_aligned(const T* ptr, size_t alignment) noexcept {
     auto iptr = reinterpret_cast<uintptr_t>(ptr);
 
     // Check if the integer value is a multiple of the alignment
-    return (iptr & ~(alignment - 1) == 0);
+    return ((iptr & (~(alignment - 1))) == 0);
 }
 
 inline size_t align_down(size_t size, size_t alignment) noexcept {
     assert(is_power_of_2(alignment));
-    return size & ~(alignment - 1);
+    return size & (~(alignment - 1));
 }
 
 inline size_t align_up(size_t size, size_t alignment) noexcept {

--- a/ddprof-test/build.gradle
+++ b/ddprof-test/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'java'
+  id 'java-library'
   id 'application'
 }
 
@@ -7,7 +8,54 @@ repositories {
   mavenCentral()
 }
 
+// 1. Define paths and properties
+def nativeSrcDir = file('src/test/cpp')
+def jniHeadersDir = layout.buildDirectory.dir("generated/jni-headers").get().asFile
+def outputLibDir = layout.buildDirectory.dir("libs/native").get().asFile
+// Define the name of your JNI library (e.g., "ddproftest" becomes libddproftest.so/ddproftest.dll/libddproftest.dylib)
+def libraryName = "ddproftest"
+
+// Determine OS-specific file extensions and library names
+def osName = org.gradle.internal.os.OperatingSystem.current()
+def libFileExtension = (os().isMacOsX() ? "dylib" : "so")
+def libraryFileName = "lib${libraryName}.${libFileExtension}"
+
+// 2. Generate JNI headers using javac
+tasks.named('compileJava') {
+  // Tell javac to generate the JNI headers into the specified directory
+  options.compilerArgs += ['-h', jniHeadersDir]
+}
+
+// 3. Define a task to compile the native code
+tasks.register('buildNativeJniLibrary', Exec) {
+  description 'Compiles the JNI C/C++ sources into a shared library'
+  group 'build'
+
+  // Ensure Java compilation (and thus header generation) happens first
+  dependsOn tasks.named('compileJava')
+
+  // Clean up previous build artifacts
+  doFirst {
+    outputLibDir.mkdirs()
+  }
+
+  // Assume GCC/Clang on Linux/macOS
+  commandLine 'gcc'
+  args "-I${System.getenv('JAVA_HOME')}/include" // Standard JNI includes
+  if (os().isMacOsX()) {
+    args "-I${System.getenv('JAVA_HOME')}/include/darwin" // macOS-specific includes
+    args "-dynamiclib" // Build a dynamic library on macOS
+  } else if (os().isLinux()) {
+    args "-I${System.getenv('JAVA_HOME')}/include/linux" // Linux-specific includes
+    args "-fPIC"
+    args "-shared" // Build a shared library on Linux
+  }
+  args nativeSrcDir.listFiles()*.getAbsolutePath() // Source files
+  args "-o", "${outputLibDir.absolutePath}/${libraryFileName}" // Output file path
+}
+
 apply from: rootProject.file('common.gradle')
+
 
 def addCommonTestDependencies(Configuration configuration) {
   configuration.dependencies.add(project.dependencies.create('org.junit.jupiter:junit-jupiter-api:5.9.2'))
@@ -130,7 +178,7 @@ buildConfigurations.each { config ->
 
       jvmArgs '-Djdk.attach.allowAttachSelf', '-Djol.tryWithSudo=true',
         '-XX:ErrorFile=build/hs_err_pid%p.log', '-XX:+ResizeTLAB',
-        '-Xmx512m'
+        '-Xmx1G'
     }
 
     // Configure arguments for runUnwindingValidator task
@@ -217,6 +265,8 @@ task unwindingReport {
 }
 
 tasks.withType(Test).configureEach {
+  dependsOn tasks.named('buildNativeJniLibrary')
+
   // this is a shared configuration for all test tasks
   onlyIf {
     !project.hasProperty('skip-tests')
@@ -229,7 +279,7 @@ tasks.withType(Test).configureEach {
 
   jvmArgs "-Dddprof_test.keep_jfrs=${keepRecordings}", '-Djdk.attach.allowAttachSelf', '-Djol.tryWithSudo=true',
     "-Dddprof_test.config=${config}", "-Dddprof_test.ci=${project.hasProperty('CI')}", "-Dddprof.disable_unsafe=true", '-XX:ErrorFile=build/hs_err_pid%p.log', '-XX:+ResizeTLAB',
-    '-Xmx512m', '-XX:OnError=/tmp/do_stuff.sh'
+    '-Xmx512m', '-XX:OnError=/tmp/do_stuff.sh', "-Djava.library.path=${outputLibDir.absolutePath}"
 
   def javaHome = System.getenv("JAVA_TEST_HOME")
   if (javaHome == null) {

--- a/ddprof-test/build.gradle
+++ b/ddprof-test/build.gradle
@@ -178,7 +178,7 @@ buildConfigurations.each { config ->
 
       jvmArgs '-Djdk.attach.allowAttachSelf', '-Djol.tryWithSudo=true',
         '-XX:ErrorFile=build/hs_err_pid%p.log', '-XX:+ResizeTLAB',
-        '-Xmx1G'
+        '-Xmx512m'
     }
 
     // Configure arguments for runUnwindingValidator task

--- a/ddprof-test/src/test/cpp/nativethread.c
+++ b/ddprof-test/src/test/cpp/nativethread.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025, Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <pthread.h>
+#include <stdio.h>
+
+#include <jni.h>
+
+#define MAX_PRIME 100000
+
+// Burn CPU
+static void do_primes() {
+    unsigned long i, num, primes = 0;
+    for (num = 1; num <= MAX_PRIME; ++num) {
+        for (i = 2; (i <= num) && (num % i != 0); ++i);
+        if (i == num)
+            ++primes;
+    }
+}
+
+// Function to be executed by the new thread
+void* thread_function(void* arg) {
+    do_primes();
+    pthread_exit(NULL); // Terminate the thread, optionally returning a value
+}
+
+jlong JNICALL Java_com_datadoghq_profiler_nativethread_NativeThreadTest_createNativeThread
+  (JNIEnv * env, jclass clz) {
+
+    // Create a new thread
+    // Arguments:
+    // 1. &thread_id: Pointer to the pthread_t variable where the new thread's ID will be stored.
+    // 2. NULL: Pointer to thread attributes (using default attributes here).
+    // 3. thread_function: Pointer to the function the new thread will execute.
+    // 4. NULL: Pointer to the argument to pass to the thread_function.
+     pthread_t thread_id;
+    int result = pthread_create(&thread_id, NULL, thread_function, NULL);
+
+    if (result != 0) {
+        perror("Error creating thread");
+        return -1L;
+    }
+
+    return (jlong) thread_id;
+}
+
+void JNICALL Java_com_datadoghq_profiler_nativethread_NativeThreadTest_waitNativeThread
+  (JNIEnv * env, jclass clz, jlong threadId) {
+    pthread_t thread_id = (pthread_t)threadId;
+    // Wait for the created thread to finish
+    // Arguments:
+    // 1. thread_id: The ID of the thread to wait for.
+    // 2. NULL: Pointer to store the return value of the joined thread (not used here).
+    pthread_join(thread_id, NULL);
+}

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
@@ -35,7 +35,7 @@ public class NativeThreadTest extends AbstractProfilerTest {
 
   @Override
   protected String getProfilerCommand() {
-    return "cpu=1ms";
+    return "cpu=1ms,cstack=fp";
   }
 
   @RetryingTest(3)

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
@@ -35,7 +35,7 @@ public class NativeThreadTest extends AbstractProfilerTest {
 
   @Override
   protected String getProfilerCommand() {
-    return "cpu=1ms,cstack=dwarf";
+    return "cpu=1ms";
   }
 
   @RetryingTest(3)

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
@@ -35,7 +35,7 @@ public class NativeThreadTest extends AbstractProfilerTest {
 
   @Override
   protected String getProfilerCommand() {
-    return "cpu=1ms,cstack=fp";
+    return "cpu=1ms,cstack=dwarf";
   }
 
   @RetryingTest(3)

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
@@ -43,7 +43,7 @@ public class NativeThreadTest extends AbstractProfilerTest {
   @RetryingTest(3)
   public void test() {
       // Exclude J9 for now
-      if (Platform.isJ9()) {
+      if (Platform.isJ9() || Platform.isMusl()) {
           return;
       }
       long[] threads = new long[8];

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025, Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.profiler.nativethread;
+
+import com.datadoghq.profiler.AbstractProfilerTest;
+import org.junitpioneer.jupiter.RetryingTest;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IItemIterable;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
+
+import java.util.HashMap;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class NativeThreadTest extends AbstractProfilerTest {
+
+  static {
+      System.loadLibrary("ddproftest");
+  }
+
+  @Override
+  protected String getProfilerCommand() {
+    return "cpu=1ms";
+  }
+
+  @RetryingTest(3)
+  public void test() {
+      long[] threads = new long[8];
+      for (int index = 0; index < threads.length; index++) {
+          threads[index] = createNativeThread();
+      }
+
+      for (int index = 0; index < threads.length; index++) {
+          waitNativeThread(threads[index]);
+      }
+      stopProfiler();
+      int count = 0;
+      boolean stacktrace_printed = false;
+      for (IItemIterable cpuSamples : verifyEvents("datadog.ExecutionSample")) {
+          IMemberAccessor<String, IItem> stacktraceAccessor = JdkAttributes.STACK_TRACE_STRING.getAccessor(cpuSamples.getType());
+          IMemberAccessor<String, IItem> modeAccessor = THREAD_EXECUTION_MODE.getAccessor(cpuSamples.getType());
+          for (IItem item : cpuSamples) {
+              String stacktrace = stacktraceAccessor.getMember(item);
+              if (stacktrace.indexOf("do_primes()") != -1) {
+                if (!stacktrace_printed) {
+                    stacktrace_printed = true;
+                    System.out.println("Native thread stack:");
+                    System.out.println(stacktrace);
+                }
+                count++;
+              }
+          }
+      }
+      assertTrue(count > 0, "no native thread sample");
+  }
+
+  private static native long createNativeThread();
+  private static native void waitNativeThread(long threadId);
+}

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
@@ -16,6 +16,8 @@
 package com.datadoghq.profiler.nativethread;
 
 import com.datadoghq.profiler.AbstractProfilerTest;
+import com.datadoghq.profiler.Platform;
+
 import org.junitpioneer.jupiter.RetryingTest;
 import org.openjdk.jmc.common.item.IItem;
 import org.openjdk.jmc.common.item.IItemIterable;
@@ -40,6 +42,10 @@ public class NativeThreadTest extends AbstractProfilerTest {
 
   @RetryingTest(3)
   public void test() {
+      // Exclude J9 for now
+      if (Platform.isJ9()) {
+          return;
+      }
       long[] threads = new long[8];
       for (int index = 0; index < threads.length; index++) {
           threads[index] = createNativeThread();


### PR DESCRIPTION
**What does this PR do?**:
Instrument/profile native threads, the threads that are created/started outside of JVM, on hotspot/non-musl based JVM. 

**Motivation**:
Enhance Java profiler to profiler native threads.

**Additional Notes**:
The feature is now only enabled for hotspot based JVM running on non-musl Linux platform. The reasons:
- A crash seen on aarch64/musl /JDK11. It might not be related to this change, but it is hard to confirm. Disable the feature for musl based Linux for now.
- J9 has issues to walk native only thread stack in release build, it shows only
` .no_java_frame`
 while debug build shows correct stack.

**How to test the change?**:
- Regular tests 
- JDK tier1 tests with profiler agent. Although, there are failures, but match java-profiler main line.
   There are failures that are expected:
    * `HeapMonitor` uses agent, which conflicts with profiler agent
    * Compiler frame is not compatible with agent.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [X] JIRA: [PROF-11577](https://datadoghq.atlassian.net/browse/PROF-11577)

Unsure? Have a question? Request a review!


[PROF-11577]: https://datadoghq.atlassian.net/browse/PROF-11577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ