### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Copyright 2026, Datadog, Inc
+
+# Default owners for all files in the repository
+* @DataDog/profiling-java


### PR DESCRIPTION
## Summary
- Add CODEOWNERS file designating @DataDog/profiling-java as owners for all repository files

## Test plan
- [x] CODEOWNERS file created in .github/ directory
- [x] Syntax verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)