### PR TITLE
Validate javadoc early in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clang-format-11
-          # we need this to make sure we are actually using clang-format v. 11 
+          # we need this to make sure we are actually using clang-format v. 11
           sudo mv /usr/bin/clang-format /usr/bin/clang-format-14
           sudo mv /usr/bin/clang-format-11 /usr/bin/clang-format
 
@@ -75,6 +75,55 @@ jobs:
       - name: Check
         run: |
           ./gradlew spotlessCheck --no-daemon --parallel --build-cache --no-watch-fs
+
+  check-javadoc:
+    runs-on: ubuntu-22.04
+    needs: check-for-pr
+    if: needs.check-for-pr.outputs.skip != 'true'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: Setup OS
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl zip unzip binutils
+
+      - name: Cache Gradle Wrapper Binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/wrapper/dists
+          key: gradle-wrapper-${{ runner.os }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-wrapper-${{ runner.os }}-
+
+      - name: Cache Gradle User Home
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: gradle-caches-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-caches-${{ runner.os }}-
+
+      - name: Cache async-profiler
+        uses: actions/cache@v4
+        with:
+          path: ddprof-lib/build/async-profiler
+          key: async-profiler-${{ runner.os }}-${{ hashFiles('gradle/lock.properties') }}
+          enableCrossOsArchive: true
+          restore-keys: |
+            async-profiler-${{ runner.os }}-
+
+      - name: Validate Javadoc
+        run: |
+          # Note: javadoc task depends on copyReleaseLibs which requires building native libraries
+          # This ensures javadoc validation matches the exact conditions used during publishing
+          ./gradlew :ddprof-lib:javadoc --no-daemon --parallel --build-cache --no-watch-fs
 
   test-matrix:
     needs: check-formatting

--- a/ddprof-lib/build.gradle
+++ b/ddprof-lib/build.gradle
@@ -695,6 +695,11 @@ tasks.register('sourcesJar', Jar) {
   archiveVersion = component_version
 }
 
+tasks.withType(Javadoc).configureEach {
+  // Allow javadoc to access internal sun.nio.ch package used by BufferWriter8
+  options.addStringOption('-add-exports', 'java.base/sun.nio.ch=ALL-UNNAMED')
+}
+
 tasks.register('javadocJar', Jar) {
   dependsOn javadoc
   archiveBaseName = libraryName


### PR DESCRIPTION
**What does this PR do?**:
Adds early validation of javadoc target

**Motivation**:
Prevent wasted time when we discover that javadocs are not 'as-expected' only during publishing phase, late in the release process.


Unsure? Have a question? Request a review!
