### PR TITLE
Bump the AP lock to get the lib-ranges initialization fix

### DIFF
--- a/gradle/lock.properties
+++ b/gradle/lock.properties
@@ -1,5 +1,5 @@
 ap.branch=dd/master
-ap.commit=5cb62d0de28e179de6a28cd2b0ca83c9c0debdc7
+ap.commit=114bd43e91b910035978631492b46568989a6760
 
 ctx_branch=main
 ctx_commit=b33673d801b85a6c38fa0e9f1a139cb246737ce8


### PR DESCRIPTION
**What does this PR do?**:
It bumps the AP lock hack

**Motivation**:
We need to bring the fix from https://github.com/DataDog/async-profiler/pull/6 to Java profiler

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!
