### PR TITLE
Remove inotify-based TLS priming thread directory watcher

### DIFF
--- a/ddprof-lib/src/main/cpp/os_dd.h
+++ b/ddprof-lib/src/main/cpp/os_dd.h
@@ -24,9 +24,7 @@ public:
   static void uninstallTlsPrimeSignalHandler(int signal_num);
   static void enumerateThreadIds(const std::function<void(int)>& callback);
   static void signalThread(int tid, int signum);
-  static bool startThreadDirectoryWatcher(const std::function<void(int)>& on_new_thread, const std::function<void(int)>& on_dead_thread);
   static int getThreadCount();
-  static void stopThreadDirectoryWatcher();
 };
 }
 #endif // _OS_DD_H

--- a/ddprof-lib/src/main/cpp/os_linux_dd.cpp
+++ b/ddprof-lib/src/main/cpp/os_linux_dd.cpp
@@ -6,14 +6,11 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/syscall.h>
-#include <sys/inotify.h>
 #include <dirent.h>
 #include <errno.h>
-#include <pthread.h>
-#include <atomic>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
-#include <memory>
 
 #ifndef __musl__
 #include <malloc.h>
@@ -24,43 +21,6 @@
 #else
 #define MMAP_SYSCALL __NR_mmap2
 #endif
-
-// Thread directory watcher state
-static std::atomic<bool> g_watcher_running{false};
-static std::atomic<int> g_watcher_fd{-1};
-static pthread_t g_watcher_thread;
-static std::atomic<bool> g_watcher_thread_created{false};
-static std::function<void(int)> g_on_new_thread;
-static std::function<void(int)> g_on_dead_thread;
-
-static void* threadDirectoryWatcherLoop(void* arg);
-
-// Fork handler to reset watcher state in child process
-static void resetWatcherStateInChild() {
-  // After fork(), child process doesn't have the watcher thread
-  // Reset all state to prevent deadlock when child tries to cleanup
-  g_watcher_running.store(false);
-  g_watcher_thread_created.store(false);
-
-  // Close the inherited fd in child to prevent issues
-  int fd = g_watcher_fd.exchange(-1);
-  if (fd >= 0) {
-    close(fd);
-  }
-
-  // Clear callback functions to prevent accidental invocation
-  g_on_new_thread = nullptr;
-  g_on_dead_thread = nullptr;
-}
-
-// Register fork handler on first use
-static void ensureForkHandlerRegistered() {
-  static bool registered = false;
-  if (!registered) {
-    pthread_atfork(nullptr, nullptr, resetWatcherStateInChild);
-    registered = true;
-  }
-}
 
 int ddprof::OS::truncateFile(int fd) {
   int rslt = ftruncate(fd, 0);
@@ -174,136 +134,6 @@ int ddprof::OS::getThreadCount() {
   }
   fclose(status);
   return thread_count;
-}
-
-bool ddprof::OS::startThreadDirectoryWatcher(const std::function<void(int)>& on_new_thread, const std::function<void(int)>& on_dead_thread) {
-  // Ensure fork handler is registered to prevent deadlock in child processes
-  ensureForkHandlerRegistered();
-
-  if (g_watcher_running.load()) {
-    return true; // Already running
-  }
-
-  int inotify_fd = inotify_init1(IN_CLOEXEC | IN_NONBLOCK);
-  if (inotify_fd == -1) {
-    TEST_LOG("Failed to initialize inotify: %s", strerror(errno));
-    return false;
-  }
-
-  int watch_fd = inotify_add_watch(inotify_fd, "/proc/self/task", IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO);
-  if (watch_fd == -1) {
-    TEST_LOG("Failed to add inotify watch on /proc/self/task: %s", strerror(errno));
-    close(inotify_fd);
-    return false;
-  }
-
-  g_on_new_thread = on_new_thread;
-  g_on_dead_thread = on_dead_thread;
-  g_watcher_fd.store(inotify_fd);
-  g_watcher_running.store(true);
-
-  if (pthread_create(&g_watcher_thread, nullptr, threadDirectoryWatcherLoop, nullptr) != 0) {
-    TEST_LOG("Failed to create thread directory watcher thread: %s", strerror(errno));
-    g_watcher_running.store(false);
-    g_watcher_fd.store(-1);
-    close(inotify_fd);
-    return false;
-  }
-
-  g_watcher_thread_created.store(true);
-  TEST_LOG("Started thread directory watcher (thread will be joined on cleanup)");
-  return true;
-}
-
-void ddprof::OS::stopThreadDirectoryWatcher() {
-  if (!g_watcher_running.load()) {
-    return;
-  }
-
-  TEST_LOG("Stopping thread directory watcher...");
-
-  // Signal the watcher thread to stop
-  g_watcher_running.store(false);
-
-  // Close the inotify fd to wake up select()
-  int fd = g_watcher_fd.exchange(-1);
-  if (fd >= 0) {
-    close(fd);
-  }
-
-  // Wait for the watcher thread to actually terminate
-  if (g_watcher_thread_created.load()) {
-    TEST_LOG("Waiting for watcher thread to terminate...");
-    void* retval;
-    int join_result = pthread_join(g_watcher_thread, &retval);
-    if (join_result != 0) {
-      TEST_LOG("Failed to join watcher thread: %s", strerror(join_result));
-    } else {
-      TEST_LOG("Watcher thread terminated successfully");
-    }
-    g_watcher_thread_created.store(false);
-  }
-
-  TEST_LOG("Thread directory watcher stopped");
-}
-
-static void* threadDirectoryWatcherLoop(void* arg) {
-  const int fd = g_watcher_fd.load();
-  if (fd < 0) return nullptr;
-
-  char buffer[4096];
-  fd_set readfds;
-  struct timeval timeout;
-
-  while (g_watcher_running.load()) {
-    FD_ZERO(&readfds);
-    FD_SET(fd, &readfds);
-    timeout.tv_sec = 1;
-    timeout.tv_usec = 0;
-
-    int ret = select(fd + 1, &readfds, nullptr, nullptr, &timeout);
-    if (ret < 0) {
-      if (errno != EINTR) {
-        TEST_LOG("Thread directory watcher select failed: %s", strerror(errno));
-        break;
-      }
-      continue;
-    }
-
-    if (ret == 0) continue; // Timeout, check running flag
-
-    ssize_t len = read(fd, buffer, sizeof(buffer));
-    if (len <= 0) {
-      if (len < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
-        TEST_LOG("Thread directory watcher read failed: %s", strerror(errno));
-        break;
-      }
-      continue;
-    }
-
-    // Parse inotify events
-    for (ssize_t i = 0; i < len;) {
-      struct inotify_event *event = (struct inotify_event *)(buffer + i);
-
-      if (event->mask & IN_Q_OVERFLOW) {
-        TEST_LOG("Thread directory watcher queue overflow, triggering full rescan");
-        // TODO: Trigger full rescan callback
-      } else if (event->len > 0 && event->name[0] >= '1' && event->name[0] <= '9') {
-        int tid = atoi(event->name);
-        if (tid > 0) {
-          if (event->mask & (IN_CREATE | IN_MOVED_TO)) {
-            if (g_on_new_thread) g_on_new_thread(tid);
-          } else if (event->mask & (IN_DELETE | IN_MOVED_FROM)) {
-            if (g_on_dead_thread) g_on_dead_thread(tid);
-          }
-        }
-      }
-
-      i += sizeof(struct inotify_event) + event->len;
-    }
-  }
-
-  return nullptr;
 }
 
 #endif // __linux__

--- a/ddprof-lib/src/main/cpp/os_macos_dd.cpp
+++ b/ddprof-lib/src/main/cpp/os_macos_dd.cpp
@@ -75,36 +75,28 @@ void ddprof::OS::enumerateThreadIds(const std::function<void(int)>& callback) {
 void ddprof::OS::signalThread(int tid, int signum) {
   // On macOS, tid is actually a mach thread port
   thread_t thread = static_cast<thread_t>(tid);
-  
+
   // Convert mach thread to pthread for signaling
   // This is a limitation - we can't easily signal arbitrary mach threads
   // In practice, this is mainly used for TLS priming which is disabled on macOS
   TEST_LOG("Thread signaling not fully supported on macOS (thread=%d, signal=%d)", tid, signum);
 }
 
-bool ddprof::OS::startThreadDirectoryWatcher(const std::function<void(int)>& on_new_thread, const std::function<void(int)>& on_dead_thread) {
-  return false; // Thread directory watching not supported on macOS
-}
-
 int ddprof::OS::getThreadCount() {
   task_t task = mach_task_self();
   thread_act_array_t thread_list;
   mach_msg_type_number_t thread_count;
-  
+
   kern_return_t kr = task_threads(task, &thread_list, &thread_count);
   if (kr != KERN_SUCCESS) {
     TEST_LOG("Failed to get thread count: %d", kr);
     return 0;
   }
-  
+
   // Clean up
   vm_deallocate(task, (vm_address_t)thread_list, thread_count * sizeof(thread_t));
-  
-  return static_cast<int>(thread_count);
-}
 
-void ddprof::OS::stopThreadDirectoryWatcher() {
-  // No-op on macOS
+  return static_cast<int>(thread_count);
 }
 
 #endif // __APPLE__


### PR DESCRIPTION
**What does this PR do?**:
Removes the inotify-based thread directory watcher from the TLS priming system. This includes removing the `startThreadDirectoryWatcher()` and `stopThreadDirectoryWatcher()` functions along with all associated implementation code across Linux and macOS platforms.

**Motivation**:
The filesystem-based thread monitoring using inotify was causing performance overhead in production environments. This functionality will be replaced with library patching in the near future, providing a more efficient approach to native thread TLS initialization.

**Additional Notes**:
- The TLS priming infrastructure for Java threads via JVMTI remains intact and fully functional
- Native threads will now use lazy initialization until lib patching is implemented
- All signal handler infrastructure remains available for future lib patching use
- Documentation has been updated to reflect these changes and document the removal rationale

Changes made:
- Removed watcher thread loop and inotify monitoring from `os_linux_dd.cpp`
- Removed watcher stubs from `os_macos_dd.cpp`
- Removed watcher function declarations from `os_dd.h`
- Updated `thread.cpp` to remove watcher initialization and cleanup calls
- Removed `ThreadDirectoryWatcher` test from `test_tlsPriming.cpp`
- Updated `TlsPriming.md` documentation to reflect the removal and document future direction

**How to test the change?**:
All C++ unit tests pass successfully, including the TLS priming tests:
- Built and ran `gtestDebug` - all 93 C++ unit tests passed
- TLS priming tests verify signal handler installation, thread enumeration, and signal delivery
- JVMTI-based thread initialization remains tested and functional

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!