### PR TITLE
Fix TLS re-entrancy crash in signal handlers

### DIFF
--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 Andrei Pangin
+ * Copyright 2025, Datadog, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -317,8 +318,22 @@ void CTimer::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
   ExecutionEvent event;
   VMThread *vm_thread = VMThread::current();
   if (vm_thread) {
-    event._execution_mode = VM::jni() != NULL
-                                ? convertJvmExecutionState(vm_thread->state())
+    // Check thread state to distinguish Java threads from JVM internal threads.
+    // Java threads have states in [4, 12) range (_thread_in_native to _thread_max_state).
+    // JVM internal threads (GC, Compiler) have state 0 or outside this range.
+    //
+    // We MUST NOT call VM::jni() here because it calls JavaVM->GetEnv(), which triggers
+    // __tls_get_addr for thread-local JNIEnv lookup. If the signal interrupts during
+    // TLS initialization (e.g., ForkJoinWorkerThread startup), this causes re-entrant
+    // TLS allocation and heap corruption.
+    //
+    // Thread states defined in OpenJDK:
+    // https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/globalDefinitions.hpp
+    // Search for "enum JavaThreadState"
+    int raw_thread_state = vm_thread->state();
+    bool is_java_thread = raw_thread_state >= 4 && raw_thread_state < 12;
+    event._execution_mode = is_java_thread
+                                ? convertJvmExecutionState(raw_thread_state)
                                 : ExecutionMode::JVM;
   }
   Profiler::instance()->recordSample(ucontext, _interval, tid, BCI_CPU, 0,

--- a/ddprof-lib/src/main/cpp/itimer.cpp
+++ b/ddprof-lib/src/main/cpp/itimer.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018 Andrei Pangin
+ * Copyright 2025, Datadog, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,8 +51,22 @@ void ITimer::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
   ExecutionEvent event;
   VMThread *vm_thread = VMThread::current();
   if (vm_thread) {
-    event._execution_mode = VM::jni() != NULL
-                                ? convertJvmExecutionState(vm_thread->state())
+    // Check thread state to distinguish Java threads from JVM internal threads.
+    // Java threads have states in [4, 12) range (_thread_in_native to _thread_max_state).
+    // JVM internal threads (GC, Compiler) have state 0 or outside this range.
+    //
+    // We MUST NOT call VM::jni() here because it calls JavaVM->GetEnv(), which triggers
+    // __tls_get_addr for thread-local JNIEnv lookup. If the signal interrupts during
+    // TLS initialization (e.g., ForkJoinWorkerThread startup), this causes re-entrant
+    // TLS allocation and heap corruption.
+    //
+    // Thread states defined in OpenJDK:
+    // https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/globalDefinitions.hpp
+    // Search for "enum JavaThreadState"
+    int raw_thread_state = vm_thread->state();
+    bool is_java_thread = raw_thread_state >= 4 && raw_thread_state < 12;
+    event._execution_mode = is_java_thread
+                                ? convertJvmExecutionState(raw_thread_state)
                                 : ExecutionMode::JVM;
   }
   Profiler::instance()->recordSample(ucontext, _interval, tid, BCI_CPU, 0,

--- a/ddprof-lib/src/main/cpp/itimer.cpp
+++ b/ddprof-lib/src/main/cpp/itimer.cpp
@@ -21,6 +21,7 @@
 #include "profiler.h"
 #include "stackWalker.h"
 #include "thread.h"
+#include "threadState.h"
 #include "vmStructs.h"
 #include "criticalSection.h"
 #include <sys/time.h>
@@ -50,25 +51,7 @@ void ITimer::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
 
   ExecutionEvent event;
   VMThread *vm_thread = VMThread::current();
-  if (vm_thread) {
-    // Check thread state to distinguish Java threads from JVM internal threads.
-    // Java threads have states in [4, 12) range (_thread_in_native to _thread_max_state).
-    // JVM internal threads (GC, Compiler) have state 0 or outside this range.
-    //
-    // We MUST NOT call VM::jni() here because it calls JavaVM->GetEnv(), which triggers
-    // __tls_get_addr for thread-local JNIEnv lookup. If the signal interrupts during
-    // TLS initialization (e.g., ForkJoinWorkerThread startup), this causes re-entrant
-    // TLS allocation and heap corruption.
-    //
-    // Thread states defined in OpenJDK:
-    // https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/globalDefinitions.hpp
-    // Search for "enum JavaThreadState"
-    int raw_thread_state = vm_thread->state();
-    bool is_java_thread = raw_thread_state >= 4 && raw_thread_state < 12;
-    event._execution_mode = is_java_thread
-                                ? convertJvmExecutionState(raw_thread_state)
-                                : ExecutionMode::JVM;
-  }
+  event._execution_mode = getThreadExecutionMode(vm_thread);
   Profiler::instance()->recordSample(ucontext, _interval, tid, BCI_CPU, 0,
                                      &event);
   Shims::instance().setSighandlerTid(-1);

--- a/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
+++ b/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
@@ -744,25 +744,7 @@ void PerfEvents::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
     u64 counter = readCounter(siginfo, ucontext);
     ExecutionEvent event;
     VMThread *vm_thread = VMThread::current();
-    if (vm_thread) {
-      // Check thread state to distinguish Java threads from JVM internal threads.
-      // Java threads have states in [4, 12) range (_thread_in_native to _thread_max_state).
-      // JVM internal threads (GC, Compiler) have state 0 or outside this range.
-      //
-      // We MUST NOT call VM::jni() here because it calls JavaVM->GetEnv(), which triggers
-      // __tls_get_addr for thread-local JNIEnv lookup. If the signal interrupts during
-      // TLS initialization (e.g., ForkJoinWorkerThread startup), this causes re-entrant
-      // TLS allocation and heap corruption.
-      //
-      // Thread states defined in OpenJDK:
-      // https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/globalDefinitions.hpp
-      // Search for "enum JavaThreadState"
-      int raw_thread_state = vm_thread->state();
-      bool is_java_thread = raw_thread_state >= 4 && raw_thread_state < 12;
-      event._execution_mode = is_java_thread
-                                  ? convertJvmExecutionState(raw_thread_state)
-                                  : ExecutionMode::JVM;
-    }
+    event._execution_mode = getThreadExecutionMode(vm_thread);
     Profiler::instance()->recordSample(ucontext, counter, tid, BCI_CPU, 0,
                                        &event);
     Shims::instance().setSighandlerTid(-1);

--- a/ddprof-lib/src/main/cpp/threadState.h
+++ b/ddprof-lib/src/main/cpp/threadState.h
@@ -67,7 +67,7 @@ static ExecutionMode convertJvmExecutionState(int state) {
  *         or the appropriate execution mode for Java threads
  */
 template<typename VMThreadType>
-static inline ExecutionMode getThreadExecutionMode(const VMThreadType* vm_thread) {
+static inline ExecutionMode getThreadExecutionMode(VMThreadType* vm_thread) {
   if (vm_thread == nullptr) {
     return ExecutionMode::UNKNOWN;
   }

--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -78,9 +78,21 @@ void WallClockASGCT::signalHandler(int signo, siginfo_t *siginfo, void *ucontext
 
   ExecutionEvent event;
   ddprof::VMThread *vm_thread = ddprof::VMThread::current();
-  bool is_java_thread = vm_thread && VM::jni();
-  int raw_thread_state = vm_thread && is_java_thread ? vm_thread->state() : 0;
-  bool is_initialized = raw_thread_state >= 4 && raw_thread_state < 12;
+  // Check thread state to distinguish Java threads from JVM internal threads.
+  // Java threads have states in [4, 12) range (_thread_in_native to _thread_max_state).
+  // JVM internal threads (GC, Compiler) have state 0 or outside this range.
+  //
+  // We MUST NOT call VM::jni() here because it calls JavaVM->GetEnv(), which triggers
+  // __tls_get_addr for thread-local JNIEnv lookup. If the signal interrupts during
+  // TLS initialization (e.g., ForkJoinWorkerThread startup), this causes re-entrant
+  // TLS allocation and heap corruption.
+  //
+  // Thread states defined in OpenJDK:
+  // https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/globalDefinitions.hpp
+  // Search for "enum JavaThreadState"
+  int raw_thread_state = vm_thread ? vm_thread->state() : 0;
+  bool is_java_thread = raw_thread_state >= 4 && raw_thread_state < 12;
+  bool is_initialized = is_java_thread;
   OSThreadState state = OSThreadState::UNKNOWN;
   ExecutionMode mode = ExecutionMode::UNKNOWN;
   if (vm_thread && is_initialized) {

--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -13,6 +13,7 @@
 #include "profiler.h"
 #include "stackFrame.h"
 #include "thread.h"
+#include "threadState.h"
 #include "vmStructs_dd.h"
 #include "criticalSection.h"
 #include <math.h>
@@ -78,18 +79,6 @@ void WallClockASGCT::signalHandler(int signo, siginfo_t *siginfo, void *ucontext
 
   ExecutionEvent event;
   ddprof::VMThread *vm_thread = ddprof::VMThread::current();
-  // Check thread state to distinguish Java threads from JVM internal threads.
-  // Java threads have states in [4, 12) range (_thread_in_native to _thread_max_state).
-  // JVM internal threads (GC, Compiler) have state 0 or outside this range.
-  //
-  // We MUST NOT call VM::jni() here because it calls JavaVM->GetEnv(), which triggers
-  // __tls_get_addr for thread-local JNIEnv lookup. If the signal interrupts during
-  // TLS initialization (e.g., ForkJoinWorkerThread startup), this causes re-entrant
-  // TLS allocation and heap corruption.
-  //
-  // Thread states defined in OpenJDK:
-  // https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/globalDefinitions.hpp
-  // Search for "enum JavaThreadState"
   int raw_thread_state = vm_thread ? vm_thread->state() : 0;
   bool is_java_thread = raw_thread_state >= 4 && raw_thread_state < 12;
   bool is_initialized = is_java_thread;
@@ -100,8 +89,7 @@ void WallClockASGCT::signalHandler(int signo, siginfo_t *siginfo, void *ucontext
     if (os_state != OSThreadState::UNKNOWN) {
       state = os_state;
     }
-    mode = is_java_thread ? convertJvmExecutionState(raw_thread_state)
-                          : ExecutionMode::JVM;
+    mode = getThreadExecutionMode(vm_thread);
   }
   if (state == OSThreadState::UNKNOWN) {
     if (inSyscall(ucontext)) {
@@ -251,7 +239,7 @@ void WallClockJVMTI::timerLoop() {
     } else {
       state = os_state;
     }
-    mode = convertJvmExecutionState(raw_thread_state);
+    mode = getThreadExecutionMode(vm_thread);
 
     event._thread_state = state;
     event._execution_mode = mode;


### PR DESCRIPTION
**What does this PR do?**:
Fixes a critical crash caused by re-entrant TLS allocation in CPU sampling signal handlers. Replaces `VM::jni()` calls with direct thread state checks to distinguish Java threads from JVM internal threads without triggering `__tls_get_addr`.

**Motivation**:
The profiler was crashing with heap corruption when SIGPROF interrupted ForkJoinWorkerThread during TLS initialization. The crash occurred because:
1. Thread interrupted during `__tls_get_addr` (TLS allocation)
2. Signal handler called `VM::jni()` → `JavaVM->GetEnv()` → `jni_GetEnv` → `__tls_get_addr`
3. Re-entrant call to `__tls_get_addr` corrupted heap metadata
4. Later `free()` crashed with corrupted heap

Stack trace showed:
```
C  [libc.so.6+0xadd55]  __libc_free+0x25
C  [ld-linux-x86-64.so.2+0x1785c]  __tls_get_addr+0x3c
V  [libjvm.so+0x9b6567]  jni_GetEnv+0x47
C  [libjavaProfiler...so+0x1d24a]  CTimer::signalHandler+0xea
C  [ld-linux-x86-64.so.2+0x1785c]  __tls_get_addr+0x3c  ← Re-entrant!
```

**Additional Notes**:
- Fixed in 4 signal handlers: CTimer, ITimer, PerfEvents, WallClock
- Thread state range [4, 12) corresponds to Java threads (_thread_in_native to _thread_max_state)
- Direct memory read of `vm_thread->state()` is async-signal-safe
- Added detailed comments with OpenJDK reference links

**How to test the change?**:
The crash is race-condition dependent and hard to reproduce deterministically. Testing requires:
1. Running with ZGC (which has more TLS usage)
2. High-frequency CPU sampling during ForkJoinPool thread creation
3. Extended stress testing under load

The fix has been validated through:
- Code review against async-signal-safety requirements
- Verification that thread state checks match wallClock.cpp existing pattern
- Confirmation that no TLS access occurs in signal handlers

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-13176]


[PROF-13176]: https://datadoghq.atlassian.net/browse/PROF-13176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ