### PR TITLE
Add alignment checks to NativeFunc mark methods

### DIFF
--- a/.github/actions/upsert-pr-comment/action.yml
+++ b/.github/actions/upsert-pr-comment/action.yml
@@ -7,6 +7,10 @@ inputs:
   body-file:
     description: "Path to file whose contents become the comment body"
     required: true
+  comment-id:
+    description: "Unique identifier for this comment type (used to find/update existing comment)"
+    required: false
+    default: "upsert-pr-comment"
   repo:        # optional; defaults to triggering repo
     description: "Repository (owner/repo)."
     required: false
@@ -31,25 +35,30 @@ runs:
       env:
         GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         BODY_FILE: ${{ inputs['body-file'] }}
+        COMMENT_ID: ${{ inputs['comment-id'] }}
         REPO: ${{ inputs.repo || github.repository }}
         PR:   ${{ inputs['pr-number'] || github.event.pull_request.number }}
       shell: bash
       run: |
         if [[ -s "$BODY_FILE" ]]; then
           set -e
-          # find last comment by this actor
-          # first, build a jq filter that embeds the actor’s login
-          filter=".[] | select(.user.login == \"${GITHUB_ACTOR}\") | .id"
+          # Create marker to identify this comment type
+          MARKER="<!-- ${COMMENT_ID} -->"
+
+          # Find existing comment with this marker
           cid=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
-                --jq "${filter}" | tail -n1)
-  
+                --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -n1)
+
+          # Prepend marker to body
+          BODY="${MARKER}"$'\n'"$(< "$BODY_FILE")"
+
           if [[ -n "$cid" ]]; then
             gh api --method PATCH "repos/$REPO/issues/comments/$cid" \
-              --raw-field body="$(< "$BODY_FILE")"
+              --raw-field body="$BODY"
             echo "✏️  Updated comment $cid"
           else
             gh api --method POST "repos/$REPO/issues/$PR/comments" \
-              --raw-field body="$(< "$BODY_FILE")"
+              --raw-field body="$BODY"
             echo "💬  Created new comment"
           fi
         else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
     tags-ignore:
       - v*
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
 permissions:
@@ -24,20 +25,18 @@ jobs:
     outputs:
       skip: ${{ steps.check.outputs.skip }}
     steps:
-      - name: Check if PR exists
+      - name: Check if PR exists for this branch (skip push if PR exists)
         id: check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REF: ${{ github.ref_name }}
         run: |
+          # On push events, base_ref is empty; skip if a PR already exists for this branch
           if [ -z "${{ github.base_ref }}" ]; then
             prs=$(gh pr list \
                 --repo "$GITHUB_REPOSITORY" \
-                --json baseRefName,headRefName \
-                --jq '
-                    map(select(.baseRefName == "${{ github.base_ref }}" and .headRefName == "$HEAD_REF}"))
-                    | length
-                ')
+                --json headRefName \
+                --jq "[.[] | select(.headRefName == env.HEAD_REF)] | length")
             if ((prs > 0)); then
                 echo "skip=true" >> "$GITHUB_OUTPUT"
             fi
@@ -116,19 +115,49 @@ jobs:
           # This ensures javadoc validation matches the exact conditions used during publishing
           ./gradlew :ddprof-lib:javadoc --no-daemon --parallel --build-cache --no-watch-fs
 
+  compute-configurations:
+    runs-on: ubuntu-latest
+    needs: check-for-pr
+    if: needs.check-for-pr.outputs.skip != 'true'
+    outputs:
+      configurations: ${{ steps.compute.outputs.configurations }}
+    steps:
+      - name: Debounce label events
+        if: github.event.action == 'labeled'
+        run: |
+          echo "Waiting 30s to allow adding multiple labels..."
+          sleep 30
+      - name: Compute test configurations from PR labels
+        id: compute
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Always include debug
+          configs='["debug"'
+
+          # For PRs, check labels; for push/workflow_dispatch, use debug only
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            labels=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} --jq '.labels[].name' 2>/dev/null) || labels=""
+
+            if echo "$labels" | grep -Fq "test:release"; then
+              configs="$configs"',"release"'
+            fi
+            if echo "$labels" | grep -Fq "test:asan"; then
+              configs="$configs"',"asan"'
+            fi
+            if echo "$labels" | grep -Fq "test:tsan"; then
+              configs="$configs"',"tsan"'
+            fi
+          fi
+
+          configs="$configs]"
+          echo "configurations=$configs" >> $GITHUB_OUTPUT
+          echo "Test configurations: $configs"
+
   test-matrix:
-    needs: check-formatting
+    needs: [check-for-pr, check-formatting, compute-configurations]
     if: needs.check-for-pr.outputs.skip != 'true'
     uses: ./.github/workflows/test_workflow.yml
     with:
-      configuration: '["debug"]'
+      configuration: ${{ needs.compute-configurations.outputs.configurations }}
 
-  gh-release:
-    if: startsWith(github.event.ref, 'refs/heads/release/')
-    runs-on: ubuntu-latest
-    needs: [test-matrix]
-    steps:
-      - name: Create Github Release
-        uses: ./.github/workflows/gh_release.yml@gh-release
-        with:
-          release_branch: ${GITHUB_REF_NAME}

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -52,6 +52,7 @@ jobs:
         uses: ./.github/actions/upsert-pr-comment
         with:
           body-file: comment.html
+          comment-id: scan-build-report
 
   codeql:
     if: needs.check-for-pr.outputs.skip != 'true'

--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -74,7 +74,7 @@ public:
     return func->_lib_index;
   }
 
-  static bool isMarked(const char *name) {
+  static bool is_marked(const char *name) {
     if (name == nullptr) {
       return false;
     }
@@ -85,7 +85,7 @@ public:
     return func->_mark != 0;
   }
 
-  static char mark(const char* name) {
+  static char read_mark(const char* name) {
     if (name == nullptr) {
       return 0;
     }
@@ -96,7 +96,7 @@ public:
     return func->_mark;
   }
 
-  static void mark(const char* name, char value) {
+  static void set_mark(const char* name, char value) {
     if (name == nullptr) {
       return;
     }
@@ -231,13 +231,13 @@ public:
       for (int i = 0; i < _count; i++) {
           const char* blob_name = _blobs[i]._name;
           if (blob_name != NULL && predicate(blob_name)) {
-              NativeFunc::mark(blob_name, value);
+              NativeFunc::set_mark(blob_name, value);
           }
       }
 
       if (value == MARK_VM_RUNTIME && _name != NULL) {
           // In case a library has no debug symbols
-          NativeFunc::mark(_name, value);
+          NativeFunc::set_mark(_name, value);
       }
   }
 

--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -75,14 +75,7 @@ public:
   }
 
   static bool is_marked(const char *name) {
-    if (name == nullptr) {
-      return false;
-    }
-    NativeFunc* func = from(name);
-    if (!is_aligned(func, sizeof(func))) {
-      return false;
-    }
-    return func->_mark != 0;
+    return read_mark(name) != 0;
   }
 
   static char read_mark(const char* name) {

--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -64,6 +64,9 @@ public:
   static void destroy(char *name);
 
   static short libIndex(const char *name) {
+    if (name == nullptr) {
+      return -1;
+    }
     NativeFunc* func = from(name);
     if (!is_aligned(func, sizeof(func))) {
       return -1;
@@ -71,14 +74,37 @@ public:
     return func->_lib_index;
   }
 
-  static bool isMarked(const char *name) { return from(name)->_mark != 0; }
+  static bool isMarked(const char *name) {
+    if (name == nullptr) {
+      return false;
+    }
+    NativeFunc* func = from(name);
+    if (!is_aligned(func, sizeof(func))) {
+      return false;
+    }
+    return func->_mark != 0;
+  }
 
   static char mark(const char* name) {
-      return from(name)->_mark;
+    if (name == nullptr) {
+      return 0;
+    }
+    NativeFunc* func = from(name);
+    if (!is_aligned(func, sizeof(func))) {
+      return 0;
+    }
+    return func->_mark;
   }
 
   static void mark(const char* name, char value) {
-      from(name)->_mark = value;
+    if (name == nullptr) {
+      return;
+    }
+    NativeFunc* func = from(name);
+    if (!is_aligned(func, sizeof(func))) {
+      return;
+    }
+    func->_mark = value;
   }
 };
 

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -375,7 +375,7 @@ Profiler::NativeFrameResolution Profiler::resolveNativeFrameForWalkVM(uintptr_t 
       // Get symbol name and check mark
       const char *method_name = nullptr;
       lib->binarySearch((void*)pc, &method_name);
-      char mark = (method_name != nullptr) ? NativeFunc::mark(method_name) : 0;
+      char mark = (method_name != nullptr) ? NativeFunc::read_mark(method_name) : 0;
 
       if (mark != 0) {
         return {nullptr, BCI_NATIVE_FRAME, true};  // Marked - stop processing
@@ -395,7 +395,7 @@ Profiler::NativeFrameResolution Profiler::resolveNativeFrameForWalkVM(uintptr_t 
 
   // Fallback: Traditional symbol resolution
   const char *method_name = findNativeMethod((void*)pc);
-  if (method_name != nullptr && NativeFunc::isMarked(method_name)) {
+  if (method_name != nullptr && NativeFunc::is_marked(method_name)) {
     return {nullptr, BCI_NATIVE_FRAME, true};
   }
 
@@ -427,7 +427,7 @@ int Profiler::convertNativeTrace(int native_frames, const void **callchain,
         // binarySearch() returns symbol name, then we check mark (O(1))
         const char *method_name = nullptr;
         lib->binarySearch((void*)pc, &method_name);
-        char mark = (method_name != nullptr) ? NativeFunc::mark(method_name) : 0;
+        char mark = (method_name != nullptr) ? NativeFunc::read_mark(method_name) : 0;
 
         if (mark != 0) {
           // Terminate scan at marked frame
@@ -450,7 +450,7 @@ int Profiler::convertNativeTrace(int native_frames, const void **callchain,
 
     // Fallback: Traditional symbol resolution
     const char *method_name = findNativeMethod((void*)pc);
-    if (method_name != nullptr && NativeFunc::isMarked(method_name)) {
+    if (method_name != nullptr && NativeFunc::is_marked(method_name)) {
       // Terminate scan at marked frame
       return depth;
     }

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -471,7 +471,7 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
             const char* method_name = (const char*)resolution.method_id;
             int frame_bci = resolution.bci;
             char mark;
-            if (frame_bci != BCI_NATIVE_FRAME_REMOTE && method_name != NULL && (mark = NativeFunc::mark(method_name)) != 0) {
+            if (frame_bci != BCI_NATIVE_FRAME_REMOTE && method_name != NULL && (mark = NativeFunc::read_mark(method_name)) != 0) {
                 if (mark == MARK_ASYNC_PROFILER && event_type == MALLOC_SAMPLE) {
                     // Skip all internal frames above malloc_hook functions, leave the hook itself
                     depth = 0;
@@ -516,7 +516,7 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
                     Profiler::NativeFrameResolution prev_resolution = profiler->resolveNativeFrameForWalkVM((uintptr_t)prev_native_pc, lock_index);
                     const char* prev_method_name = (const char*)prev_resolution.method_id;
                     if (prev_method_name != NULL) {
-                        char prev_mark = NativeFunc::mark(prev_method_name);
+                        char prev_mark = NativeFunc::read_mark(prev_method_name);
                         if (prev_mark == MARK_THREAD_ENTRY) {
                             // Thread entry point detected in previous frame (Rust thread_start, libc start_thread, etc.)
                             // This is the root frame - stop unwinding

--- a/ddprof-lib/src/main/cpp/utils.h
+++ b/ddprof-lib/src/main/cpp/utils.h
@@ -16,7 +16,7 @@ inline bool is_aligned(const T* ptr, size_t alignment) noexcept {
     auto iptr = reinterpret_cast<uintptr_t>(ptr);
 
     // Check if the integer value is a multiple of the alignment
-    return ((iptr & (~(alignment - 1))) == 0);
+    return ((iptr & (alignment - 1)) == 0);
 }
 
 inline size_t align_down(size_t size, size_t alignment) noexcept {

--- a/ddprof-lib/src/test/cpp/nativefunc_ut.cpp
+++ b/ddprof-lib/src/test/cpp/nativefunc_ut.cpp
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026, Datadog, Inc
+ */
+
+#include <gtest/gtest.h>
+#include <vector>
+#include "../../main/cpp/codeCache.h"
+#include "../../main/cpp/utils.h"
+#include "../../main/cpp/gtest_crash_handler.h"
+
+static constexpr char NATIVEFUNC_TEST_NAME[] = "NativeFuncTest";
+
+class NativeFuncTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        installGtestCrashHandler<NATIVEFUNC_TEST_NAME>();
+    }
+
+    void TearDown() override {
+        // Clean up any allocated NativeFunc instances
+        for (char* name : created_names) {
+            NativeFunc::destroy(name);
+        }
+        created_names.clear();
+        restoreDefaultSignalHandlers();
+    }
+
+    std::vector<char*> created_names;
+
+    char* createAndTrack(const char* name, short lib_index) {
+        char* result = NativeFunc::create(name, lib_index);
+        created_names.push_back(result);
+        return result;
+    }
+};
+
+TEST_F(NativeFuncTest, CreateReturnsNonNull) {
+    char* name = createAndTrack("test_function", 42);
+    ASSERT_NE(name, nullptr) << "NativeFunc::create() should not return nullptr";
+}
+
+TEST_F(NativeFuncTest, CreateReturnsAlignedPointer) {
+    char* name = createAndTrack("test_function", 42);
+    ASSERT_NE(name, nullptr);
+
+    // The NativeFunc struct pointer (backing up from name)
+    // should be aligned to sizeof(NativeFunc*)
+    NativeFunc* func_ptr = (NativeFunc*)(name - sizeof(NativeFunc));
+    EXPECT_TRUE(is_aligned(func_ptr, sizeof(NativeFunc*)))
+        << "NativeFunc structure must be aligned to sizeof(NativeFunc*) = " << sizeof(NativeFunc*)
+        << " for alignment checks to work correctly";
+}
+
+TEST_F(NativeFuncTest, CreatePreservesName) {
+    const char* input_name = "my_test_function";
+    char* name = createAndTrack(input_name, 1);
+    ASSERT_NE(name, nullptr);
+
+    EXPECT_STREQ(name, input_name)
+        << "NativeFunc::create() should preserve the function name";
+}
+
+TEST_F(NativeFuncTest, LibIndexAccessible) {
+    char* name = createAndTrack("my_function", 123);
+    ASSERT_NE(name, nullptr);
+
+    short lib_index = NativeFunc::libIndex(name);
+    EXPECT_EQ(lib_index, 123)
+        << "NativeFunc::libIndex() should return the lib_index set during create()";
+}
+
+TEST_F(NativeFuncTest, InitialMarkIsZero) {
+    char* name = createAndTrack("unmarked_function", 1);
+    ASSERT_NE(name, nullptr);
+
+    EXPECT_FALSE(NativeFunc::is_marked(name))
+        << "Newly created NativeFunc should not be marked (is_marked returns false)";
+    EXPECT_EQ(NativeFunc::read_mark(name), 0)
+        << "Newly created NativeFunc should have mark value of 0";
+}
+
+TEST_F(NativeFuncTest, SetAndReadMark) {
+    char* name = createAndTrack("marked_function", 1);
+    ASSERT_NE(name, nullptr);
+
+    // Set mark to MARK_THREAD_ENTRY (5)
+    NativeFunc::set_mark(name, 5);
+
+    // Verify mark was set
+    EXPECT_TRUE(NativeFunc::is_marked(name))
+        << "After set_mark(5), is_marked() should return true";
+    EXPECT_EQ(NativeFunc::read_mark(name), 5)
+        << "After set_mark(5), read_mark() should return 5";
+}
+
+TEST_F(NativeFuncTest, SetMultipleDifferentMarks) {
+    char* name1 = createAndTrack("func1", 1);
+    char* name2 = createAndTrack("func2", 2);
+    char* name3 = createAndTrack("func3", 3);
+
+    NativeFunc::set_mark(name1, MARK_VM_RUNTIME);
+    NativeFunc::set_mark(name2, MARK_INTERPRETER);
+    NativeFunc::set_mark(name3, MARK_THREAD_ENTRY);
+
+    EXPECT_EQ(NativeFunc::read_mark(name1), MARK_VM_RUNTIME);
+    EXPECT_EQ(NativeFunc::read_mark(name2), MARK_INTERPRETER);
+    EXPECT_EQ(NativeFunc::read_mark(name3), MARK_THREAD_ENTRY);
+}
+
+TEST_F(NativeFuncTest, OverwriteMark) {
+    char* name = createAndTrack("func", 1);
+    ASSERT_NE(name, nullptr);
+
+    // Set initial mark
+    NativeFunc::set_mark(name, MARK_INTERPRETER);
+    EXPECT_EQ(NativeFunc::read_mark(name), MARK_INTERPRETER);
+
+    // Overwrite with different mark
+    NativeFunc::set_mark(name, MARK_THREAD_ENTRY);
+    EXPECT_EQ(NativeFunc::read_mark(name), MARK_THREAD_ENTRY)
+        << "Marks should be overwritable";
+}
+
+TEST_F(NativeFuncTest, MarkOnNonNativeFuncPointerReturnsSafe) {
+    // Test that reading marks from random strings returns safe defaults
+    // without crashing (due to alignment check protection)
+    const char* random_string = "not_a_nativefunc";
+
+    // Should return safe defaults without crashing
+    EXPECT_FALSE(NativeFunc::is_marked(random_string))
+        << "is_marked() on non-NativeFunc string should return false (safe default)";
+    EXPECT_EQ(NativeFunc::read_mark(random_string), 0)
+        << "read_mark() on non-NativeFunc string should return 0 (safe default)";
+    EXPECT_EQ(NativeFunc::libIndex(random_string), -1)
+        << "libIndex() on non-NativeFunc string should return -1 (safe default)";
+}
+
+TEST_F(NativeFuncTest, NullPointerReturnsSafe) {
+    // Test that NULL pointer is handled safely
+    // The from() method computes (NativeFunc*)(nullptr - sizeof(NativeFunc))
+    // which is a large negative address that should fail alignment check
+
+    EXPECT_FALSE(NativeFunc::is_marked(nullptr))
+        << "is_marked(nullptr) should return false (safe default)";
+    EXPECT_EQ(NativeFunc::read_mark(nullptr), 0)
+        << "read_mark(nullptr) should return 0 (safe default)";
+    EXPECT_EQ(NativeFunc::libIndex(nullptr), -1)
+        << "libIndex(nullptr) should return -1 (safe default)";
+
+    // set_mark should be a no-op on nullptr (doesn't crash)
+    NativeFunc::set_mark(nullptr, MARK_THREAD_ENTRY);
+    // If we got here without crashing, the test passes
+}
+
+TEST_F(NativeFuncTest, MarkingDisabledDetection) {
+    // *** CRITICAL TEST ***
+    // This test would have caught the is_aligned() bug where marking was silently disabled.
+    // If is_aligned() is broken, marks won't be readable even though they're set.
+
+    char* name = createAndTrack("critical_test", 99);
+    ASSERT_NE(name, nullptr);
+
+    // Set a mark
+    NativeFunc::set_mark(name, MARK_THREAD_ENTRY);
+
+    // Read it back - if alignment check is broken, this returns 0
+    char mark = NativeFunc::read_mark(name);
+
+    ASSERT_EQ(mark, MARK_THREAD_ENTRY)
+        << "CRITICAL FAILURE: Marking appears to be disabled!\n"
+        << "Set mark to " << (int)MARK_THREAD_ENTRY << " but read back " << (int)mark << "\n"
+        << "\n"
+        << "This likely means:\n"
+        << "  1. is_aligned() has a bug (inverted logic? wrong mask?)\n"
+        << "  2. NativeFunc::read_mark() alignment check is failing\n"
+        << "  3. NativeFunc::set_mark() alignment check is failing\n"
+        << "\n"
+        << "Impact: ALL stack unwinding optimizations are broken:\n"
+        << "  - THREAD_ENTRY detection won't work\n"
+        << "  - COMPILER_ENTRY injection won't work\n"
+        << "  - VM_RUNTIME filtering won't work\n"
+        << "\n"
+        << "This is a critical performance regression.";
+}
+
+TEST_F(NativeFuncTest, AllMarkTypesWork) {
+    // Verify all mark enum values can be set and read
+    const char mark_values[] = {
+        MARK_VM_RUNTIME,
+        MARK_INTERPRETER,
+        MARK_COMPILER_ENTRY,
+        MARK_ASYNC_PROFILER,
+        MARK_THREAD_ENTRY
+    };
+
+    for (size_t i = 0; i < sizeof(mark_values); i++) {
+        char mark_value = mark_values[i];
+        char* name = createAndTrack("test", i);
+        ASSERT_NE(name, nullptr);
+
+        NativeFunc::set_mark(name, mark_value);
+        EXPECT_EQ(NativeFunc::read_mark(name), mark_value)
+            << "Mark value " << (int)mark_value << " should be readable after setting";
+    }
+}
+
+TEST_F(NativeFuncTest, MultipleAllocationsIndependent) {
+    // Create multiple NativeFunc instances and verify they're independent
+    char* name1 = createAndTrack("func1", 10);
+    char* name2 = createAndTrack("func2", 20);
+    char* name3 = createAndTrack("func3", 30);
+
+    ASSERT_NE(name1, nullptr);
+    ASSERT_NE(name2, nullptr);
+    ASSERT_NE(name3, nullptr);
+
+    // Set different marks
+    NativeFunc::set_mark(name1, 1);
+    NativeFunc::set_mark(name2, 2);
+    NativeFunc::set_mark(name3, 3);
+
+    // Verify independence
+    EXPECT_EQ(NativeFunc::read_mark(name1), 1);
+    EXPECT_EQ(NativeFunc::read_mark(name2), 2);
+    EXPECT_EQ(NativeFunc::read_mark(name3), 3);
+
+    EXPECT_EQ(NativeFunc::libIndex(name1), 10);
+    EXPECT_EQ(NativeFunc::libIndex(name2), 20);
+    EXPECT_EQ(NativeFunc::libIndex(name3), 30);
+}

--- a/ddprof-lib/src/test/cpp/utils_ut.cpp
+++ b/ddprof-lib/src/test/cpp/utils_ut.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026, Datadog, Inc
+ */
+
+#include <gtest/gtest.h>
+#include <cstdlib>
+#include "../../main/cpp/utils.h"
+#include "../../main/cpp/gtest_crash_handler.h"
+
+static constexpr char UTILS_TEST_NAME[] = "UtilsTest";
+
+class GlobalSetup {
+public:
+    GlobalSetup() {
+        installGtestCrashHandler<UTILS_TEST_NAME>();
+    }
+    ~GlobalSetup() {
+        restoreDefaultSignalHandlers();
+    }
+};
+
+static GlobalSetup global_setup;
+
+TEST(UtilsTest, IsAlignedNullPointer) {
+    // NULL should be aligned to any power-of-2
+    EXPECT_TRUE(is_aligned((void*)0x0, 1));
+    EXPECT_TRUE(is_aligned((void*)0x0, 2));
+    EXPECT_TRUE(is_aligned((void*)0x0, 4));
+    EXPECT_TRUE(is_aligned((void*)0x0, 8));
+    EXPECT_TRUE(is_aligned((void*)0x0, 16));
+}
+
+TEST(UtilsTest, IsAlignedValidPointers) {
+    // Aligned addresses
+    EXPECT_TRUE(is_aligned((void*)0x1000, 8)) << "0x1000 should be 8-byte aligned";
+    EXPECT_TRUE(is_aligned((void*)0x1008, 8)) << "0x1008 should be 8-byte aligned";
+    EXPECT_TRUE(is_aligned((void*)0x2000, 16)) << "0x2000 should be 16-byte aligned";
+    EXPECT_TRUE(is_aligned((void*)0x1000, 4)) << "0x1000 should be 4-byte aligned";
+
+    // Common heap addresses are typically aligned to sizeof(void*)
+    void* heap_mem = malloc(64);
+    ASSERT_NE(heap_mem, nullptr);
+    EXPECT_TRUE(is_aligned(heap_mem, sizeof(void*)))
+        << "malloc() should return pointer aligned to sizeof(void*)";
+    free(heap_mem);
+}
+
+TEST(UtilsTest, IsAlignedUnalignedPointers) {
+    // Unaligned addresses
+    EXPECT_FALSE(is_aligned((void*)0x1001, 8)) << "0x1001 is not 8-byte aligned (off by 1)";
+    EXPECT_FALSE(is_aligned((void*)0x1002, 8)) << "0x1002 is not 8-byte aligned (off by 2)";
+    EXPECT_FALSE(is_aligned((void*)0x1007, 8)) << "0x1007 is not 8-byte aligned (off by 7)";
+    EXPECT_FALSE(is_aligned((void*)0x100F, 16)) << "0x100F is not 16-byte aligned (off by 15)";
+    EXPECT_FALSE(is_aligned((void*)0x2001, 2)) << "0x2001 is not 2-byte aligned";
+}
+
+TEST(UtilsTest, IsAlignedPowerOf2Sizes) {
+    // Test various power-of-2 alignments on the same address
+    void* addr = (void*)0x1000;
+    EXPECT_TRUE(is_aligned(addr, 1));
+    EXPECT_TRUE(is_aligned(addr, 2));
+    EXPECT_TRUE(is_aligned(addr, 4));
+    EXPECT_TRUE(is_aligned(addr, 8));
+    EXPECT_TRUE(is_aligned(addr, 16));
+    EXPECT_TRUE(is_aligned(addr, 256));
+    EXPECT_TRUE(is_aligned(addr, 4096));
+}
+
+TEST(UtilsTest, IsAlignedCriticalBugCheck) {
+    // This test specifically catches the inverted logic bug where
+    // is_aligned() was incorrectly using ~(alignment-1) instead of (alignment-1)
+
+    void* aligned_ptr = (void*)0x1000;
+    void* unaligned_ptr = (void*)0x1001;
+
+    // With correct logic:
+    //   aligned: (0x1000 & 0x7) == 0 → true ✓
+    //   unaligned: (0x1001 & 0x7) == 1 → false ✓
+
+    // With INVERTED logic (the bug):
+    //   aligned: (0x1000 & ~0x7) == 0x1000 != 0 → false ✗
+    //   unaligned: (0x1001 & ~0x7) == 0x1000 != 0 → false ✗
+
+    ASSERT_TRUE(is_aligned(aligned_ptr, 8))
+        << "CRITICAL BUG: is_aligned() returns false for aligned pointer 0x1000! "
+        << "This suggests the alignment check logic is inverted. "
+        << "Expected: (ptr & (alignment-1)) == 0, "
+        << "Got: (ptr & ~(alignment-1)) == 0";
+
+    ASSERT_FALSE(is_aligned(unaligned_ptr, 8))
+        << "is_aligned() should return false for unaligned pointer 0x1001";
+}
+
+TEST(UtilsTest, AlignUpBasic) {
+    EXPECT_EQ(align_up(0, 8), 0);
+    EXPECT_EQ(align_up(1, 8), 8);
+    EXPECT_EQ(align_up(7, 8), 8);
+    EXPECT_EQ(align_up(8, 8), 8);
+    EXPECT_EQ(align_up(9, 8), 16);
+    EXPECT_EQ(align_up(15, 8), 16);
+    EXPECT_EQ(align_up(16, 8), 16);
+}
+
+TEST(UtilsTest, AlignDownBasic) {
+    EXPECT_EQ(align_down(0, 8), 0);
+    EXPECT_EQ(align_down(1, 8), 0);
+    EXPECT_EQ(align_down(7, 8), 0);
+    EXPECT_EQ(align_down(8, 8), 8);
+    EXPECT_EQ(align_down(9, 8), 8);
+    EXPECT_EQ(align_down(15, 8), 8);
+    EXPECT_EQ(align_down(16, 8), 16);
+}
+
+TEST(UtilsTest, IsPowerOf2) {
+    EXPECT_FALSE(is_power_of_2(0));
+    EXPECT_TRUE(is_power_of_2(1));
+    EXPECT_TRUE(is_power_of_2(2));
+    EXPECT_FALSE(is_power_of_2(3));
+    EXPECT_TRUE(is_power_of_2(4));
+    EXPECT_FALSE(is_power_of_2(5));
+    EXPECT_TRUE(is_power_of_2(8));
+    EXPECT_TRUE(is_power_of_2(16));
+    EXPECT_TRUE(is_power_of_2(256));
+    EXPECT_FALSE(is_power_of_2(255));
+}

--- a/doc/RemoteSymbolication.md
+++ b/doc/RemoteSymbolication.md
@@ -51,14 +51,14 @@ Modified frame collection to support dual modes:
 - `populateRemoteFrame()`: Packs pc_offset, mark, and lib_index into jmethodID field
 - `resolveNativeFrameForWalkVM()`: Resolves native frames for walkVM/walkVMX modes
   - Performs binarySearch() to get symbol name
-  - Extracts mark via NativeFunc::mark() (O(1))
+  - Extracts mark via NativeFunc::read_mark() (O(1))
   - Packs data using RemoteFramePacker::pack()
 - `convertNativeTrace()`: Converts raw PCs to frames for walkFP/walkDwarf modes
   - Checks marks to terminate at JVM internal frames
   - Calls populateRemoteFrame() to pack data
 
 **Mark Checking**:
-- Uses binarySearch() + NativeFunc::mark() approach (O(log n) + O(1))
+- Uses binarySearch() + NativeFunc::read_mark() approach (O(log n) + O(1))
 - Performance identical to traditional symbolication
 - Simpler than maintaining separate marked ranges index
 - Mark values packed into jmethodID for later unpacking
@@ -304,7 +304,7 @@ ddprof-test/src/test/java/
 
 ### Design Evolution
 - **Original approach**: Separate marked ranges index with O(log n) isMarkedAddress()
-- **Current approach**: Simplified to binarySearch() + NativeFunc::mark()
+- **Current approach**: Simplified to binarySearch() + NativeFunc::read_mark()
   - Same O(log n) performance but ~150 lines less code
   - Eliminated complexity of maintaining separate index
   - Marks packed into jmethodID for JFR serialization


### PR DESCRIPTION
**What does this PR do?**:

Fixes NativeFunc mark methods to prevent ASAN segfaults and adds CI workflow improvements for label-based test configuration selection.

**Core fix - NativeFunc marking:**
- Adds alignment validation to all NativeFunc mark-related methods (`isMarked`, `mark` getter/setter)
- Prevents segfaults when accessing marks on non-NativeFunc allocated strings
- Uses the same `is_aligned()` check pattern as `libIndex()`
- Invalid pointers now return safe defaults (false, 0, or no-op) instead of crashing
- Fixes inverted logic in `is_aligned()` helper
- Adds comprehensive tests for marking behavior

**CI workflow improvements:**
- Adds label-based test configuration: `test:release`, `test:asan`, `test:tsan`
- PRs always run `debug` config; labels add additional configurations
- 30-second debounce on label events allows adding multiple labels before run starts
- Fixes pre-existing bugs in `check-for-pr` job (broken jq expression)
- Removes dead `gh-release` job with invalid workflow syntax

**Motivation**:

ASAN tests revealed a segfault in `NativeFunc::mark()` at codeCache.h:77. The profiler was calling `mark()` on function names that weren't allocated via `NativeFunc::create()`, causing invalid memory access.

The CI changes enable easily running ASAN tests on PRs by adding the `test:asan` label, which was needed to properly validate this fix.

**How to test the change?**:

1. Run ASAN tests: `./gradlew :ddprof-test:testAsan`
2. Or add `test:asan` label to the PR to trigger ASAN CI run

The fix prevents crashes when the profiler encounters native frames from libraries without proper NativeFunc metadata.

**For Datadog employees**:

- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from @DataDog/security-design-and-guidance.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

🤖 Generated with [Claude Code](https://claude.com/claude-code)