### PR TITLE
Use default cstack for tests and improve stackwalk test coverage

### DIFF
--- a/ddprof-test/src/test/java/com/datadoghq/profiler/classgc/ClassGCTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/classgc/ClassGCTest.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 public class ClassGCTest extends AbstractProfilerTest {
     @Override
     protected String getProfilerCommand() {
-        return "cpu=1ms,wall=1ms,filter=0,memory=524288:L,cstack=fp";
+        return "cpu=1ms,wall=1ms,filter=0,memory=524288:L";
     }
 
     private static final String CLASS_NAME = "code.Worker";

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/CpuDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/CpuDumpSmokeTest.java
@@ -19,7 +19,7 @@ public class CpuDumpSmokeTest extends JfrDumpTest {
     @RetryingTest(3)
     @Timeout(value = 60)
     @ValueSource(strings = {"vm", "fp", "dwarf"})
-    public void test() throws Exception {
+    public void test(@CStack String cstack) throws Exception {
         runTest("datadog.ExecutionSample");
     }
 }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/CpuDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/CpuDumpSmokeTest.java
@@ -3,9 +3,14 @@ package com.datadoghq.profiler.jfr;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junitpioneer.jupiter.RetryingTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.datadoghq.profiler.junit.CStack;
 
 public class CpuDumpSmokeTest extends JfrDumpTest {
-
+    public CpuDumpSmokeTest(@CStack String cstack) {
+        super(cstack);
+    }
     @Override
     protected String getProfilerCommand() {
         return "cpu=1ms";
@@ -13,6 +18,7 @@ public class CpuDumpSmokeTest extends JfrDumpTest {
 
     @RetryingTest(3)
     @Timeout(value = 60)
+    @ValueSource(strings = {"vm", "fp", "dwarf"})
     public void test() throws Exception {
         runTest("datadog.ExecutionSample");
     }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/CpuDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/CpuDumpSmokeTest.java
@@ -2,10 +2,11 @@ package com.datadoghq.profiler.jfr;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junitpioneer.jupiter.RetryingTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.TestTemplate;
 
 import com.datadoghq.profiler.junit.CStack;
+import com.datadoghq.profiler.junit.RetryTest;
 
 public class CpuDumpSmokeTest extends JfrDumpTest {
     public CpuDumpSmokeTest(@CStack String cstack) {
@@ -16,8 +17,9 @@ public class CpuDumpSmokeTest extends JfrDumpTest {
         return "cpu=1ms";
     }
 
-    @RetryingTest(3)
+    @RetryTest(3)
     @Timeout(value = 60)
+    @TestTemplate
     @ValueSource(strings = {"vm", "fp", "dwarf"})
     public void test(@CStack String cstack) throws Exception {
         runTest("datadog.ExecutionSample");

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/CpuDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/CpuDumpSmokeTest.java
@@ -8,7 +8,7 @@ public class CpuDumpSmokeTest extends JfrDumpTest {
 
     @Override
     protected String getProfilerCommand() {
-        return "cpu=1ms,cstack=fp";
+        return "cpu=1ms";
     }
 
     @RetryingTest(3)

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/CpuDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/CpuDumpSmokeTest.java
@@ -20,7 +20,7 @@ public class CpuDumpSmokeTest extends JfrDumpTest {
     @RetryTest(3)
     @Timeout(value = 60)
     @TestTemplate
-    @ValueSource(strings = {"vm", "fp", "dwarf"})
+    @ValueSource(strings = {"vm", "vmx", "fp", "dwarf"})
     public void test(@CStack String cstack) throws Exception {
         runTest("datadog.ExecutionSample");
     }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/JfrDumpTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/JfrDumpTest.java
@@ -1,6 +1,8 @@
 package com.datadoghq.profiler.jfr;
 
-import com.datadoghq.profiler.AbstractProfilerTest;
+import com.datadoghq.profiler.CStackAwareAbstractProfilerTest;
+import com.datadoghq.profiler.junit.RetryTest;
+import com.datadoghq.profiler.junit.CStack;
 import com.datadoghq.profiler.Platform;
 
 import java.io.File;
@@ -9,7 +11,10 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.Assumptions;
 
-public abstract class JfrDumpTest extends AbstractProfilerTest {
+public abstract class JfrDumpTest extends CStackAwareAbstractProfilerTest {
+    public JfrDumpTest(@CStack String cstack) {
+        super(cstack);
+    }
 
     public void runTest(String eventName) throws Exception {
         runTest(eventName, "method1", "method2", "method3");

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/ObjectSampleDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/ObjectSampleDumpSmokeTest.java
@@ -4,10 +4,11 @@ import com.datadoghq.profiler.Platform;
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.TestTemplate;
 
 import com.datadoghq.profiler.junit.CStack;
-import org.junitpioneer.jupiter.RetryingTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import com.datadoghq.profiler.junit.RetryTest;
 
 public class ObjectSampleDumpSmokeTest extends JfrDumpTest {
     public ObjectSampleDumpSmokeTest(@CStack String cstack) {
@@ -24,8 +25,9 @@ public class ObjectSampleDumpSmokeTest extends JfrDumpTest {
         return "memory=32:a";
     }
 
-    @RetryingTest(5)
+    @RetryTest(5)
     @Timeout(value = 300)
+    @TestTemplate
     @ValueSource(strings = {"vm", "fp", "dwarf"})
     public void test(@CStack String cstack) throws Exception {
         runTest("datadog.ObjectSample", 3, "method3");

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/ObjectSampleDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/ObjectSampleDumpSmokeTest.java
@@ -27,7 +27,7 @@ public class ObjectSampleDumpSmokeTest extends JfrDumpTest {
     @RetryingTest(5)
     @Timeout(value = 300)
     @ValueSource(strings = {"vm", "fp", "dwarf"})
-    public void test() throws Exception {
+    public void test(@CStack String cstack) throws Exception {
         runTest("datadog.ObjectSample", 3, "method3");
     }
 }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/ObjectSampleDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/ObjectSampleDumpSmokeTest.java
@@ -5,9 +5,15 @@ import com.datadoghq.profiler.Platform;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Timeout;
 
+import com.datadoghq.profiler.junit.CStack;
 import org.junitpioneer.jupiter.RetryingTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class ObjectSampleDumpSmokeTest extends JfrDumpTest {
+    public ObjectSampleDumpSmokeTest(@CStack String cstack) {
+        super(cstack);
+    }
+
     @Override
     protected boolean isPlatformSupported() {
         return !Platform.isJavaVersion(8) && !Platform.isJ9();
@@ -20,6 +26,7 @@ public class ObjectSampleDumpSmokeTest extends JfrDumpTest {
 
     @RetryingTest(5)
     @Timeout(value = 300)
+    @ValueSource(strings = {"vm", "fp", "dwarf"})
     public void test() throws Exception {
         runTest("datadog.ObjectSample", 3, "method3");
     }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/ObjectSampleDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/ObjectSampleDumpSmokeTest.java
@@ -28,7 +28,7 @@ public class ObjectSampleDumpSmokeTest extends JfrDumpTest {
     @RetryTest(5)
     @Timeout(value = 300)
     @TestTemplate
-    @ValueSource(strings = {"vm", "fp", "dwarf"})
+    @ValueSource(strings = {"vm", "vmx", "fp", "dwarf"})
     public void test(@CStack String cstack) throws Exception {
         runTest("datadog.ObjectSample", 3, "method3");
     }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/WallclockDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/WallclockDumpSmokeTest.java
@@ -20,7 +20,7 @@ public class WallclockDumpSmokeTest extends JfrDumpTest {
     @RetryingTest(3)
     @Timeout(value = 60)
     @ValueSource(strings = {"vm", "fp", "dwarf"})
-    public void test() throws Exception {
+    public void test(@CStack String cstack) throws Exception {
         registerCurrentThreadForWallClockProfiling();
         runTest("datadog.MethodSample");
     }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/WallclockDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/WallclockDumpSmokeTest.java
@@ -3,8 +3,14 @@ package com.datadoghq.profiler.jfr;
 import org.junit.jupiter.api.Timeout;
 
 import org.junitpioneer.jupiter.RetryingTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.datadoghq.profiler.junit.CStack;
 
 public class WallclockDumpSmokeTest extends JfrDumpTest {
+    public WallclockDumpSmokeTest(@CStack String cstack) {
+        super(cstack);
+    }
 
     @Override
     protected String getProfilerCommand() {
@@ -13,6 +19,7 @@ public class WallclockDumpSmokeTest extends JfrDumpTest {
 
     @RetryingTest(3)
     @Timeout(value = 60)
+    @ValueSource(strings = {"vm", "fp", "dwarf"})
     public void test() throws Exception {
         registerCurrentThreadForWallClockProfiling();
         runTest("datadog.MethodSample");

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/WallclockDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/WallclockDumpSmokeTest.java
@@ -1,11 +1,11 @@
 package com.datadoghq.profiler.jfr;
 
 import org.junit.jupiter.api.Timeout;
-
-import org.junitpioneer.jupiter.RetryingTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.TestTemplate;
 
 import com.datadoghq.profiler.junit.CStack;
+import com.datadoghq.profiler.junit.RetryTest;
 
 public class WallclockDumpSmokeTest extends JfrDumpTest {
     public WallclockDumpSmokeTest(@CStack String cstack) {
@@ -17,8 +17,9 @@ public class WallclockDumpSmokeTest extends JfrDumpTest {
         return "wall=5ms";
     }
 
-    @RetryingTest(3)
+    @RetryTest(3)
     @Timeout(value = 60)
+    @TestTemplate
     @ValueSource(strings = {"vm", "fp", "dwarf"})
     public void test(@CStack String cstack) throws Exception {
         registerCurrentThreadForWallClockProfiling();

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/WallclockDumpSmokeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/WallclockDumpSmokeTest.java
@@ -20,7 +20,7 @@ public class WallclockDumpSmokeTest extends JfrDumpTest {
     @RetryTest(3)
     @Timeout(value = 60)
     @TestTemplate
-    @ValueSource(strings = {"vm", "fp", "dwarf"})
+    @ValueSource(strings = {"vm", "vmx", "fp", "dwarf"})
     public void test(@CStack String cstack) throws Exception {
         registerCurrentThreadForWallClockProfiling();
         runTest("datadog.MethodSample");

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/GCGenerationsTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/GCGenerationsTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Assumptions;
 public class GCGenerationsTest extends AbstractProfilerTest {
     @Override
     protected String getProfilerCommand() {
-        return "memory=128,generations=true,cstack=fp";
+        return "memory=128,generations=true";
     }
 
     @Override

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/MemleakProfilerTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/MemleakProfilerTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Assumptions;
 public class MemleakProfilerTest extends AbstractProfilerTest {
     @Override
     protected String getProfilerCommand() {
-        return "memory=524288:L:0.5,cstack=fp";
+        return "memory=524288:L:0.5";
     }
 
     @Override

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativelibs/NativeLibrariesTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativelibs/NativeLibrariesTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class NativeLibrariesTest extends AbstractProfilerTest {
     @Override
     protected String getProfilerCommand() {
-        return "cpu=1ms";
+        return "cpu=1ms,cstack=" + (Platform.isMac() ? "fp" : "dwarf");
     }
 
     @RetryingTest(3)

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativelibs/NativeLibrariesTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativelibs/NativeLibrariesTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class NativeLibrariesTest extends AbstractProfilerTest {
     @Override
     protected String getProfilerCommand() {
-        return "cpu=1ms,cstack=" + (Platform.isMac() ? "fp" : "dwarf");
+        return "cpu=1ms";
     }
 
     @RetryingTest(3)


### PR DESCRIPTION
**What does this PR do?**:
Use platform default `cstack` value for running tests. Also improve stack walk test coverage for some of tests.

**Motivation**:
Improve test coverage.

**Additional Notes**:
`NativeLibrariesTest` is an exception, default value fails.

**How to test the change?**:
- Tests should pass

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-13013](https://datadoghq.atlassian.net/browse/PROF-13013)

Unsure? Have a question? Request a review!


[PROF-13013]: https://datadoghq.atlassian.net/browse/PROF-13013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ