### PR TITLE
Fix wallclock sample collapse for blocking operations

### DIFF
--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -70,8 +70,9 @@ void WallClockASGCT::signalHandler(int signo, siginfo_t *siginfo, void *ucontext
     StackFrame frame(ucontext);
     Context &context = Contexts::get();
     call_trace_id = current->lookupWallclockCallTraceId(
-        (u64)frame.pc(), Profiler::instance()->recordingEpoch(),
-        context.spanId);
+        (u64)frame.pc(), (u64)frame.sp(),
+        Profiler::instance()->recordingEpoch(),
+        context.spanId, context.rootSpanId);
     if (call_trace_id != 0) {
       Counters::increment(SKIPPED_WALLCLOCK_UNWINDS);
     }


### PR DESCRIPTION
**What does this PR do?**:
Fixes wallclock sample collapsing to work correctly for blocking I/O-heavy workloads by comparing execution state (PC+SP) and trace context (spanId+rootSpanId) instead of requiring CPU samples between wallclock samples.

**Motivation**:
The current collapsing logic requires a CPU sample to have occurred between wallclock samples. This causes incorrect behavior when code does mostly blocking operations (e.g., syscalls, I/O):
- Thread may move between different blocking calls (sleep → read → write) without CPU samples
- Samples could be incorrectly collapsed when PC matches but call stack differs
- Trace context changes may not be detected, leading to misattribution

**Additional Notes**:
- Changes are minimal and allocation-free (signal-handler safe)
- Removed dependency on `_wall_epoch == _cpu_epoch` check
- Now collapses only when PC, SP, spanId, rootSpanId, and recording_epoch all match
- Fields `_wall_epoch` and `_cpu_epoch` remain for now but are no longer used by collapsing logic

**How to test the change?**:
Existing tests verify the behavior. The fix ensures:
- Repeated blocking calls at same location → correctly collapsed
- Different blocking calls → NOT collapsed (different SP or PC)
- Same location, context changed → NOT collapsed (different spanId/rootSpanId)

**For Datadog employees**:
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-13088](https://datadoghq.atlassian.net/browse/PROF-13088)

[PROF-13088]: https://datadoghq.atlassian.net/browse/PROF-13088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ