### PR TITLE
Instrument native threads on Linux/musl

### DIFF
--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -32,9 +32,8 @@ private:
   func_start_routine _routine;
   void* const _args;
 public:
-  RoutineInfo(func_start_routine routine, void* args) {
-    _routine = routine;
-    _args = args;
+  RoutineInfo(func_start_routine routine, void* args) :
+    _routine(routine), _args(args) {
   }
 
   func_start_routine routine() const {

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -15,7 +15,6 @@ SpinLock LibraryPatcher::_lock;
 const char* LibraryPatcher::_profiler_name = nullptr;
 PatchEntry LibraryPatcher::_patched_entries[MAX_NATIVE_LIBS];
 int        LibraryPatcher::_size = 0;
-bool       LibraryPatcher::_patch_pthread_create = false;
 
 void LibraryPatcher::initialize() {
   if (_profiler_name == nullptr) {
@@ -25,14 +24,27 @@ void LibraryPatcher::initialize() {
     assert(ret);
     _profiler_name = strdup(info.dli_fname);
     _size = 0;
-    _patch_pthread_create = !OS::isMusl();
   }
 }
 
-typedef struct _startRoutineArg {
-  func_start_routine _func;
-  void*              _arg;
-} StartRoutineArg;
+class ThreadInfo {
+private:
+  func_start_routine _routine;
+  void* const _args;
+public:
+  ThreadInfo(func_start_routine routine, void* args) {
+    _routine = routine;
+    _args = args;
+  }
+
+  func_start_routine routine() const {
+    return _routine;
+  }
+
+  void* const args() const {
+    return _args;
+  }
+};
 
 // Wrapper around the real start routine.
 // The wrapper:
@@ -40,14 +52,17 @@ typedef struct _startRoutineArg {
 // 2. Call real start routine
 // 3. Unregister the thread from profiler once the routine is completed.
 static void* start_routine_wrapper(void* args) {
-    StartRoutineArg* data = (StartRoutineArg*)args;
+    ThreadInfo* thr = (ThreadInfo*)args;
+    func_start_routine routine = thr->routine();
+    void* const args = thr->args();
+    delete thr;
+
     ProfiledThread::initCurrentThread();
     int tid = ProfiledThread::currentTid();
     Profiler::registerThread(tid);
-    void* result = data->_func(data->_arg);
+    void* result = routine(args);
     Profiler::unregisterThread(tid);
     ProfiledThread::release();
-    free(args);
     return result;
 }
 
@@ -55,13 +70,9 @@ static int pthread_create_hook(pthread_t* thread,
                           const pthread_attr_t* attr,
                           func_start_routine start_routine,
                           void* arg) {
-  StartRoutineArg* data = (StartRoutineArg*)malloc(sizeof(StartRoutineArg));
-  data->_func = start_routine;
-  data->_arg = arg;
-  return pthread_create(thread, attr, start_routine_wrapper, (void*)data);
+  ThreadInfo* thr = new ThreadInfo(start_routine, args);
+  return pthread_create(thread, attr, start_routine_wrapper, (void*)thr);
 }
-
-
 
 void LibraryPatcher::patch_libraries() {
    // LibraryPatcher has yet initialized, only happens in Gtest
@@ -70,38 +81,32 @@ void LibraryPatcher::patch_libraries() {
    }
 
    TEST_LOG("Patching libraries");
-   if (_patch_pthread_create) {
-     patch_pthread_create();
-   } else {
-     patch_pthread_setspecific();
-   }
+   patch_pthread_create();
    TEST_LOG("%d libraries patched", _size);
 }
 
 void LibraryPatcher::patch_library_unlocked(CodeCache* lib) {
-  if (_patch_pthread_create) {
-    // Don't patch self
-    if(strcmp(lib->name(), _profiler_name) == 0) {
-      return;
-    }
-    void** pthread_create_location = (void**)lib->findImport(im_pthread_create);
-    if (pthread_create_location == nullptr) {
-      return;
-    }
-
-    for (int index = 0; index < _size; index++) {
-      // Already patched
-      if (_patched_entries[index]._lib == lib) {
-        return;
-      }
-    }
-    TEST_LOG("Patching: %s", lib->name());
-    _patched_entries[_size]._lib = lib;
-    _patched_entries[_size]._location = pthread_create_location;
-    _patched_entries[_size]._func = (void*)__atomic_load_n(pthread_create_location, __ATOMIC_RELAXED);
-    __atomic_store_n(pthread_create_location, (void*)pthread_create_hook, __ATOMIC_RELAXED);
-    _size++;
+  // Don't patch self
+  if(strcmp(lib->name(), _profiler_name) == 0) {
+    return;
   }
+  void** pthread_create_location = (void**)lib->findImport(im_pthread_create);
+  if (pthread_create_location == nullptr) {
+    return;
+  }
+
+  for (int index = 0; index < _size; index++) {
+    // Already patched
+    if (_patched_entries[index]._lib == lib) {
+      return;
+    }
+  }
+  TEST_LOG("Patching: %s", lib->name());
+  _patched_entries[_size]._lib = lib;
+  _patched_entries[_size]._location = pthread_create_location;
+  _patched_entries[_size]._func = (void*)__atomic_load_n(pthread_create_location, __ATOMIC_RELAXED);
+  __atomic_store_n(pthread_create_location, (void*)pthread_create_hook, __ATOMIC_RELAXED);
+  _size++;
 }
 
 void LibraryPatcher::unpatch_libraries() {
@@ -120,46 +125,6 @@ void LibraryPatcher::patch_pthread_create() {
   for (int index = 0; index < num_of_libs; index++) {
      CodeCache* lib = native_libs.at(index);
      patch_library_unlocked(lib);
-  }
-}
-
-// Intercept thread creation/termination by patching libjvm's GOT entry for
-// pthread_setspecific(). HotSpot puts VMThread into TLS on thread start, and
-// resets on thread end.
-static int pthread_setspecific_hook(pthread_key_t key, const void *value) {
-  if (key != static_cast<pthread_key_t>(VMThread::key())) {
-    return pthread_setspecific(key, value);
-  }
-  if (pthread_getspecific(key) == value) {
-    return 0;
-  }
-
-  if (value != NULL) {
-    ProfiledThread::initCurrentThread();
-    int result = pthread_setspecific(key, value);
-    Profiler::registerThread(ProfiledThread::currentTid());
-    return result;
-  } else {
-    int tid = ProfiledThread::currentTid();
-    Profiler::unregisterThread(tid);
-    ProfiledThread::release();
-    return pthread_setspecific(key, value);
-  }
-}
-
-void LibraryPatcher::patch_pthread_setspecific() {
-   ExclusiveLockGuard locker(&_lock);
-   // Already patched
-   if (_size != 0) return;
-   CodeCache *lib = Libraries::instance()->findJvmLibrary("libj9thr");
-   void** func_location = lib->findImport(im_pthread_setspecific);
-   if (func_location != nullptr) {
-     TEST_LOG("Patching %s", lib->name());
-     _patched_entries[0]._lib = lib;
-     _patched_entries[0]._location = func_location;
-     _patched_entries[0]._func = (void*)__atomic_load_n(func_location, __ATOMIC_RELAXED);
-     __atomic_store_n(func_location, (void*)pthread_setspecific_hook, __ATOMIC_RELAXED);
-     _size = 1;
   }
 }
 #endif // __linux__

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/DynamicNativeThread.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/DynamicNativeThread.java
@@ -51,10 +51,6 @@ public class DynamicNativeThread extends AbstractProfilerTest {
 
     @RetryingTest(3)
     public void test() {
-        // Exclude Musl for now due to a crash on aarch64
-        if (Platform.isMusl()) {
-            return;
-        }
         long[] threads = new long[8];
         for (int index = 0; index < threads.length; index++) {
             threads[index] = threadCreator.createThread();

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativethread/NativeThreadTest.java
@@ -40,10 +40,6 @@ public class NativeThreadTest extends AbstractProfilerTest {
 
   @RetryingTest(3)
   public void test() {
-      // Exclude Musl for now due to a crash on aarch64
-      if (Platform.isMusl()) {
-          return;
-      }
       long[] threads = new long[8];
       for (int index = 0; index < threads.length; index++) {
           threads[index] = NativeThreadCreator.createNativeThread();


### PR DESCRIPTION
**What does this PR do?**:
This is the final piece of instrumenting native threads. It fixed a crash on Linux/musl/aarch64/jdk11 and removed the special case for avoiding the crash.

**Motivation**:
Fixing the crash on particular platform so that we can cleanup the code by removing the special case.

**Additional Notes**:
The crash was peculiar, only happened on Linux/musl/aarch64/jdk11 in newly introduced thread startup wrapper.
Changed the data structure for passing the routine info from `struct` to `class` fixed the crash.


**How to test the change?**:
Unit tests:  used to crash on Linux/musl/aarch64/jdk11, now passed.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-13397](https://datadoghq.atlassian.net/browse/PROF-13397)

Unsure? Have a question? Request a review!


[PROF-13397]: https://datadoghq.atlassian.net/browse/PROF-13397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ