### PR TITLE
Add SafeAccess protection and frame type validation for signal handlers

### DIFF
--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -78,16 +78,7 @@ public:
     return read_mark(name) != 0;
   }
 
-  static char read_mark(const char* name) {
-    if (name == nullptr) {
-      return 0;
-    }
-    NativeFunc* func = from(name);
-    if (!is_aligned(func, sizeof(func))) {
-      return 0;
-    }
-    return func->_mark;
-  }
+  static char read_mark(const char* name);
 
   static void set_mark(const char* name, char value) {
     if (name == nullptr) {

--- a/ddprof-lib/src/main/cpp/j9WallClock.cpp
+++ b/ddprof-lib/src/main/cpp/j9WallClock.cpp
@@ -91,7 +91,7 @@ void J9WallClock::timerLoop() {
         for (int j = 0; j < si->frame_count; j++) {
           jvmtiFrameInfoExtended *fi = &si->frame_buffer[j];
           frames[j].method_id = fi->method;
-          frames[j].bci = FrameType::encode(fi->type, fi->location);
+          frames[j].bci = FrameType::encode(sanitizeJ9FrameType(fi->type), fi->location);
         }
 
         int tid = J9Ext::GetOSThreadID(si->thread);

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -112,7 +112,7 @@ int StackWalker::walkFP(void* ucontext, const void** callchain, int max_depth, S
         }
 
         sp = fp + (FRAME_PC_SLOT + 1) * sizeof(void*);
-        fp = *(uintptr_t*)fp;
+        fp = (uintptr_t)SafeAccess::load((void**)fp);
     }
 
     if (truncated && depth > max_depth) {


### PR DESCRIPTION
**What does this PR do?**:

This PR adds SafeAccess protection to several critical code paths in signal handler context and fixes invalid frame type handling:

1. **SafeAccess for frame pointer walking**: Replaces raw pointer dereference with `SafeAccess::load()` in `StackWalker::walkFP()` to prevent ASan stack-buffer-overflow errors during frame pointer chain traversal.

2. **Frame type sanitization for J9**: Adds validation and clamping for frame types to prevent invalid `FrameTypeId` values (e.g., value 48 causing ASAN errors). Implements defensive clamping in `FrameType::decode()` using `FRAME_TYPE_MAX` constant and properly handles negative BCI values (BCI_WALL, BCI_ERROR, etc.) through `<= 0` check instead of `== 0`.

3. **SafeAccess for NativeFunc marking**: Adds SafeAccess protection to `NativeFunc::read_mark()` which is called from signal handler context during stack walking.

4. **Test stability improvements**: Fixes NPE and timing issues in flaky profiler tests, particularly in `JfrDumpTest` and `BaseContextWallClockTest`.

**Motivation**:

ASan detected multiple issues during signal handler execution:
- Stack-buffer-overflow in `walkFP()` when traversing into stack frames with local variables
- Invalid FrameTypeId values (e.g., 48) causing "not a valid value for type 'FrameTypeId'" errors
- SEGV in `NativeFunc::read_mark()` when accessing potentially unmapped memory

The `walkDwarf()` function already uses `SafeAccess::load()` consistently (lines 190, 194), but `walkFP()` was inconsistent - using SafeAccess for PC but not for FP.

**Additional Notes**:
- SafeAccess mechanism:
  - Uses assembly-level fault protection via `safefetch64_impl` / `safefetch32_impl`
  - If the read faults, the handler returns the default value (0/null), causing loops to exit naturally
  - Aligns `walkFP()` and `read_mark()` with the protection pattern used in `walkDwarf()`
- Frame type clamping:
  - `FRAME_TYPE_MAX` constant provides future-proof clamping instead of hardcoded bit masks
  - Properly handles negative special BCI values through arithmetic right shift sign extension
- Test infrastructure: `run_docker_tests.sh` can now target J9/OpenJ9 JVMs (8-j9, 11-j9, 17-j9, 21-j9)

**How to test the change?**:

Run ASan tests via CI (testAsan task).

The fixes prevent the following ASan errors that were occurring:
```
AddressSanitizer: stack-buffer-overflow in StackWalker::walkFP
READ of size 8 at address pointing to 'thread_count' (4 bytes)

runtime error: load of value 48, which is not a valid value for type 'FrameTypeId'

AddressSanitizer: SEGV in NativeFunc::read_mark(char const*)
```

**For Datadog employees**:

- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

Unsure? Have a question? Request a review!

🤖 Generated with [Claude Code](https://claude.com/claude-code)