### PR TITLE
Fix build-and-summarize script and description

### DIFF
--- a/.claude/commands/build-and-summarize
+++ b/.claude/commands/build-and-summarize
@@ -72,4 +72,8 @@ echo
 echo "Delegating to gradle-logs-analyst agent…"
 # If your CLI supports non-streaming, set it here to avoid verbose output.
 # Example (uncomment if supported): export CLAUDE_NO_STREAM=1
+
+# Sub-agents would inherit the full parent env, including CLAUDECODE, which
+# apparently causes problems with some versions of Claude (e.g. 4.6).
+unset CLAUDECODE
 claude "Act as the gradle-logs-analyst agent to parse the build log at: $LOG. Generate the required Gradle summary artifacts as specified in the gradle-logs-analyst agent definition."

--- a/.claude/commands/build-and-summarize.md
+++ b/.claude/commands/build-and-summarize.md
@@ -1,6 +1,6 @@
 # build-and-summarize
 
-Execute the bash script `~/.claude/commands/build-and-summarize` with all provided arguments.
+Execute the bash script `.claude/commands/build-and-summarize` with all provided arguments.
 
 This script will:
 - Run `./gradlew` with the specified arguments (defaults to 'build' if none provided)


### PR DESCRIPTION
**What does this PR do?**:
Fix the build-and-summarize script/description. The description should reference the project-based build-and-summarize script, not the per-user script. The script itself failed to launch the subagent at the end, because the environment inherited the whole parent env, including CLAUDECODE, which apparently causes the subagent to fail (at least here, claude 4.6).

**Motivation**:
Improve agentic workflow.

**Additional Notes**:
None

**How to test the change?**:
Tell Claude Code to build and test the project.

**For Datadog employees**:
- [x] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
