### PR TITLE
Mitigating VMMethod::id() crash

### DIFF
--- a/ddprof-lib/src/main/cpp/safeAccess.h
+++ b/ddprof-lib/src/main/cpp/safeAccess.h
@@ -73,6 +73,11 @@ public:
 
   NOINLINE __attribute__((aligned(16)))
   static void *loadPtr(void** ptr, void* default_value);
+
+  static inline bool isReadable(void* ptr) {
+    return load32((int32_t*)ptr, 1) != 1 ||
+           load32((int32_t*)ptr, -1) != -1; 
+  }
 };
 
 #endif // _SAFEACCESS_H

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -59,7 +59,7 @@ static inline void fillFrame(ASGCT_CallFrame& frame, FrameTypeId type, int bci, 
 }
 
 static jmethodID getMethodId(VMMethod* method) {
-    if (!inDeadZone(method) && aligned((uintptr_t)method)) {
+    if (!inDeadZone(method) && aligned((uintptr_t)method) && SafeAccess::isReadable((void*)method)) {
         return method->validatedId();
     }
     return NULL;

--- a/ddprof-lib/src/test/cpp/safefetch_ut.cpp
+++ b/ddprof-lib/src/test/cpp/safefetch_ut.cpp
@@ -105,6 +105,12 @@ TEST_F(SafeFetchTest, invalidAccessPtr) {
   EXPECT_EQ(res, bp);
 }
 
+TEST_F(SafeFetchTest, isReadable) {
+  char c = 'x';
+  EXPECT_TRUE(SafeAccess::isReadable(&c));
+  EXPECT_FALSE(SafeAccess::isReadable(nullptr));
+}
+
 /**
  * Tests that safeFetch32 correctly handles mprotected memory.
  *


### PR DESCRIPTION
**What does this PR do?**:
Mitigating `VMMethod::id()` crashes in latest release.
 
**Motivation**:
Currently,  crash tracker report does not provide sufficient information to identify the root cause. While we are waiting for [DataDog/dd-trace-java #10544 Preserve the function relative address when parsing a crash](https://github.com/DataDog/dd-trace-java/pull/10544) to gather more information to solve the mysteries, let's provide a mitigation for this crash.

Other than `SafeAccess`s inside `VMMethod::id()` method, `VMMethod*` can be invalid, e.g. points to unmapped memory, let's validates the memory before the access. 

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
-Regular tests
-New gtest to verify new `SafeAccess::isReadable()`

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [ ] JIRA: [PROF-13655](https://datadoghq.atlassian.net/browse/PROF-13655)

Unsure? Have a question? Request a review!


[PROF-13655]: https://datadoghq.atlassian.net/browse/PROF-13655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ