### PR TITLE
Possible using duplicated keys to access MethodInfo hash table

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -336,7 +336,7 @@ MethodInfo *Lookup::resolveMethod(ASGCT_CallFrame &frame) {
   } else if (bci == BCI_ERROR || bci == BCI_NATIVE_FRAME) {
     key = MethodMap::makeKey((void*)method);
   } else if (bci == BCI_NATIVE_FRAME_REMOTE) {
-    key = MethodMap::makeRemoteKey((unsigned long)method);
+    key = MethodMap::makeKey((unsigned long)method);
   } else {
     assert(frame_type == FRAME_INTERPRETED || frame_type == FRAME_JIT_COMPILED ||
            frame_type == FRAME_INLINED || frame_type == FRAME_C1_COMPILED);

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -328,18 +328,19 @@ MethodInfo *Lookup::resolveMethod(ASGCT_CallFrame &frame) {
   static const char* UNKNOWN = "unknown";
   unsigned long key;
   jint bci = frame.bci;
-  FrameTypeId frame_type = FrameType::decode(bci);
 
   jmethodID method = frame.method_id;
   if (method == nullptr) {
-    key = MethodMap::makeKey((void*)UNKNOWN);
+    key = MethodMap::makeKey(UNKNOWN);
   } else if (bci == BCI_ERROR || bci == BCI_NATIVE_FRAME) {
-    key = MethodMap::makeKey((void*)method);
+    key = MethodMap::makeKey(frame.native_function_name);
   } else if (bci == BCI_NATIVE_FRAME_REMOTE) {
-    key = MethodMap::makeKey((unsigned long)method);
+    key = MethodMap::makeKey(frame.packed_remote_frame);
   } else {
+    FrameTypeId frame_type = FrameType::decode(bci);
     assert(frame_type == FRAME_INTERPRETED || frame_type == FRAME_JIT_COMPILED ||
-           frame_type == FRAME_INLINED || frame_type == FRAME_C1_COMPILED);
+           frame_type == FRAME_INLINED || frame_type == FRAME_C1_COMPILED ||
+           VM::isOpenJ9()); // OpenJ9 may have bugs that produce invalid frame types
     key = MethodMap::makeKey(method);
   }
 
@@ -351,10 +352,10 @@ MethodInfo *Lookup::resolveMethod(ASGCT_CallFrame &frame) {
     if (first_time) {
       mi->_key = _method_map->size() + 1; // avoid zero key
     }
-    if (method == NULL) {
-      fillNativeMethodInfo(mi, UNKNOWN, NULL);
+    if (method == nullptr) {
+      fillNativeMethodInfo(mi, UNKNOWN, nullptr);
     } else if (bci == BCI_ERROR) {
-      fillNativeMethodInfo(mi, (const char *)method, NULL);
+      fillNativeMethodInfo(mi, (const char *)method, nullptr);
     } else if (bci == BCI_NATIVE_FRAME) {
       const char *name = (const char *)method;
       fillNativeMethodInfo(mi, name,
@@ -362,12 +363,13 @@ MethodInfo *Lookup::resolveMethod(ASGCT_CallFrame &frame) {
     } else if (bci == BCI_NATIVE_FRAME_REMOTE) {
       // Unpack remote symbolication data using utility struct
       // Layout: pc_offset (44 bits) | mark (3 bits) | lib_index (15 bits)
-      uintptr_t pc_offset = Profiler::RemoteFramePacker::unpackPcOffset(method);
-      char mark = Profiler::RemoteFramePacker::unpackMark(method);
-      uint32_t lib_index = Profiler::RemoteFramePacker::unpackLibIndex(method);
+      unsigned long packed_remote_frame = frame.packed_remote_frame;
+      uintptr_t pc_offset = Profiler::RemoteFramePacker::unpackPcOffset(packed_remote_frame);
+      char mark = Profiler::RemoteFramePacker::unpackMark(packed_remote_frame);
+      uint32_t lib_index = Profiler::RemoteFramePacker::unpackLibIndex(packed_remote_frame);
 
-      TEST_LOG("Unpacking remote frame: packed=0x%lx, pc_offset=0x%lx, mark=%d, lib_index=%u",
-               (uintptr_t)method, pc_offset, (int)mark, lib_index);
+      TEST_LOG("Unpacking remote frame: packed=0x%zx, pc_offset=0x%lx, mark=%d, lib_index=%u",
+               packed_remote_frame, pc_offset, (int)mark, lib_index);
 
       // Lookup library by index to get build_id
       // Note: This is called during JFR serialization with lockAll() held (see Profiler::dump),
@@ -380,7 +382,7 @@ MethodInfo *Lookup::resolveMethod(ASGCT_CallFrame &frame) {
         fillRemoteFrameInfo(mi, &rfi);
       } else {
         TEST_LOG("WARNING: Library lookup failed for index %u", lib_index);
-        fillNativeMethodInfo(mi, "unknown_library", NULL);
+        fillNativeMethodInfo(mi, "unknown_library", nullptr);
       }
     } else {
       fillJavaMethodInfo(mi, method, first_time);

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -109,6 +109,15 @@ public:
 #define HIGHEST_BIT_MASK 0x8000000000000000ULL
 #define HIGHEST_2_BITS_MASK 0xC000000000000000ULL
 
+// MethodMap's key can be derived from 3 sources:
+// 1) jmethodID for Java methods
+// 2) void* address for native method names
+// 3) Encoded RemoteFrameInfo
+// The values of the keys are potentially overlapping, so we use 
+// the highest 2 bits to distinguish them.
+// 00 - jmethodID
+// 10 - void* address
+// 11 - RemoteFrameInfo
 class MethodMap : public std::map<unsigned long, MethodInfo> {
 public:
   MethodMap() {}
@@ -122,7 +131,7 @@ public:
     return ((unsigned long)addr | HIGHEST_BIT_MASK);
   }
 
-  static unsigned long makeRemoteKey(unsigned long key) {
+  static unsigned long makeKey(unsigned long key) {
     assert((key & HIGHEST_2_BITS_MASK) == 0);
     return (key | HIGHEST_2_BITS_MASK);
   }

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -106,9 +106,6 @@ public:
   }
 };
 
-#define HIGHEST_BIT_MASK 0x8000000000000000ULL
-#define HIGHEST_2_BITS_MASK 0xC000000000000000ULL
-
 // MethodMap's key can be derived from 3 sources:
 // 1) jmethodID for Java methods
 // 2) void* address for native method names
@@ -117,24 +114,31 @@ public:
 // the highest 2 bits to distinguish them.
 // 00 - jmethodID
 // 10 - void* address
-// 11 - RemoteFrameInfo
+// 01 - RemoteFrameInfo
 class MethodMap : public std::map<unsigned long, MethodInfo> {
 public:
+  static constexpr unsigned long ADDRESS_MARK = 0x8000000000000000ULL;
+  static constexpr unsigned long REMOTE_FRAME_MARK = 0x4000000000000000ULL;
+  static constexpr unsigned long KEY_TYPE_MASK = ADDRESS_MARK | REMOTE_FRAME_MARK;
+
   MethodMap() {}
 
   static unsigned long makeKey(jmethodID method) {
-    return (unsigned long)method;
+    unsigned long key = (unsigned long)method;
+    assert((key & KEY_TYPE_MASK) == 0);
+    return key;
   }
 
-  static unsigned long makeKey(void* addr) {
-    assert(((unsigned long)addr & HIGHEST_BIT_MASK) == 0);
-    return ((unsigned long)addr | HIGHEST_BIT_MASK);
+  static unsigned long makeKey(const char* addr) {
+    unsigned long key = (unsigned long)addr;
+    assert((key & KEY_TYPE_MASK) == 0);
+    return (key | ADDRESS_MARK);
   }
 
-  static unsigned long makeKey(unsigned long key) {
-    assert((key & HIGHEST_2_BITS_MASK) == 0);
-    return (key | HIGHEST_2_BITS_MASK);
-  }
+  static unsigned long makeKey(unsigned long packed_remote_frame) {
+    unsigned long key = packed_remote_frame;
+    assert((key & KEY_TYPE_MASK) == 0);
+    return (key | REMOTE_FRAME_MARK);}
 };
 
 class Recording {

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -106,9 +106,26 @@ public:
   }
 };
 
-class MethodMap : public std::map<jmethodID, MethodInfo> {
+#define HIGHEST_BIT_MASK 0x8000000000000000ULL
+#define HIGHEST_2_BITS_MASK 0xC000000000000000ULL
+
+class MethodMap : public std::map<unsigned long, MethodInfo> {
 public:
   MethodMap() {}
+
+  static unsigned long makeKey(jmethodID method) {
+    return (unsigned long)method;
+  }
+
+  static unsigned long makeKey(void* addr) {
+    assert(((unsigned long)addr & HIGHEST_BIT_MASK) == 0);
+    return ((unsigned long)addr | HIGHEST_BIT_MASK);
+  }
+
+  static unsigned long makeRemoteKey(unsigned long key) {
+    assert((key & HIGHEST_2_BITS_MASK) == 0);
+    return (key | HIGHEST_2_BITS_MASK);
+  }
 };
 
 class Recording {

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -343,13 +343,13 @@ void Profiler::populateRemoteFrame(ASGCT_CallFrame* frame, uintptr_t pc, CodeCac
   uintptr_t pc_offset = pc - (uintptr_t)lib->imageBase();
   uint32_t lib_index = (uint32_t)lib->libIndex();
 
-  jmethodID packed = RemoteFramePacker::pack(pc_offset, mark, lib_index);
+  unsigned long packed = RemoteFramePacker::pack(pc_offset, mark, lib_index);
 
-  TEST_LOG("populateRemoteFrame: lib=%s, build_id=%s, pc=0x%lx, pc_offset=0x%lx, mark=%d, lib_index=%u, packed=0x%lx",
-           lib->name(), lib->buildId(), pc, pc_offset, (int)mark, lib_index, (uintptr_t)packed);
+  TEST_LOG("populateRemoteFrame: lib=%s, build_id=%s, pc=0x%lx, pc_offset=0x%lx, mark=%d, lib_index=%u, packed=0x%zx",
+           lib->name(), lib->buildId(), pc, pc_offset, (int)mark, lib_index, packed);
 
   frame->bci = BCI_NATIVE_FRAME_REMOTE;
-  frame->method_id = packed;
+  frame->packed_remote_frame = packed;
 
   // Track remote symbolication usage
   Counters::increment(REMOTE_SYMBOLICATION_FRAMES);
@@ -384,22 +384,22 @@ Profiler::NativeFrameResolution Profiler::resolveNativeFrameForWalkVM(uintptr_t 
       // Pack remote symbolication data using utility struct
       uintptr_t pc_offset = pc - (uintptr_t)lib->imageBase();
       uint32_t lib_index = (uint32_t)lib->libIndex();
-      jmethodID packed = RemoteFramePacker::pack(pc_offset, mark, lib_index);
+      unsigned long packed = RemoteFramePacker::pack(pc_offset, mark, lib_index);
 
-      TEST_LOG("resolveNativeFrameForWalkVM: lib=%s, build_id=%s, pc=0x%lx, pc_offset=0x%lx, mark=%d, lib_index=%u, packed=0x%lx",
-               lib->name(), lib->buildId(), pc, pc_offset, (int)mark, lib_index, (uintptr_t)packed);
+      TEST_LOG("resolveNativeFrameForWalkVM: lib=%s, build_id=%s, pc=0x%lx, pc_offset=0x%lx, mark=%d, lib_index=%u, packed=0x%zx",
+               lib->name(), lib->buildId(), pc, pc_offset, (int)mark, lib_index, packed);
 
-      return {packed, BCI_NATIVE_FRAME_REMOTE, false};
+      return NativeFrameResolution(packed, BCI_NATIVE_FRAME_REMOTE, false);
     }
   }
 
   // Fallback: Traditional symbol resolution
   const char *method_name = findNativeMethod((void*)pc);
   if (method_name != nullptr && NativeFunc::is_marked(method_name)) {
-    return {nullptr, BCI_NATIVE_FRAME, true};
+    return NativeFrameResolution(nullptr, BCI_NATIVE_FRAME, true);
   }
 
-  return {(jmethodID)method_name, BCI_NATIVE_FRAME, false};
+  return NativeFrameResolution(method_name, BCI_NATIVE_FRAME, false);
 }
 
 /**

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -289,7 +289,8 @@ public:
    *
    *   Bits 0-43:   pc_offset (44 bits, 16 TB range)
    *   Bits 44-46:  mark (3 bits, 0-7 values)
-   *   Bits 47-63:  lib_index (17 bits, 128K libraries)
+   *   Bits 47-61:  lib_index (15 bits, 32K libraries)
+   *.  Bits 62-63:  reserved
    *
    * Mark values indicate JVM internal frames that should terminate stack walks:
    *   0 = no mark (regular native frame)
@@ -306,7 +307,7 @@ public:
   struct RemoteFramePacker {
     static const int PC_OFFSET_BITS = 44;
     static const int MARK_BITS = 3;
-    static const int LIB_INDEX_BITS = 17;
+    static const int LIB_INDEX_BITS = 15;
 
     static const uintptr_t PC_OFFSET_MASK = (1ULL << PC_OFFSET_BITS) - 1;  // 0xFFFFFFFFFFF (44 bits)
     static const uintptr_t MARK_MASK = (1ULL << MARK_BITS) - 1;             // 0x7 (3 bits)

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -468,7 +468,7 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
                 // This is a marked C++ interpreter frame, terminate scan
                 break;
             }
-            const char* method_name = (const char*)resolution.method_id;
+            const char* method_name = resolution.method_name;
             int frame_bci = resolution.bci;
             char mark;
             if (frame_bci != BCI_NATIVE_FRAME_REMOTE && method_name != NULL && (mark = NativeFunc::read_mark(method_name)) != 0) {
@@ -514,7 +514,7 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
                 // Check previous frame for thread entry points (Rust, libc/pthread)
                 if (prev_native_pc != NULL) {
                     Profiler::NativeFrameResolution prev_resolution = profiler->resolveNativeFrameForWalkVM((uintptr_t)prev_native_pc, lock_index);
-                    const char* prev_method_name = (const char*)prev_resolution.method_id;
+                    const char* prev_method_name = (const char*)prev_resolution.method_name;
                     if (prev_method_name != NULL) {
                         char prev_mark = NativeFunc::read_mark(prev_method_name);
                         if (prev_mark == MARK_THREAD_ENTRY) {

--- a/ddprof-lib/src/main/cpp/vmEntry.h
+++ b/ddprof-lib/src/main/cpp/vmEntry.h
@@ -52,12 +52,6 @@ enum ASGCT_Failure {
   ASGCT_FAILURE_TYPES = 12
 };
 
-typedef struct {
-    jint bci;
-    LP64_ONLY(jint padding;)
-    jmethodID method_id;
-} ASGCT_CallFrame;
-
 /**
  * Information for native frames requiring remote symbolication.
  * Used when bci == BCI_NATIVE_FRAME_REMOTE.
@@ -73,6 +67,16 @@ typedef struct RemoteFrameInfo {
         : build_id(bid), pc_offset(offset), lib_index(lib_idx) {}
 #endif
 } RemoteFrameInfo;
+
+typedef struct {
+    jint bci;
+    LP64_ONLY(jint padding;)
+    union {
+        jmethodID method_id;
+        unsigned long packed_remote_frame; // packed RemoteFrameInfo data
+        const char* native_function_name;
+    };
+} ASGCT_CallFrame;
 
 typedef struct {
   JNIEnv *env;

--- a/ddprof-lib/src/test/cpp/methodInfo_hash_ut.cpp
+++ b/ddprof-lib/src/test/cpp/methodInfo_hash_ut.cpp
@@ -1,0 +1,22 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "../../main/cpp/flightRecorder.h"
+
+
+class MethodInfoHashTest : public ::testing::Test {
+};
+
+TEST_F(MethodInfoHashTest, makeHashTest) {
+    unsigned long dummy = 0xABCD1234;
+    // jmethodID key
+    unsigned long key1 = MethodMap::makeKey((jmethodID)dummy);
+    // method name address key
+    unsigned long key2 = MethodMap::makeKey((const char*)dummy);
+    // packed remote frame key
+    unsigned long key3 = MethodMap::makeKey((unsigned long)dummy);
+
+    // The same value of different types should produce different keys
+    EXPECT_TRUE(key1 != key2);
+    EXPECT_TRUE(key1 != key3);
+    EXPECT_TRUE(key2 != key3);
+}


### PR DESCRIPTION
**What does this PR do?**:
Improves memory safety in signal handler contexts and hardens frame type handling for J9/OpenJ9 JVMs:
- Uses `SafeAccess` for `NativeFunc::read_mark()` to prevent SIGSEGV in signal handlers
- Uses `SafeAccess` for frame pointer dereference in `walkFP` stack walking
- Sanitizes J9 frame types to prevent invalid `FrameTypeId` values from corrupted JVMTI data
- Clamps `FrameType::decode()` to valid range to defend against corrupted BCI values

**Motivation**:
Signal handlers must not crash on invalid memory access. The previous direct struct field access in `read_mark()` and `walkFP` could cause crashes if the pointer was invalid. Additionally, J9's JVMTI extension can return unexpected frame type values that need sanitization before use.

**Additional Notes**:
- Also fixes NPE and timing issues in flaky profiler tests (`JfrDumpTest`, `BaseContextWallClockTest`)
- Adds J9/OpenJ9 JDK support to `run-docker-tests.sh` (8-j9, 11-j9, 17-j9, 21-j9 variants)
- Version bump to 1.38.0

**How to test the change?**:
- Existing unit tests cover the functionality
- `gtestDebug` includes `NativeFunc` tests for `read_mark()` behavior
- J9 tests can be run via `./utils/run-docker-tests.sh --jdk=21-j9`

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [ ] JIRA: [PROF-13622](https://datadoghq.atlassian.net/browse/PROF-13622)

Unsure? Have a question? Request a review!


[PROF-13622]: https://datadoghq.atlassian.net/browse/PROF-13622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ