### PR TITLE
Bump the AP lock to get the walkvm crash fix in

### DIFF
--- a/ddprof-lib/src/main/cpp/codeCache.cpp
+++ b/ddprof-lib/src/main/cpp/codeCache.cpp
@@ -363,7 +363,7 @@ void CodeCache::setDwarfTable(FrameDesc *table, int length) {
   _dwarf_table_length = length;
 }
 
-FrameDesc *CodeCache::findFrameDesc(const void *pc) {
+FrameDesc CodeCache::findFrameDesc(const void *pc) {
   u32 target_loc = (const char *)pc - _text_base;
   int low = 0;
   int high = _dwarf_table_length - 1;
@@ -375,15 +375,15 @@ FrameDesc *CodeCache::findFrameDesc(const void *pc) {
     } else if (_dwarf_table[mid].loc > target_loc) {
       high = mid - 1;
     } else {
-      return &_dwarf_table[mid];
+      return _dwarf_table[mid];
     }
   }
 
   if (low > 0) {
-    return &_dwarf_table[low - 1];
+    return _dwarf_table[low - 1];
   } else if (target_loc - _plt_offset < _plt_size) {
-    return &FrameDesc::empty_frame;
+    return FrameDesc::empty_frame;
   } else {
-    return &FrameDesc::default_frame;
+    return FrameDesc::default_frame;
   }
 }

--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -202,7 +202,7 @@ public:
                            std::vector<const void *> &symbols);
 
   void setDwarfTable(FrameDesc *table, int length);
-  FrameDesc *findFrameDesc(const void *pc);
+  FrameDesc findFrameDesc(const void *pc);
 
   long long memoryUsage() {
     return _capacity * sizeof(CodeBlob *) + _count * sizeof(NativeFunc);

--- a/ddprof-lib/src/main/cpp/vmStructs_dd.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs_dd.cpp
@@ -328,8 +328,11 @@ namespace ddprof {
   }
 
   bool VMStructs_::isSafeToWalk(uintptr_t pc) {
-    return !(_unsafe_to_walk.contains((const void *)pc) &&
-            _unsafe_to_walk.findFrameDesc((const void *)pc));
+    // Check if PC is in the unsafe-to-walk code region
+    // Note: findFrameDesc now returns by value instead of pointer, but it always returns
+    // a valid FrameDesc (either from table or default_frame), so the old pointer check
+    // was always true. The effective logic is simply checking if pc is in _unsafe_to_walk.
+    return !_unsafe_to_walk.contains((const void *)pc);
   }
 
   void VMStructs_::NativeMethodBind(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread,

--- a/gradle/lock.properties
+++ b/gradle/lock.properties
@@ -1,5 +1,5 @@
 ap.branch=dd/master
-ap.commit=114bd43e91b910035978631492b46568989a6760
+ap.commit=cf49c3a568b1884285dfe92a9992606af2a62040
 
 ctx_branch=main
 ctx_commit=b33673d801b85a6c38fa0e9f1a139cb246737ce8


### PR DESCRIPTION
**What does this PR do?**:
Protect native stack walking for foreign threads without vm_thread

**Motivation**:
Ensure crash-free stack walking for threads not attached to JVM (e.g.,
Rust threads, naked pthreads) by using SafeAccess for all transitive
memory dereferences in native stack walking.

**Additional Notes**:
Changes:
- Add SafeAccess::loadInt for safe integer field access
- Change findFrameDesc to return by value with SafeAccess protection
- Use SafeAccess in binarySearch for all _blobs array accesses
- Fix direct stack dereferences in walkVM/walkDwarf
- Extract validation helpers to StackWalkValidation namespace

**How to test the change?**:
All existing tests must pass

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-13268]

Unsure? Have a question? Request a review!


[PROF-13268]: https://datadoghq.atlassian.net/browse/PROF-13268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ