### PR TITLE
Allow 'no-thread-filter' if 'filter' profiler argument is not provided

### DIFF
--- a/ddprof-lib/src/main/cpp/threadFilter.cpp
+++ b/ddprof-lib/src/main/cpp/threadFilter.cpp
@@ -289,7 +289,7 @@ void ThreadFilter::init(const char* filter) {
     // Only explicitly registered threads via addThread() will be sampled
     // Previously we had a syntax where we could manually force some thread IDs.
     // This is no longer supported.
-    _enabled.store(filter != nullptr, std::memory_order_release);
+    _enabled.store(filter != nullptr && strlen(filter) > 0, std::memory_order_release);
 }
 
 bool ThreadFilter::enabled() const {

--- a/ddprof-lib/src/test/cpp/threadFilter_ut.cpp
+++ b/ddprof-lib/src/test/cpp/threadFilter_ut.cpp
@@ -33,7 +33,7 @@ protected:
         // Install crash handler for debugging potential issues
         installGtestCrashHandler<THREAD_FILTER_TEST_NAME>();
         filter = std::make_unique<ThreadFilter>();
-        filter->init("");  // Enable filtering
+        filter->init("enabled");  // Enable filtering with non-empty string
     }
 
     void TearDown() override {
@@ -66,12 +66,27 @@ TEST_F(ThreadFilterTest, BasicRegisterAndAccept) {
 
 TEST_F(ThreadFilterTest, DisabledFilterAcceptsAll) {
     ThreadFilter disabled_filter;
-    disabled_filter.init(nullptr);  // Disabled
-    
+    disabled_filter.init(nullptr);  // Disabled with nullptr
+
     EXPECT_FALSE(disabled_filter.enabled());
     EXPECT_TRUE(disabled_filter.accept(-1));
     EXPECT_TRUE(disabled_filter.accept(0));
     EXPECT_TRUE(disabled_filter.accept(999999));
+}
+
+TEST_F(ThreadFilterTest, EmptyStringDisablesFilter) {
+    // Empty string should disable the filter (same as nullptr)
+    // This allows 'no-thread-filter' when 'filter' argument is provided without value
+    ThreadFilter empty_filter;
+    empty_filter.init("");  // Disabled with empty string
+
+    EXPECT_FALSE(empty_filter.enabled());
+    EXPECT_TRUE(empty_filter.accept(-1));
+    EXPECT_TRUE(empty_filter.accept(0));
+    EXPECT_TRUE(empty_filter.accept(999999));
+
+    // When disabled, registerThread() blocks new registrations
+    EXPECT_EQ(empty_filter.registerThread(), -1);
 }
 
 TEST_F(ThreadFilterTest, InvalidSlotHandling) {


### PR DESCRIPTION
**What does this PR do?**:
Re-enable 'no-thread-filter' mode

**Motivation**:
Some users want to run profiler without the tracer. Without this fix, wallclock will not generate any data.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
