### PR TITLE
Fix musl TLS init crash with signal blocking

### DIFF
--- a/.github/scripts/generate-test-summary.sh
+++ b/.github/scripts/generate-test-summary.sh
@@ -160,10 +160,10 @@ for key in "${!job_status[@]}"; do
     dur="${job_duration[$key]:-0}"
 
     case "$status" in
-        success)   ((passed_jobs++)) ;;
+        success)   ((++passed_jobs)) ;;
         failure)   ;;  # already counted
-        skipped)   ((skipped_jobs++)) ;;
-        cancelled) ((cancelled_jobs++)) ;;
+        skipped)   ((++skipped_jobs)) ;;
+        cancelled) ((++cancelled_jobs)) ;;
     esac
 
     ((total_duration += dur)) || true
@@ -257,9 +257,9 @@ log "Generating markdown summary..."
         echo ""
 
         # Separator row
-        printf "|----------|"
+        printf "%s" "|----------|"
         for _ in "${sorted_java[@]}"; do
-            printf "--------|"
+            printf "%s" "--------|"
         done
         echo ""
 

--- a/.github/scripts/generate-test-summary.sh
+++ b/.github/scripts/generate-test-summary.sh
@@ -91,7 +91,9 @@ while IFS= read -r job; do
 
     # Only process test jobs (match pattern: test-linux-{libc}-{arch} ({java}, {config}))
     # Note: regex stored in variable to avoid bash parsing issues with ) character
-    test_job_pattern='^test-linux-([a-z]+)-([a-z0-9]+) \(([^,]+), ([^)]+)\)$'
+    # Note: No ^ anchor because reusable workflow jobs are prefixed with caller job name
+    #       e.g., "test-matrix / test-linux-glibc-amd64 (8, debug)"
+    test_job_pattern='test-linux-([a-z]+)-([a-z0-9]+) \(([^,]+), ([^)]+)\)$'
     if [[ "$name" =~ $test_job_pattern ]]; then
         libc="${BASH_REMATCH[1]}"
         arch="${BASH_REMATCH[2]}"

--- a/ddprof-lib/src/main/cpp/callTraceStorage.cpp
+++ b/ddprof-lib/src/main/cpp/callTraceStorage.cpp
@@ -11,7 +11,7 @@
 #include "thread.h"
 #include "vmEntry.h" // For BCI_ERROR constant
 #include "arch.h" // For LP64_ONLY macro and COMMA macro
-#include "criticalSection.h" // For table swap critical sections
+#include "guards.h" // For table swap critical sections
 #include "primeProbing.h"
 #include "thread.h"
 #include <string.h>

--- a/ddprof-lib/src/main/cpp/ctimer.h
+++ b/ddprof-lib/src/main/cpp/ctimer.h
@@ -55,6 +55,9 @@ public:
   inline void enableEvents(bool enabled) {
     __atomic_store_n(&_enabled, enabled, __ATOMIC_RELEASE);
   }
+
+  // Get the signal number used by CTimer (0 if not initialized)
+  static int getSignal() { return _signal; }
 };
 
 #else

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -17,7 +17,7 @@
 
 #ifdef __linux__
 
-#include "criticalSection.h"
+#include "guards.h"
 #include "ctimer.h"
 #include "debugSupport.h"
 #include "libraries.h"

--- a/ddprof-lib/src/main/cpp/itimer.cpp
+++ b/ddprof-lib/src/main/cpp/itimer.cpp
@@ -23,7 +23,7 @@
 #include "thread.h"
 #include "threadState.inline.h"
 #include "vmStructs.h"
-#include "criticalSection.h"
+#include "guards.h"
 #include <sys/time.h>
 
 volatile bool ITimer::_enabled = false;

--- a/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
+++ b/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
@@ -20,7 +20,7 @@
 #include "arch.h"
 #include "arguments.h"
 #include "context.h"
-#include "criticalSection.h"
+#include "guards.h"
 #include "debugSupport.h"
 #include "libraries.h"
 #include "log.h"

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -7,7 +7,7 @@
 #include "profiler.h"
 #include "asyncSampleMutex.h"
 #include "context.h"
-#include "criticalSection.h"
+#include "guards.h"
 #include "common.h"
 #include "counters.h"
 #include "ctimer.h"

--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -15,7 +15,7 @@
 #include "thread.h"
 #include "threadState.inline.h"
 #include "vmStructs.h"
-#include "criticalSection.h"
+#include "guards.h"
 #include <math.h>
 #include <random>
 #include <algorithm> // For std::sort and std::binary_search

--- a/ddprof-lib/src/test/cpp/stress_callTraceStorage.cpp
+++ b/ddprof-lib/src/test/cpp/stress_callTraceStorage.cpp
@@ -6,7 +6,7 @@
 #include "gtest/gtest.h"
 #include "callTraceStorage.h"
 #include "callTraceHashTable.h"
-#include "criticalSection.h"
+#include "guards.h"
 #include <vector>
 #include <unordered_set>
 #include <thread>


### PR DESCRIPTION
**What does this PR do?**:
Fixes a crash on musl libc systems where profiling signal handlers interrupt thread-local storage (TLS) initialization, causing reentrancy into musl's non-reentrant TLS setup code.

**Motivation**:
On musl-based systems (Alpine Linux, embedded systems), the profiler crashes with this stack trace:
```
#0 Recording::recordExecutionSample
#1 FlightRecorder::recordEvent
#2 Profiler::recordSample
#3 CTimer::signalHandler         ← Signal handler runs
#4 ld-musl-x86_64.so.1           ← INSIDE musl's TLS initialization
#5 Java_...initializeContextTls0 ← JNI call accessing context_tls_v1
```

The issue occurs because:
1. Thread calls `initializeContextTls0()` which accesses `context_tls_v1` (thread_local variable)
2. First access to thread_local triggers musl's TLS initialization
3. Profiling signal (SIGPROF/SIGVTALRM/CTimer) arrives during musl's TLS setup
4. Signal handler tries to access ProfiledThread TLS via `pthread_getspecific()`
5. This reenters musl's non-reentrant TLS code → crash/deadlock

**Additional Notes**:
- The fix uses RAII-based signal blocking during the critical TLS initialization window
- Consolidates `CriticalSection` and new `SignalBlocker` into unified `guards.h/cpp` module
- Uses proper ACQUIRE/RELEASE memory ordering for thread safety
- Blocks all profiling signals: SIGPROF, SIGVTALRM, and RT signals (SIGRTMIN to SIGRTMIN+5)
- All 128 tests pass after the fix

**How to test the change?**:
1. **Automated tests**: All existing tests pass (128/128), including TLS-related tests:
   - `gtestDebug_context_sanity_ut` - Context TLS tests
   - `gtestDebug_test_tlsPriming` - TLS priming tests
   - `gtestDebug_stress_callTraceStorage` - Uses CriticalSection

2. **Manual testing on musl**: Deploy on Alpine Linux or musl-based system with high thread creation rate during active profiling to reproduce the race condition.

3. **Code review**: Focus areas:
   - Thread safety: ACQUIRE/RELEASE memory ordering in guards.cpp
   - Async-signal safety: Signal blocking covers all profiling signals
   - Exception safety: RAII pattern guarantees signal mask restoration

**For Datadog employees**:
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-13683](https://datadoghq.atlassian.net/browse/PROF-13683)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PROF-13683]: https://datadoghq.atlassian.net/browse/PROF-13683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ