### PR TITLE
Instrument native threads in J9

### DIFF
--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -25,7 +25,7 @@ void LibraryPatcher::initialize() {
     assert(ret);
     _profiler_name = strdup(info.dli_fname);
     _size = 0;
-    _patch_pthread_create = (VM::isHotspot() || VM::isZing()) && !OS::isMusl();
+    _patch_pthread_create = !OS::isMusl();
   }
 }
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/DynamicNativeThread.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/DynamicNativeThread.java
@@ -51,8 +51,8 @@ public class DynamicNativeThread extends AbstractProfilerTest {
 
     @RetryingTest(3)
     public void test() {
-        // Exclude J9 for now due to a bug inherited from async-profiler
-        if (Platform.isJ9() || Platform.isMusl()) {
+        // Exclude Musl for now due to a crash on aarch64
+        if (Platform.isMusl()) {
             return;
         }
         long[] threads = new long[8];

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
@@ -40,8 +40,8 @@ public class NativeThreadTest extends AbstractProfilerTest {
 
   @RetryingTest(3)
   public void test() {
-      // Exclude J9 for now due to a bug inherited from async-profiler
-      if (Platform.isJ9() || Platform.isMusl()) {
+      // Exclude Musl for now due to a crash on aarch64
+      if (Platform.isMusl()) {
           return;
       }
       long[] threads = new long[8];

--- a/gradle/lock.properties
+++ b/gradle/lock.properties
@@ -1,5 +1,5 @@
 ap.branch=dd/master
-ap.commit=cf49c3a568b1884285dfe92a9992606af2a62040
+ap.commit=4f494f50c77ab1459156190edb6cfc41cf36d065
 
 ctx_branch=main
 ctx_commit=b33673d801b85a6c38fa0e9f1a139cb246737ce8


### PR DESCRIPTION
**What does this PR do?**:
Enable instrumenting native threads in J9

**Motivation**:
Enable instrumenting native threads in J9


**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
Ran `NativeThreadTest` and `DynamicNativeThread` tests, they failed without the patch, passed with it.


**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-13384](https://datadoghq.atlassian.net/browse/PROF-13384)

Unsure? Have a question? Request a review!


[PROF-13384]: https://datadoghq.atlassian.net/browse/PROF-13384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ