### PR TITLE
Add gdb to Docker test containers

### DIFF
--- a/utils/run-docker-tests.sh
+++ b/utils/run-docker-tests.sh
@@ -13,7 +13,7 @@
 #   --config=debug|release|asan|tsan   (default: debug)
 #   --tests="TestPattern"    (optional, specific test to run)
 #   --gtest                  (enable C++ gtests, disabled by default)
-#   --shell                  (drop to shell instead of running tests)
+#   --shell                  (drop to shell instead of running tests; enables SYS_PTRACE for gdb)
 #   --mount                  (mount local repo instead of cloning - faster but may have stale artifacts)
 #   --rebuild                (force rebuild of Docker images)
 #   --rebuild-base           (force rebuild of base image only)
@@ -275,7 +275,7 @@ RUN apk update && \
     apk add --no-cache \
         curl wget bash make g++ clang git jq cmake coreutils \
         gtest-dev gmock tar binutils musl-dbg linux-headers \
-        compiler-rt llvm openssh-client
+        compiler-rt llvm openssh-client gdb
 
 # Set up Gradle cache directory
 ENV GRADLE_USER_HOME=/gradle-cache
@@ -299,7 +299,7 @@ RUN apt-get update && \
         curl wget bash make g++ clang git jq cmake \
         libgtest-dev libgmock-dev tar binutils libc6-dbg \
         ca-certificates linux-libc-dev \
-        libasan6 libtsan0 openssh-client && \
+        libasan6 libtsan0 openssh-client build-essential gdb && \
     rm -rf /var/lib/apt/lists/*
 
 # Set up Gradle cache directory
@@ -430,7 +430,7 @@ GRADLE_CMD="$GRADLE_CMD --no-daemon --parallel --build-cache --no-watch-fs"
 # Build Docker run command base
 DOCKER_CMD="docker run --rm"
 if $SHELL_MODE; then
-    DOCKER_CMD="$DOCKER_CMD -it"
+    DOCKER_CMD="$DOCKER_CMD -it --init --ulimit core=-1 --cap-add=SYS_PTRACE"
 fi
 DOCKER_CMD="$DOCKER_CMD $DOCKER_PLATFORM"
 DOCKER_CMD="$DOCKER_CMD -e LIBC=$LIBC"


### PR DESCRIPTION
**What does this PR do?**:

- Install gdb in Alpine (musl) base image
- Add --cap-add=SYS_PTRACE and --init/--ulimit flags to shell mode so gdb can ptrace processes inside the container

**Motivation**:
Add ability to debug crashes encountered during the test runs.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
- Run `./utils/run-docker-tests.sh --libc=musl --jdk=11 --shell --mount`
- Inside docker shell, run `gdb`
- `gdb` should execute

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
- [X] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
