### PR TITLE
Patch libraries for instrumenting native threads

### DIFF
--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -23,7 +23,6 @@
 #include "profiler.h"
 #include "vmStructs.h"
 #include <assert.h>
-#include <dlfcn.h>
 #include <stdlib.h>
 #include <sys/syscall.h>
 #include <time.h>
@@ -32,150 +31,6 @@
 #ifndef SIGEV_THREAD_ID
 #define SIGEV_THREAD_ID 4
 #endif
-
-typedef void* (*func_start_routine)(void*);
-
-// Patch libraries' @plt entries
-typedef struct _patchEntry {
-    // library's @plt location
-    void** _location;
-    // original function
-    void*  _func;
-} PatchEntry;
-
-static PatchEntry* patched_entries = nullptr;
-static volatile int num_of_entries = 0;
-
-typedef struct _startRoutineArg {
-    func_start_routine _func;
-    void*              _arg;
-} StartRoutineArg;
-
-static void* start_routine_wrapper(void* args) {
-    StartRoutineArg* data = (StartRoutineArg*)args;
-    ProfiledThread::initCurrentThread();
-    int tid = ProfiledThread::currentTid();
-    Profiler::registerThread(tid);
-    void* result = data->_func(data->_arg);
-    Profiler::unregisterThread(tid);
-    ProfiledThread::release();
-    free(args);
-    return result;
-}
-
-static int pthread_create_hook(pthread_t* thread,
-                          const pthread_attr_t* attr,
-                          func_start_routine start_routine,
-                          void* arg) {
-  StartRoutineArg* data = (StartRoutineArg*)malloc(sizeof(StartRoutineArg));
-  data->_func = start_routine;
-  data->_arg = arg;
-  return pthread_create(thread, attr, start_routine_wrapper, (void*)data);
-}
-
-static Error patch_libraries_for_hotspot_or_zing() {
-   Dl_info info;
-   void* caller_address = __builtin_return_address(0); // Get return address of caller
-
-   if (!dladdr(caller_address, &info)) {
-      return Error("Cannot resolve current library name");
-   }
-   TEST_LOG("Profiler library name: %s", info.dli_fname );
-
-  const CodeCacheArray& native_libs = Libraries::instance()->native_libs();
-  int count = 0;
-  int num_of_libs = native_libs.count();
-  size_t size = num_of_libs * sizeof(PatchEntry);
-  patched_entries = (PatchEntry*)malloc(size);
-  memset((void*)patched_entries, 0, size);
-  TEST_LOG("Patching libraries");
-
-  for (int index = 0; index < num_of_libs; index++) {
-     CodeCache* lib = native_libs.at(index);
-     // Don't patch self
-     if (strcmp(lib->name(), info.dli_fname) == 0) {
-        continue;
-     }
-
-     void** pthread_create_location = (void**)lib->findImport(im_pthread_create);
-     if (pthread_create_location != nullptr) {
-       TEST_LOG("Patching %s", lib->name());
-
-       patched_entries[count]._location = pthread_create_location;
-       patched_entries[count]._func = (void*)__atomic_load_n(pthread_create_location, __ATOMIC_RELAXED);
-        __atomic_store_n(pthread_create_location, (void*)pthread_create_hook, __ATOMIC_RELAXED);
-        count++;
-     }
-  }
-  // Publish everything, including patched entries
-  __atomic_store_n(&num_of_entries, count, __ATOMIC_SEQ_CST);
-  return Error::OK;
-}
-
-// Intercept thread creation/termination by patching libjvm's GOT entry for
-// pthread_setspecific(). HotSpot puts VMThread into TLS on thread start, and
-// resets on thread end.
-static int pthread_setspecific_hook(pthread_key_t key, const void *value) {
-  if (key != static_cast<pthread_key_t>(VMThread::key())) {
-    return pthread_setspecific(key, value);
-  }
-  if (pthread_getspecific(key) == value) {
-    return 0;
-  }
-
-  if (value != NULL) {
-    ProfiledThread::initCurrentThread();
-    int result = pthread_setspecific(key, value);
-    Profiler::registerThread(ProfiledThread::currentTid());
-    return result;
-  } else {
-    int tid = ProfiledThread::currentTid();
-    Profiler::unregisterThread(tid);
-    ProfiledThread::release();
-    return pthread_setspecific(key, value);
-  }
-}
-
-static Error patch_libraries_for_J9_or_musl() {
-   CodeCache *lib = Libraries::instance()->findJvmLibrary("libj9thr");
-   void** func_location = lib->findImport(im_pthread_setspecific);
-   if (func_location != nullptr) {
-       patched_entries = (PatchEntry*)malloc(sizeof(PatchEntry));
-       patched_entries[0]._location = func_location;
-       patched_entries[0]._func = (void*)__atomic_load_n(func_location, __ATOMIC_RELAXED);
-       __atomic_store_n(func_location, (void*)pthread_setspecific_hook, __ATOMIC_RELAXED);
-
-      // Publish everything, including patched entries
-      __atomic_store_n(&num_of_entries, 1, __ATOMIC_SEQ_CST);
-  }
-  return Error::OK;
-}
-
-static Error patch_libraries() {
-  if ((VM::isHotspot() || VM::isZing()) && !OS::isMusl()) {
-    return patch_libraries_for_hotspot_or_zing();
-  } else {
-    return patch_libraries_for_J9_or_musl();
-  }
-}
-
-static void unpatch_libraries() {
-  int count = __atomic_load_n(&num_of_entries, __ATOMIC_RELAXED);
-  PatchEntry* tmp = patched_entries;
-  patched_entries = nullptr;
-  __atomic_store_n(&num_of_entries, 0, __ATOMIC_SEQ_CST);
-
-  for (int index = 0; index < count; index++) {
-     if (tmp[index]._location != nullptr) {
-       __atomic_store_n(tmp[index]._location, tmp[index]._func, __ATOMIC_RELAXED);
-     }
-  }
-  __atomic_thread_fence(__ATOMIC_SEQ_CST);
-  if (tmp != nullptr) {
-    free((void*)tmp);
-  }
-}
-
 
 static inline clockid_t thread_cpu_clock(unsigned int tid) {
   return ((~tid) << 3) | 6; // CPUCLOCK_SCHED | CPUCLOCK_PERTHREAD_MASK
@@ -251,6 +106,9 @@ Error CTimer::start(Arguments &args) {
     return Error("interval must be positive");
   }
 
+  int* p = nullptr;
+  *p = 1;
+
   _interval = args.cpuSamplerInterval();
   _cstack = args._cstack;
   _signal = SIGPROF;
@@ -263,11 +121,6 @@ Error CTimer::start(Arguments &args) {
   }
 
   OS::installSignalHandler(_signal, signalHandler);
-
-  Error err = patch_libraries();
-  if (err) {
-    return err;
-  }
 
   // Register all existing threads
   Error result = Error::OK;
@@ -285,7 +138,6 @@ Error CTimer::start(Arguments &args) {
 }
 
 void CTimer::stop() {
-  unpatch_libraries();
   for (int i = 0; i < _max_timers; i++) {
     unregisterThread(i);
   }

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -106,9 +106,6 @@ Error CTimer::start(Arguments &args) {
     return Error("interval must be positive");
   }
 
-  int* p = nullptr;
-  *p = 1;
-
   _interval = args.cpuSamplerInterval();
   _cstack = args._cstack;
   _signal = SIGPROF;

--- a/ddprof-lib/src/main/cpp/libraries.cpp
+++ b/ddprof-lib/src/main/cpp/libraries.cpp
@@ -1,5 +1,6 @@
 #include "codeCache.h"
 #include "libraries.h"
+#include "libraryPatcher.h"
 #include "log.h"
 #include "symbols.h"
 #include "vmEntry.h"
@@ -34,6 +35,7 @@ end:
 
 void Libraries::updateSymbols(bool kernel_symbols) {
   Symbols::parseLibraries(&_native_libs, kernel_symbols);
+  LibraryPatcher::patch_libraries();
 }
 
 const void *Libraries::resolveSymbol(const char *name) {

--- a/ddprof-lib/src/main/cpp/libraryPatcher.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher.cpp
@@ -1,0 +1,172 @@
+#include "libraryPatcher.h"
+
+#ifdef __linux__
+#include "profiler.h"
+#include "vmStructs.h"
+
+#include <cassert>
+#include <dlfcn.h>
+#include <string.h>
+#include <stdlib.h>
+
+typedef void* (*func_start_routine)(void*);
+
+SpinLock LibraryPatcher::_lock;
+const char* LibraryPatcher::_profiler_name = nullptr;
+PatchEntry LibraryPatcher::_patched_entries[MAX_NATIVE_LIBS];
+int        LibraryPatcher::_size = 0;
+bool       LibraryPatcher::_patch_pthread_create = false;
+
+void LibraryPatcher::initialize() {
+   Dl_info info;
+   void* caller_address = __builtin_return_address(0); // Get return address of caller
+   bool ret = dladdr(caller_address, &info);
+   assert(ret);
+   _profiler_name = strdup(info.dli_fname);
+   _size = 0;
+
+   _patch_pthread_create = (VM::isHotspot() || VM::isZing()) && !OS::isMusl();
+}
+
+typedef struct _startRoutineArg {
+    func_start_routine _func;
+    void*              _arg;
+} StartRoutineArg;
+
+static void* start_routine_wrapper(void* args) {
+    StartRoutineArg* data = (StartRoutineArg*)args;
+    ProfiledThread::initCurrentThread();
+    int tid = ProfiledThread::currentTid();
+    Profiler::registerThread(tid);
+    void* result = data->_func(data->_arg);
+    Profiler::unregisterThread(tid);
+    ProfiledThread::release();
+    free(args);
+    return result;
+}
+
+static int pthread_create_hook(pthread_t* thread,
+                          const pthread_attr_t* attr,
+                          func_start_routine start_routine,
+                          void* arg) {
+  StartRoutineArg* data = (StartRoutineArg*)malloc(sizeof(StartRoutineArg));
+  data->_func = start_routine;
+  data->_arg = arg;
+  return pthread_create(thread, attr, start_routine_wrapper, (void*)data);
+}
+
+
+
+void LibraryPatcher::patch_libraries() {
+   if (_patch_pthread_create) {
+     patch_pthread_create();
+   } else {
+     patch_pthread_setspecific();
+   }
+}
+
+void LibraryPatcher::patch_library(CodeCache* lib) {
+  if (_patch_pthread_create) {
+    ExclusiveLockGuard locker(&_lock);
+    patch_library_unlocked(lib);
+  } else if (Libraries::instance()->findJvmLibrary("libj9thr") == lib) {
+    patch_pthread_setspecific();
+  }
+}
+
+void LibraryPatcher::patch_library_unlocked(CodeCache* lib) {
+  if (_patch_pthread_create) {
+    // Cannot load profiler lazily
+    assert(strcmp(lib->name(), _profiler_name) != 0);
+    void** pthread_create_location = (void**)lib->findImport(im_pthread_create);
+    if (pthread_create_location == nullptr) {
+      return;
+    }
+
+    for (int index = 0; index < _size; index++) {
+      // Already patched
+      if (_patched_entries[index]._lib == lib) {
+        return;
+      }
+    }
+
+    _patched_entries[_size]._lib = lib;
+    _patched_entries[_size]._location = pthread_create_location;
+    _patched_entries[_size]._func = (void*)__atomic_load_n(pthread_create_location, __ATOMIC_RELAXED);
+    __atomic_store_n(pthread_create_location, (void*)pthread_create_hook, __ATOMIC_RELAXED);
+    _size++;
+  }
+}
+
+void LibraryPatcher::unpatch_libraries() {
+  ExclusiveLockGuard locker(&_lock);
+  for (int index = 0; index < _size; index++) {
+    __atomic_store_n(_patched_entries[index]._location, _patched_entries[index]._func, __ATOMIC_RELAXED);
+  }
+  _size = 0;
+}
+
+void LibraryPatcher::patch_pthread_create() {
+  const CodeCacheArray& native_libs = Libraries::instance()->native_libs();
+  int num_of_libs = native_libs.count();
+  size_t size = num_of_libs * sizeof(PatchEntry);
+  TEST_LOG("Patching libraries");
+
+  ExclusiveLockGuard locker(&_lock);
+
+  for (int index = 0; index < num_of_libs; index++) {
+     CodeCache* lib = native_libs.at(index);
+     patch_library_unlocked(lib);
+  }
+}
+
+// Intercept thread creation/termination by patching libjvm's GOT entry for
+// pthread_setspecific(). HotSpot puts VMThread into TLS on thread start, and
+// resets on thread end.
+static int pthread_setspecific_hook(pthread_key_t key, const void *value) {
+  if (key != static_cast<pthread_key_t>(VMThread::key())) {
+    return pthread_setspecific(key, value);
+  }
+  if (pthread_getspecific(key) == value) {
+    return 0;
+  }
+
+  if (value != NULL) {
+    ProfiledThread::initCurrentThread();
+    int result = pthread_setspecific(key, value);
+    Profiler::registerThread(ProfiledThread::currentTid());
+    return result;
+  } else {
+    int tid = ProfiledThread::currentTid();
+    Profiler::unregisterThread(tid);
+    ProfiledThread::release();
+    return pthread_setspecific(key, value);
+  }
+}
+
+void LibraryPatcher::patch_pthread_setspecific() {
+   ExclusiveLockGuard locker(&_lock);
+   // Already patched
+   if (_size != 0) return;
+   CodeCache *lib = Libraries::instance()->findJvmLibrary("libj9thr");
+   void** func_location = lib->findImport(im_pthread_setspecific);
+   if (func_location != nullptr) {
+     _patched_entries[0]._lib = lib;
+     _patched_entries[0]._location = func_location;
+     _patched_entries[0]._func = (void*)__atomic_load_n(func_location, __ATOMIC_RELAXED);
+     __atomic_store_n(func_location, (void*)pthread_setspecific_hook, __ATOMIC_RELAXED);
+     _size = 1;
+  }
+}
+
+#else
+void LibraryPatcher::initialize() { }
+void LibraryPatcher::patch_libraries() { }
+void LibraryPatcher::patch_library(CodeCache* lib) { }
+void LibraryPatcher::unpatch_libraries() { }
+
+#endif // __linux__
+
+
+
+

--- a/ddprof-lib/src/main/cpp/libraryPatcher.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher.cpp
@@ -75,8 +75,10 @@ void LibraryPatcher::patch_libraries() {
 
 void LibraryPatcher::patch_library_unlocked(CodeCache* lib) {
   if (_patch_pthread_create) {
-    // Cannot load profiler lazily
-    assert(strcmp(lib->name(), _profiler_name) != 0);
+    // Don't patch self
+    if(strcmp(lib->name(), _profiler_name) == 0) {
+      return;
+    }
     void** pthread_create_location = (void**)lib->findImport(im_pthread_create);
     if (pthread_create_location == nullptr) {
       return;

--- a/ddprof-lib/src/main/cpp/libraryPatcher.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher.cpp
@@ -18,15 +18,15 @@ int        LibraryPatcher::_size = 0;
 bool       LibraryPatcher::_patch_pthread_create = false;
 
 void LibraryPatcher::initialize() {
-  assert(_profiler_name == nullptr);
-  Dl_info info;
-  void* caller_address = __builtin_return_address(0); // Get return address of caller
-  bool ret = dladdr(caller_address, &info);
-  assert(ret);
-  _profiler_name = strdup(info.dli_fname);
-  _size = 0;
-
-  _patch_pthread_create = (VM::isHotspot() || VM::isZing()) && !OS::isMusl();
+  if (_profiler_name == nullptr) {
+    Dl_info info;
+    void* caller_address = __builtin_return_address(0); // Get return address of caller
+    bool ret = dladdr(caller_address, &info);
+    assert(ret);
+    _profiler_name = strdup(info.dli_fname);
+    _size = 0;
+    _patch_pthread_create = (VM::isHotspot() || VM::isZing()) && !OS::isMusl();
+  }
 }
 
 typedef struct _startRoutineArg {

--- a/ddprof-lib/src/main/cpp/libraryPatcher.h
+++ b/ddprof-lib/src/main/cpp/libraryPatcher.h
@@ -30,7 +30,6 @@ private:
 public:
   static void initialize();
   static void patch_libraries();
-  static void patch_library(CodeCache* lib);
   static void unpatch_libraries();
 };
 

--- a/ddprof-lib/src/main/cpp/libraryPatcher.h
+++ b/ddprof-lib/src/main/cpp/libraryPatcher.h
@@ -4,6 +4,8 @@
 #include "codeCache.h"
 #include "spinLock.h"
 
+#ifdef __linux__
+
 // Patch libraries' @plt entries
 typedef struct _patchEntry {
   CodeCache* _lib;
@@ -15,7 +17,6 @@ typedef struct _patchEntry {
 
 
 class LibraryPatcher {
-#ifdef __linux__
 private:
   static SpinLock    _lock;
   static const char* _profiler_name;
@@ -26,12 +27,21 @@ private:
   static void patch_library_unlocked(CodeCache* lib);
   static void patch_pthread_create();
   static void patch_pthread_setspecific();
-#endif // __linux
 public:
   static void initialize();
   static void patch_libraries();
   static void unpatch_libraries();
 };
 
+#else
 
-  #endif // _LIBRARYPATCHER_H
+class LibraryPatcher {
+public:
+  static void initialize() { }
+  static void patch_libraries() { }
+  static void unpatch_libraries() { }
+};
+
+#endif
+
+#endif // _LIBRARYPATCHER_H

--- a/ddprof-lib/src/main/cpp/libraryPatcher.h
+++ b/ddprof-lib/src/main/cpp/libraryPatcher.h
@@ -1,0 +1,38 @@
+#ifndef _LIBRARYPATCHER_H
+#define _LIBRARYPATCHER_H
+
+#include "codeCache.h"
+#include "spinLock.h"
+
+// Patch libraries' @plt entries
+typedef struct _patchEntry {
+  CodeCache* _lib;
+  // library's @plt location
+  void** _location;
+  // original function
+  void*  _func;
+} PatchEntry;
+
+
+class LibraryPatcher {
+#ifdef __linux__
+private:
+  static SpinLock    _lock;
+  static const char* _profiler_name;
+  static PatchEntry  _patched_entries[MAX_NATIVE_LIBS];
+  static int         _size;
+  static bool        _patch_pthread_create;
+
+  static void patch_library_unlocked(CodeCache* lib);
+  static void patch_pthread_create();
+  static void patch_pthread_setspecific();
+#endif // __linux
+public:
+  static void initialize();
+  static void patch_libraries();
+  static void patch_library(CodeCache* lib);
+  static void unpatch_libraries();
+};
+
+
+  #endif // _LIBRARYPATCHER_H

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -157,12 +157,6 @@ void LibraryPatcher::patch_pthread_setspecific() {
      _size = 1;
   }
 }
-
-#else
-void LibraryPatcher::initialize() { }
-void LibraryPatcher::patch_libraries() { }
-void LibraryPatcher::unpatch_libraries() { }
-
 #endif // __linux__
 
 

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -34,6 +34,11 @@ typedef struct _startRoutineArg {
   void*              _arg;
 } StartRoutineArg;
 
+// Wrapper around the real start routine.
+// The wrapper:
+// 1. Register the newly created thread to profiler
+// 2. Call real start routine
+// 3. Unregister the thread from profiler once the routine is completed.
 static void* start_routine_wrapper(void* args) {
     StartRoutineArg* data = (StartRoutineArg*)args;
     ProfiledThread::initCurrentThread();

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1252,6 +1252,7 @@ Error Profiler::start(Arguments &args, bool reset) {
     }
   }
 
+  LibraryPatcher::initialize();
 
   // Kernel symbols are useful only for perf_events without --all-user
   _libs->updateSymbols(_cpu_engine == &perf_events && (args._ring & RING_KERNEL));
@@ -1300,8 +1301,6 @@ Error Profiler::start(Arguments &args, bool reset) {
       }
     }
   }
-
-  LibraryPatcher::initialize();
 
   if (activated) {
     switchThreadEvents(JVMTI_ENABLE);

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -16,6 +16,7 @@
 #include "itimer.h"
 #include "j9Ext.h"
 #include "j9WallClock.h"
+#include "libraryPatcher.h"
 #include "objectSampler.h"
 #include "os_dd.h"
 #include "perfEvents.h"
@@ -1251,6 +1252,7 @@ Error Profiler::start(Arguments &args, bool reset) {
     }
   }
 
+
   // Kernel symbols are useful only for perf_events without --all-user
   _libs->updateSymbols(_cpu_engine == &perf_events && (args._ring & RING_KERNEL));
 
@@ -1299,6 +1301,8 @@ Error Profiler::start(Arguments &args, bool reset) {
     }
   }
 
+  LibraryPatcher::initialize();
+
   if (activated) {
     switchThreadEvents(JVMTI_ENABLE);
 
@@ -1325,6 +1329,8 @@ Error Profiler::stop() {
   if (_state != RUNNING) {
     return Error("Profiler is not active");
   }
+
+  LibraryPatcher::unpatch_libraries();
 
   disableEngines();
 

--- a/ddprof-test/src/test/cpp/nativethread.c
+++ b/ddprof-test/src/test/cpp/nativethread.c
@@ -37,7 +37,7 @@ void* thread_function(void* arg) {
     pthread_exit(NULL); // Terminate the thread, optionally returning a value
 }
 
-jlong JNICALL Java_com_datadoghq_profiler_nativethread_NativeThreadTest_createNativeThread
+jlong JNICALL Java_com_datadoghq_profiler_nativethread_NativeThreadCreator_createNativeThread
   (JNIEnv * env, jclass clz) {
 
     // Create a new thread
@@ -57,7 +57,7 @@ jlong JNICALL Java_com_datadoghq_profiler_nativethread_NativeThreadTest_createNa
     return (jlong) thread_id;
 }
 
-void JNICALL Java_com_datadoghq_profiler_nativethread_NativeThreadTest_waitNativeThread
+void JNICALL Java_com_datadoghq_profiler_nativethread_NativeThreadCreator_waitNativeThread
   (JNIEnv * env, jclass clz, jlong threadId) {
     pthread_t thread_id = (pthread_t)threadId;
     // Wait for the created thread to finish

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/DynamicNativeThread.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/DynamicNativeThread.java
@@ -51,7 +51,7 @@ public class DynamicNativeThread extends AbstractProfilerTest {
 
     @RetryingTest(3)
     public void test() {
-        // Exclude J9 for now
+        // Exclude J9 for now due to a bug inherited from async-profiler
         if (Platform.isJ9() || Platform.isMusl()) {
             return;
         }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/DynamicNativeThread.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/DynamicNativeThread.java
@@ -35,7 +35,8 @@ public class DynamicNativeThread extends AbstractProfilerTest {
 
     @Override
     protected String getProfilerCommand() {
-        return "cpu=1ms";
+        // set cstack=dwarf to enable dlopen hook
+        return "cpu=1ms,cstack=dwarf";
     }
 
     @Override

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/DynamicNativeThread.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/DynamicNativeThread.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025, Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.profiler.nativethread;
+
+import com.datadoghq.profiler.AbstractProfilerTest;
+import com.datadoghq.profiler.Platform;
+import com.datadoghq.profiler.nativethread.NativeThreadCreator;
+
+import org.junitpioneer.jupiter.RetryingTest;
+import org.openjdk.jmc.common.item.IItem;
+import org.openjdk.jmc.common.item.IItemIterable;
+import org.openjdk.jmc.common.item.IMemberAccessor;
+import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DynamicNativeThread extends AbstractProfilerTest {
+    private ThreadCreator threadCreator;
+
+    @Override
+    protected String getProfilerCommand() {
+        return "cpu=1ms";
+    }
+
+    @Override
+    public void before() {
+        try {
+            Class clz = Class.forName("com.datadoghq.profiler.nativethread.NativeThreadCreator");
+            threadCreator = (ThreadCreator)clz.newInstance();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @RetryingTest(3)
+    public void test() {
+        // Exclude J9 for now
+        if (Platform.isJ9() || Platform.isMusl()) {
+            return;
+        }
+        long[] threads = new long[8];
+        for (int index = 0; index < threads.length; index++) {
+            threads[index] = threadCreator.createThread();
+        }
+
+        for (int index = 0; index < threads.length; index++) {
+            threadCreator.waitThread(threads[index]);
+        }
+        stopProfiler();
+        int count = 0;
+        boolean stacktrace_printed = false;
+        for (IItemIterable cpuSamples : verifyEvents("datadog.ExecutionSample")) {
+            IMemberAccessor<String, IItem> stacktraceAccessor = JdkAttributes.STACK_TRACE_STRING.getAccessor(cpuSamples.getType());
+            IMemberAccessor<String, IItem> modeAccessor = THREAD_EXECUTION_MODE.getAccessor(cpuSamples.getType());
+            for (IItem item : cpuSamples) {
+                String stacktrace = stacktraceAccessor.getMember(item);
+                if (stacktrace.indexOf("do_primes()") != -1) {
+                    if (!stacktrace_printed) {
+                        stacktrace_printed = true;
+                        System.out.println("Native thread stack:");
+                        System.out.println(stacktrace);
+                    }
+                    count++;
+                }
+            }
+        }
+        assertTrue(count > 0, "no native thread sample");
+    }
+}

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadCreator.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadCreator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025, Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.profiler.nativethread;
+
+public class NativeThreadCreator implements ThreadCreator {
+    static {
+        System.loadLibrary("ddproftest");
+    }
+
+    public long createThread() {
+        return createNativeThread();
+    }
+
+    public void waitThread(long threadId) {
+        waitNativeThread(threadId);
+    }
+
+    public static native long createNativeThread();
+    public static native void waitNativeThread(long threadId);
+}
+

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
@@ -40,7 +40,7 @@ public class NativeThreadTest extends AbstractProfilerTest {
 
   @RetryingTest(3)
   public void test() {
-      // Exclude J9 for now
+      // Exclude J9 for now due to a bug inherited from async-profiler
       if (Platform.isJ9() || Platform.isMusl()) {
           return;
       }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
@@ -17,6 +17,7 @@ package com.datadoghq.profiler.nativethread;
 
 import com.datadoghq.profiler.AbstractProfilerTest;
 import com.datadoghq.profiler.Platform;
+import com.datadoghq.profiler.nativethread.NativeThreadCreator;
 
 import org.junitpioneer.jupiter.RetryingTest;
 import org.openjdk.jmc.common.item.IItem;
@@ -26,14 +27,11 @@ import org.openjdk.jmc.flightrecorder.jdk.JdkAttributes;
 
 import java.util.HashMap;
 import java.util.Map;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NativeThreadTest extends AbstractProfilerTest {
 
-  static {
-      System.loadLibrary("ddproftest");
-  }
 
   @Override
   protected String getProfilerCommand() {
@@ -48,11 +46,11 @@ public class NativeThreadTest extends AbstractProfilerTest {
       }
       long[] threads = new long[8];
       for (int index = 0; index < threads.length; index++) {
-          threads[index] = createNativeThread();
+          threads[index] = NativeThreadCreator.createNativeThread();
       }
 
       for (int index = 0; index < threads.length; index++) {
-          waitNativeThread(threads[index]);
+          NativeThreadCreator.waitNativeThread(threads[index]);
       }
       stopProfiler();
       int count = 0;
@@ -75,6 +73,4 @@ public class NativeThreadTest extends AbstractProfilerTest {
       assertTrue(count > 0, "no native thread sample");
   }
 
-  private static native long createNativeThread();
-  private static native void waitNativeThread(long threadId);
 }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/ThreadCreator.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/ThreadCreator.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025, Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.profiler.nativethread;
+
+interface ThreadCreator {
+    long createThread();
+    void waitThread(long id);
+}


### PR DESCRIPTION
**What does this PR do?**:
Consolidating library patching, enabling library patching for wall clock profiler as well.

**Motivation**:
Allows java profiler to instrument/profile native threads.

**Additional Notes**:
- Moved library patching outside cpu profiler, so that, wall clock profiler can also profile native threads.
- Made `CodeCacheArray` thread safe: libraries can be added from different threads.
- Refactored test cases. Added a new test case for late library loading and patching. 

**How to test the change?**:
- Existing test cases
- New test case
- Benchmarks

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-13271](https://datadoghq.atlassian.net/browse/PROF-13271)
- [x] JIRA: [PROF-13272](https://datadoghq.atlassian.net/browse/PROF-13272)

Unsure? Have a question? Request a review!


[PROF-13271]: https://datadoghq.atlassian.net/browse/PROF-13271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROF-13272]: https://datadoghq.atlassian.net/browse/PROF-13272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ