### PR TITLE
Fix stack walking alignment issues causing ASAN violations

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,18 +20,30 @@ jobs:
     needs: run-test
     if: failure()
     steps:
-      - name: Download failed tests artifact
+      - name: Download all failure artifacts
         uses: actions/download-artifact@v4
         with:
-          name: failures
+          pattern: failures-*
           path: ./artifacts
+          merge-multiple: true
       - name: Report failures
         run: |
-          find ./artifacts -name 'failures_*' -exec cat {} \; > ./artifacts/failures.txt
-          scenarios=$(cat ./artifacts/failures.txt | tr '\n' ',')
-          
+          # Check if any failure files exist
+          if ! ls ./artifacts/failures_*.txt 1> /dev/null 2>&1; then
+            echo "No failure artifacts found"
+            exit 0
+          fi
+
+          # Combine all failure files
+          find ./artifacts -name 'failures_*.txt' -exec cat {} \; > ./artifacts/all_failures.txt
+          scenarios=$(cat ./artifacts/all_failures.txt | tr '\n' ',' | sed 's/,$//')
+
           echo "Failed scenarios: $scenarios"
 
-          curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
-               -H 'Content-Type: application/json' \
-               -d "{'scenarios': '${scenarios}', 'failed_run_url': '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'}"
+          if [ -n "${{ secrets.SLACK_WEBHOOK }}" ]; then
+            curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+                 -H 'Content-Type: application/json' \
+                 -d "{\"scenarios\": \"${scenarios}\", \"failed_run_url\": \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
+          else
+            echo "SLACK_WEBHOOK not configured, skipping notification"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,38 @@ Release builds automatically extract debug symbols via `NativeLinkTask`, reducin
 
 **See:** `build-logic/README.md` for full documentation
 
+### Docker-based Testing (Recommended for ASan/Non-Local Environments)
+
+**When to use**: For ASan testing, cross-architecture testing (aarch64), different libc variants (musl), or reproducing CI environment issues.
+
+```bash
+# ASan tests on aarch64 Linux
+./utils/run-docker-tests.sh --arch=aarch64 --config=asan --libc=glibc --jdk=21
+
+# Run specific test pattern
+./utils/run-docker-tests.sh --arch=aarch64 --tests="*SpecificTest*"
+
+# Enable C++ gtests
+./utils/run-docker-tests.sh --arch=aarch64 --gtest
+
+# Drop to shell for debugging
+./utils/run-docker-tests.sh --arch=aarch64 --shell
+
+# Test with musl libc
+./utils/run-docker-tests.sh --libc=musl --jdk=21
+
+# Test with OpenJ9
+./utils/run-docker-tests.sh --jdk=21-j9
+
+# Use mounted repo (faster, but may have stale artifacts)
+./utils/run-docker-tests.sh --mount
+
+# Rebuild Docker images
+./utils/run-docker-tests.sh --rebuild
+```
+
+**Note**: The Docker script supports `--config=debug|release|asan|tsan`. Use this for cross-architecture testing and reproducing CI environments. For local development, use `./gradlew testAsan` directly.
+
 ### Build Options
 ```bash
 # Skip native compilation

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -17,7 +17,7 @@
 
 const uintptr_t MAX_WALK_SIZE = 0x100000;
 const intptr_t MAX_INTERPRETER_FRAME_SIZE = 0x1000;
-const intptr_t MAX_FRAME_SIZE_WORDS = MAX_FRAME_SIZE / sizeof(void*);  // 0x8000 = 32768 words
+const intptr_t MAX_FRAME_SIZE_WORDS = StackWalkValidation::MAX_FRAME_SIZE / sizeof(void*);  // 0x8000 = 32768 words
 
 static ucontext_t empty_ucontext{};
 


### PR DESCRIPTION
**What does this PR do?**:

Fixes critical alignment issues in stack walking that were causing ASAN violations during nightly runs.

Primary fixes:
- **Adds alignment checks before all pointer dereferences in stack unwinding** - prevents misaligned memory access that triggers undefined behavior and ASAN errors
- **Adds frame size validation** - prevents walking into invalid memory regions with corrupted frame sizes

Supporting improvements:
- Adds deoptimization check before walking compiled frames
- Applies SafeAccess::load consistently in DWARF unwinding paths
- Enables ASAN/TSAN build configurations in Docker test script
- Fixes nightly workflow's report-failures job artifact collection

**Motivation**:

A recent nightly ASAN run identified alignment violations in stack walking - https://github.com/DataDog/java-profiler/actions/runs/21851118212/job/63057859995#step:9:363

The issue occurred when sp (stack pointer) was not properly aligned before being dereferenced as a pointer. Without alignment checks, the profiler could attempt to read from misaligned addresses, causing:
- Undefined behavior on architectures that require aligned access
- ASAN violations flagging the memory safety issue
- Potential crashes or data corruption

This PR systematically adds alignment validation at all pointer dereference sites in the stack walking code paths (walkVM, walkDwarf), ensuring memory is only accessed at properly aligned boundaries.

**Additional Notes**:

The alignment checks follow the pattern already established in the codebase but weren't consistently applied across all unwinding paths. Frame size validation prevents walking beyond reasonable frame boundaries (MAX_FRAME_SIZE_WORDS = 32768 words).

**How to test the change?**:

1. Run local ASAN tests: `./gradlew testAsan`
2. Run Docker-based ASAN tests: `./utils/run-docker-tests.sh --config=asan --jdk=21`
3. Verify no ASAN violations are reported
4. Existing tests should pass without degradation

**For Datadog employees**:

- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-13712](https://datadoghq.atlassian.net/browse/PROF-13712)

[PROF-13712]: https://datadoghq.atlassian.net/browse/PROF-13712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ