### PR TITLE
Make JavaProfiler a javaagent

### DIFF
--- a/ddprof-lib/build.gradle
+++ b/ddprof-lib/build.gradle
@@ -310,6 +310,10 @@ buildConfigNames().each { name ->
       dependsOn copyTask
     }
 
+    manifest {
+      attributes 'Premain-Class': 'com.datadoghq.profiler.Main'
+    }
+
     from sourceSets.main.output.classesDirs
     from sourceSets.java9.output.classesDirs
     from files(libraryTargetBase(name)) {
@@ -457,6 +461,9 @@ tasks.withType(StripSymbols).configureEach {
 }
 
 jar {
+  manifest {
+    attributes 'Premain-Class': 'com.datadoghq.profiler.Main'
+  }
   dependsOn copyExternalLibs
   dependsOn tasks.named('compileJava9Java')
 }

--- a/ddprof-lib/build.gradle
+++ b/ddprof-lib/build.gradle
@@ -310,8 +310,10 @@ buildConfigNames().each { name ->
       dependsOn copyTask
     }
 
-    manifest {
-      attributes 'Premain-Class': 'com.datadoghq.profiler.Main'
+    if (name == 'debug') {
+      manifest {
+        attributes 'Premain-Class': 'com.datadoghq.profiler.Main'
+      }
     }
 
     from sourceSets.main.output.classesDirs
@@ -461,9 +463,6 @@ tasks.withType(StripSymbols).configureEach {
 }
 
 jar {
-  manifest {
-    attributes 'Premain-Class': 'com.datadoghq.profiler.Main'
-  }
   dependsOn copyExternalLibs
   dependsOn tasks.named('compileJava9Java')
 }

--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/Main.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/Main.java
@@ -1,6 +1,7 @@
 package com.datadoghq.profiler;
 
 import java.io.IOException;
+import java.lang.instrument.Instrumentation;
 
 public class Main {
     public static void main(String... args) throws IOException {
@@ -9,6 +10,15 @@ public class Main {
         profiler.execute(command);
         if (command.contains("start")) {
             profiler.stop();
+        }
+    }
+
+    public static void premain(String agentArgs, Instrumentation inst) {
+        try {
+            JavaProfiler profiler = JavaProfiler.getInstance();
+            profiler.execute(agentArgs);
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 }


### PR DESCRIPTION
**What does this PR do?**:
Make JavaProfiler a javaagent.

**Motivation**:
Mainly for development and testing, especially the code paths that interact with Java land.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-13585](https://datadoghq.atlassian.net/browse/PROF-13585)

Unsure? Have a question? Request a review!


[PROF-13585]: https://datadoghq.atlassian.net/browse/PROF-13585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ