### PR TITLE
Improve walkVM stack unwinding quality

### DIFF
--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -83,7 +83,16 @@
   X(WALKVM_ANCHOR_CONSUMED, "walkvm_anchor_consumed")                          \
   X(WALKVM_BREAK_INTERPRETED, "walkvm_break_interpreted")                      \
   X(WALKVM_BREAK_COMPILED, "walkvm_break_compiled")                            \
-  X(WALKVM_JAVA_FRAME_OK, "walkvm_java_frame_ok")
+  X(WALKVM_JAVA_FRAME_OK, "walkvm_java_frame_ok")                            \
+  X(WALKVM_ANCHOR_INLINE_NO_ANCHOR, "walkvm_anchor_inline_no_anchor")        \
+  X(WALKVM_ANCHOR_INLINE_NO_SP, "walkvm_anchor_inline_no_sp")                \
+  X(WALKVM_ANCHOR_INLINE_BAD_SP, "walkvm_anchor_inline_bad_sp")              \
+  X(WALKVM_SAVED_ANCHOR_USED, "walkvm_saved_anchor_used")                    \
+  X(WALKVM_STUB_GENERIC_UNWIND, "walkvm_stub_generic_unwind")                \
+  X(WALKVM_STUB_FRAMESIZE_FALLBACK, "walkvm_stub_framesize_fallback")        \
+  X(WALKVM_FP_CHAIN_ATTEMPT, "walkvm_fp_chain_attempt")                      \
+  X(WALKVM_FP_CHAIN_REACHED_CODEHEAP, "walkvm_fp_chain_reached_codeheap")    \
+  X(WALKVM_ANCHOR_NOT_IN_JAVA, "walkvm_anchor_not_in_java")
 #define X_ENUM(a, b) a,
 typedef enum CounterId : int {
   DD_COUNTER_TABLE(X_ENUM) DD_NUM_COUNTERS

--- a/ddprof-lib/src/main/cpp/stackFrame_aarch64.cpp
+++ b/ddprof-lib/src/main/cpp/stackFrame_aarch64.cpp
@@ -11,6 +11,7 @@
 #include "stackFrame.h"
 #include "safeAccess.h"
 #include "vmStructs.h"
+#include "counters.h"
 
 
 #ifdef __APPLE__
@@ -188,6 +189,23 @@ bool StackFrame::unwindStub(instruction_t* entry, const char* name, uintptr_t& p
         }
         return true;
     }
+
+    // Generic fallback: detect standard aarch64 frame prologue
+    //   stp x29, x30, [sp, #-16]!  (0xa9bf7bfd)
+    //   mov x29, sp                 (0x910003fd)
+    // This catches JVM stubs not in the hardcoded whitelist.
+    if (entry != NULL && withinCurrentStack(fp)) {
+        for (int i = 0; i < 8 && entry + i < ip; i++) {
+            if (entry[i] == 0xa9bf7bfd && i + 1 < 8 && entry + i + 1 < ip && entry[i + 1] == 0x910003fd) {
+                sp = fp + 16;
+                fp = ((uintptr_t*)sp)[-2];
+                pc = ((uintptr_t*)sp)[-1];
+                Counters::increment(WALKVM_STUB_GENERIC_UNWIND);
+                return true;
+            }
+        }
+    }
+
     return false;
 }
 

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -292,6 +292,7 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
     // Should be preserved across setjmp/longjmp
     volatile int depth = 0;
     int actual_max_depth = truncated ? max_depth + 1 : max_depth;
+    bool fp_chain_fallback = false;
 
     ProfiledThread* profiled_thread = ProfiledThread::currentSignalSafe();
 
@@ -318,6 +319,13 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
     }
 
     const void* prev_native_pc = NULL;
+
+    // Saved anchor data — preserved across anchor consumption so inline
+    // recovery can redirect even after the anchor pointer has been set to NULL.
+    const void* saved_anchor_pc = NULL;
+    uintptr_t saved_anchor_sp = 0;
+    uintptr_t saved_anchor_fp = 0;
+
     // Show extended frame types and stub frames for execution-type events
     bool details = event_type <= MALLOC_SAMPLE || features.mixed;
 
@@ -331,6 +339,10 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
     while (depth < actual_max_depth) {
         if (CodeHeap::contains(pc)) {
             Counters::increment(WALKVM_HIT_CODEHEAP);
+            if (fp_chain_fallback) {
+                Counters::increment(WALKVM_FP_CHAIN_REACHED_CODEHEAP);
+                fp_chain_fallback = false;
+            }
             // If we're in JVM-generated code but don't have a VMThread, we cannot safely
             // walk the Java stack because crash protection is not set up.
             //
@@ -364,6 +376,13 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
             // Do not treat the topmost stub as Java frame.
             if (anchor != NULL && (depth > 0 || !nm->isStub())) {
                 Counters::increment(WALKVM_ANCHOR_CONSUMED);
+                // Preserve anchor data before consumption — getFrame() is read-only
+                // but we set anchor=NULL below, losing the pointer for later recovery.
+                if (saved_anchor_sp == 0) {
+                    saved_anchor_pc = anchor->lastJavaPC();
+                    saved_anchor_sp = anchor->lastJavaSP();
+                    saved_anchor_fp = anchor->lastJavaFP();
+                }
                 if (anchor->getFrame(pc, sp, fp) && !nm->contains(pc)) {
                     anchor = NULL;
                     continue;  // NMethod has changed as a result of correction
@@ -514,7 +533,8 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
                     continue;
                 }
 
-                if (depth > 1 && nm->frameSize() > 0) {
+                if (depth > 0 && nm->frameSize() > 0) {
+                    Counters::increment(WALKVM_STUB_FRAMESIZE_FALLBACK);
                     // Validate NMethod metadata before using frameSize()
                     int frame_size = nm->frameSize();
                     if (frame_size <= 0 || frame_size > MAX_FRAME_SIZE_WORDS) {
@@ -562,22 +582,38 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
                     Counters::increment(THREAD_ENTRY_MARK_DETECTIONS);
                     break;
                 }
-            } else if (method_name == NULL && details) {
-                // These workarounds will minimize the number of unknown frames for 'vm'
-                // We want to keep the 'raw' data in 'vmx', though
+            } else if (method_name == NULL && details && profiler->findLibraryByAddress(pc) == NULL) {
+                // Try anchor recovery — prefer live anchor, fall back to saved data
+                const void* recovery_pc = NULL;
+                uintptr_t recovery_sp = 0;
+                uintptr_t recovery_fp = 0;
+                bool have_anchor_data = false;
+
                 if (anchor) {
                     Counters::increment(WALKVM_ANCHOR_USED_INLINE);
-                    uintptr_t anchor_fp = anchor->lastJavaFP();
-                    uintptr_t anchor_sp = anchor->lastJavaSP();
+                    recovery_fp = anchor->lastJavaFP();
+                    recovery_sp = anchor->lastJavaSP();
+                    recovery_pc = anchor->lastJavaPC();
+                    have_anchor_data = true;
+                } else if (saved_anchor_sp != 0) {
+                    Counters::increment(WALKVM_SAVED_ANCHOR_USED);
+                    recovery_fp = saved_anchor_fp;
+                    recovery_sp = saved_anchor_sp;
+                    recovery_pc = saved_anchor_pc;
+                    have_anchor_data = true;
+                    // Clear saved data after use — one-shot recovery
+                    saved_anchor_sp = 0;
+                } else {
+                    Counters::increment(WALKVM_ANCHOR_INLINE_NO_ANCHOR);
+                }
 
+                if (have_anchor_data) {
                     // Try to read the Java method directly from the anchor's FP,
                     // treating it as an interpreter frame.
                     // In HotSpot, lastJavaFP is non-zero only for interpreter frames;
                     // compiled frames record FP=0 in the anchor.
-                    // getMethodId() guards against misinterpretation (alignment, dead-zone,
-                    // readable-range checks, and validatedId() pointer identity check).
-                    if (StackWalkValidation::isPlausibleInterpreterFrame(anchor_fp, anchor_sp, bcp_offset)) {
-                        VMMethod* method = ((VMMethod**)anchor_fp)[InterpreterFrame::method_offset];
+                    if (StackWalkValidation::isPlausibleInterpreterFrame(recovery_fp, recovery_sp, bcp_offset)) {
+                        VMMethod* method = ((VMMethod**)recovery_fp)[InterpreterFrame::method_offset];
                         jmethodID method_id = getMethodId(method);
                         if (method_id != NULL) {
                             anchor = NULL;
@@ -587,42 +623,38 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
                             }
                             Counters::increment(WALKVM_JAVA_FRAME_OK);
                             const char* bytecode_start = method->bytecode();
-                            const char* bcp = ((const char**)anchor_fp)[bcp_offset];
+                            const char* bcp = ((const char**)recovery_fp)[bcp_offset];
                             int bci = bytecode_start == NULL || bcp < bytecode_start ? 0 : bcp - bytecode_start;
                             fillFrame(frames[depth++], FRAME_INTERPRETED, bci, method_id);
 
-                            sp = ((uintptr_t*)anchor_fp)[InterpreterFrame::sender_sp_offset];
-                            pc = stripPointer(((void**)anchor_fp)[FRAME_PC_SLOT]);
-                            fp = *(uintptr_t*)anchor_fp;
+                            sp = ((uintptr_t*)recovery_fp)[InterpreterFrame::sender_sp_offset];
+                            pc = stripPointer(((void**)recovery_fp)[FRAME_PC_SLOT]);
+                            fp = *(uintptr_t*)recovery_fp;
                             continue;
                         }
                     }
 
-                    // Fallback: redirect via anchor SP/FP/PC with sp[-1] for non-interpreter frames
-                    sp = anchor_sp;
-                    fp = anchor_fp;
-                    pc = anchor->lastJavaPC();
+                    // Fallback: redirect via recovery SP/FP/PC
+                    sp = recovery_sp;
+                    fp = recovery_fp;
+                    pc = recovery_pc;
                     if (pc != NULL && !CodeHeap::contains(pc) && sp != 0 && aligned(sp) && sp < bottom) {
                         pc = ((const void**)sp)[-1];
                     }
                     if (sp != 0 && pc != NULL) {
-                        // already used the anchor; disable it
                         anchor = NULL;
-                        // Anchor SP is trusted (from VMJavaFrameAnchor) and may be
-                        // below the current DWARF position — DWARF can advance SP
-                        // past the Java frame area through native frames (common on
-                        // musl where __syscall_cp_asm lacks CFI directives).
                         if (sp >= bottom || !aligned(sp)) {
+                            Counters::increment(WALKVM_ANCHOR_INLINE_BAD_SP);
                             fillFrame(frames[depth++], BCI_ERROR, "break_no_anchor");
                             break;
                         }
-                        // we restored from Java frame; clean the prev_native_pc
                         prev_native_pc = NULL;
                         if (depth > 0) {
                             fillFrame(frames[depth++], BCI_ERROR, "[skipped frames]");
                         }
                         continue;
                     }
+                    Counters::increment(WALKVM_ANCHOR_INLINE_NO_SP);
                 }
                 // Check previous frame for thread entry points (Rust, libc/pthread)
                 if (prev_native_pc != NULL) {
@@ -631,23 +663,22 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
                     if (prev_method_name != NULL) {
                         char prev_mark = NativeFunc::read_mark(prev_method_name);
                         if (prev_mark == MARK_THREAD_ENTRY) {
-                            // Thread entry point detected in previous frame (Rust thread_start, libc start_thread, etc.)
-                            // This is the root frame - stop unwinding
                             Counters::increment(THREAD_ENTRY_MARK_DETECTIONS);
                             break;
                         }
                     }
                 }
-                if (vm_thread != NULL && vm_thread->cachedIsJavaThread()) {
-                    fillFrame(frames[depth++], BCI_ERROR, "break_no_anchor");
-                } else {
-                    fillFrame(frames[depth++], BCI_ERROR, "break_no_symbol");
-                }
-                break;
+                // Fall through to DWARF section — when findLibraryByAddress(pc)
+                // returns NULL, default_frame uses FP-chain walking (DW_REG_FP)
+                // which can bridge symbol-less gaps in libjvm.so.
+                Counters::increment(WALKVM_FP_CHAIN_ATTEMPT);
+                fp_chain_fallback = true;
+                goto dwarf_unwind;
             }
             fillFrame(frames[depth++], frame_bci, (void*)method_name);
         }
 
+        dwarf_unwind:
         uintptr_t prev_sp = sp;
         CodeCache* cc = profiler->findLibraryByAddress(pc);
         FrameDesc f = cc != NULL ? cc->findFrameDesc(pc) : FrameDesc::default_frame;
@@ -664,6 +695,13 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
         if (cfa_reg == DW_REG_SP) {
             sp = sp + cfa_off;
         } else if (cfa_reg == DW_REG_FP) {
+            // Sanity-check FP before deriving CFA from it. A corrupted FP can produce a
+            // phantom CFA and cause the walk to record spurious frames before breaking.
+            // We cannot check fp < sp here because on aarch64 the frame pointer is set
+            // to SP at function entry, which is typically less than the previous CFA.
+            if (fp >= bottom || !aligned(fp)) {
+                break;
+            }
             sp = fp + cfa_off;
         } else if (cfa_reg == DW_REG_PLT) {
             sp += ((uintptr_t)pc & 15) >= 11 ? cfa_off * 2 : cfa_off;
@@ -721,6 +759,10 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
     if (anchor != NULL) {
         uintptr_t anchor_fp = anchor->lastJavaFP();
         uintptr_t anchor_sp = anchor->lastJavaSP();
+        if (anchor_sp == 0) {
+            Counters::increment(WALKVM_ANCHOR_NOT_IN_JAVA);
+            goto done;
+        }
         if (StackWalkValidation::isPlausibleInterpreterFrame(anchor_fp, anchor_sp, bcp_offset)) {
             VMMethod* method = ((VMMethod**)anchor_fp)[InterpreterFrame::method_offset];
             jmethodID method_id = getMethodId(method);
@@ -759,6 +801,7 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
         }
     }
 
+    done:
     if (profiled_thread != nullptr) {
         profiled_thread->setCrashProtectionActive(false);
     }


### PR DESCRIPTION
**What does this PR do?**:

Improves `walkVM` stack unwinding quality, building on the foundation from PR #400. The changes address unwinding failures that produced error frames (`break_no_anchor`, `break_no_symbol`) and prevented the profiler from recovering Java frames in native-heavy stacks, particularly on aarch64.

### Key changes

**1. Anchor preservation across consumption** (`stackWalker.cpp`)

Before anchor consumption (when `anchor->getFrame()` redirects PC/SP/FP), we now save the anchor's `lastJavaPC/SP/FP`. This allows inline recovery to use the saved data even after the anchor pointer has been set to NULL.

**2. Inline anchor recovery with saved anchor fallback** (`stackWalker.cpp`)

When the DWARF walk encounters a PC with no library mapping (symbol-less gap), the code now attempts anchor recovery — first using the live anchor, then falling back to saved anchor data from a prior consumption. The condition is also tightened to only trigger when `findLibraryByAddress(pc) == NULL` (truly unmapped PC), not for all unknown symbols.

**3. FP-chain fallback for DWARF gaps** (`stackWalker.cpp`)

When inline anchor recovery fails (e.g., anchor SP=0 on compiler threads), instead of emitting a `break_no_anchor` error frame and terminating the walk, we now fall through to the DWARF section via `goto dwarf_unwind`. When `findLibraryByAddress(pc)` returns NULL, `FrameDesc::default_frame` uses FP-chain walking (`DW_REG_FP`), which can bridge across symbol-less gaps. The DWARF section's full validation (FP bounds, SP monotonicity, alignment, dead zone) acts as a safety net.

**4. Anchor SP=0 reclassification** (`stackWalker.cpp`)

When the post-loop anchor fallback finds `lastJavaSP() == 0`, the thread has no Java frames (e.g., compiler threads running pure C++). This is now classified as `WALKVM_ANCHOR_NOT_IN_JAVA` instead of falling through to `WALKVM_ANCHOR_FALLBACK_FAIL`.

**5. FP validation before DW_REG_FP CFA derivation** (`stackWalker.cpp`)

Added bounds and alignment checks on FP before using it to derive the CFA in the `DW_REG_FP` branch. A corrupted FP (e.g., from bad DWARF CFI) could produce a phantom CFA and record spurious frames before breaking.

**6. Generic aarch64 stub prologue detection** (`stackFrame_aarch64.cpp`)

Added a fallback in `unwindStub` that detects the standard aarch64 frame prologue pattern (`stp x29, x30, [sp, #-16]!` + `mov x29, sp`) in the first 8 instructions of any stub. This catches JVM stubs not in the hardcoded whitelist, with bounds checking to ensure the prologue was actually executed before using FP.

**7. Stub frameSize fallback relaxed** (`stackWalker.cpp`)

For stubs where `unwindStub` fails but `nm->frameSize() > 0`, the depth guard is relaxed from `depth > 1` to `depth > 0`, allowing frameSize-based unwinding for the topmost stub frame.

**8. New observability counters** (`counters.h`)

Nine new counters for all new code paths: `WALKVM_ANCHOR_INLINE_NO_ANCHOR`, `WALKVM_ANCHOR_INLINE_NO_SP`, `WALKVM_ANCHOR_INLINE_BAD_SP`, `WALKVM_SAVED_ANCHOR_USED`, `WALKVM_STUB_GENERIC_UNWIND`, `WALKVM_STUB_FRAMESIZE_FALLBACK`, `WALKVM_FP_CHAIN_ATTEMPT`, `WALKVM_FP_CHAIN_REACHED_CODEHEAP`, `WALKVM_ANCHOR_NOT_IN_JAVA`.

### Unwinding error rate improvements

CI data comparing before/after this PR (baseline is PR #400):

| Platform | JDK | Before | After | Improvement |
|----------|-----|--------|-------|-------------|
| **glibc-aarch64** | 17 | 11.80% | **0.24%** | ~49x |
| **glibc-aarch64** | 21 | 9.57% | **1.25%** | ~8x |
| **glibc-aarch64** | 25 | 8.93% | **0.51%** | ~18x |
| **glibc-aarch64** | 17-graal | 3.23% | **0.41%** | ~8x |
| **glibc-aarch64** | 21-graal | 2.61% | **0.57%** | ~5x |
| **glibc-aarch64** | 25-graal | 2.35% | **0.46%** | ~5x |
| **musl-aarch64** | 8-librca | 7.38% | **1.38%** | ~5x |
| **musl-aarch64** | 11-librca | 5.73% | **0.74%** | ~8x |
| **musl-aarch64** | 17-librca | 7.38% | **1.05%** | ~7x |
| **musl-aarch64** | 21-librca | 6.01% | **1.12%** | ~5x |
| **musl-aarch64** | 25-librca | 6.30% | **0.81%** | ~8x |
| glibc-amd64 | 8 | 0.88% | **0.23%** | ~4x |
| glibc-amd64 | 11 | 0.11% | 0.18% | stable |
| glibc-amd64 | 17 | 0.43% | 0.41% | stable |
| glibc-amd64 | 21 | 1.48% | **0.60%** | ~2x |
| glibc-amd64 | 25 | 0.18% | 0.41% | stable |
| musl-amd64 | 8-librca | 0.43% | 0.26% | stable |
| musl-amd64 | 11-librca | 0.65% | **0.07%** | ~9x |
| musl-amd64 | 17-librca | 0.39% | 0.14% | stable |
| musl-amd64 | 21-librca | 0.55% | 0.35% | stable |
| musl-amd64 | 25-librca | 1.08% | **0.50%** | ~2x |

Counter data from JFR recordings confirms the new paths are active:
- `walkvm_fp_chain_attempt`: 37-54 per scenario on aarch64 (near-zero on amd64)
- `walkvm_anchor_not_in_java`: 200-315 per scenario (previously misclassified as `anchor_fallback_fail`)
- `walkvm_anchor_fallback_fail`: dropped to 0 on aarch64

**Motivation**:

Wall-clock profiling on aarch64 had 9-12% unwinding error rates after PR #400, primarily from compiler threads where the DWARF walk exited `libjvm.so` into a symbol-less gap and anchor recovery failed (SP=0). These errors reduced profiling accuracy and produced noisy `break_no_anchor` error frames in flame graphs.

**Prior art**:

The anchor-based recovery and FP-chain bridging techniques used here are modeled after proven implementations in two established Java unwinders:
- **HotSpot's `AsyncGetCallTrace` (ASGCT)** — uses `JavaFrameAnchor` (`lastJavaSP`/`lastJavaFP`/`lastJavaPC`) to transition from native frames back into the Java stack, and walks interpreter frames via the anchor's FP.
- **The eBPF HotSpot unwinder** (used by Datadog's system-wide profiler) — bridges native-to-Java transitions by reading the anchor from the `VMThread` struct, and uses FP-chain walking to traverse frames where DWARF info is unavailable.

**Additional Notes**:

All changes are in signal-handler context code (`walkVM` runs during `SIGPROF`/`SIGVTALRM` handling). The new paths are allocation-free and use the existing crash protection (`setjmp`/`longjmp`) as a safety net. The FP-chain fallback leverages the fact that `libjvm.so` is compiled with frame pointers on all platforms.

**How to test the change?**:

Automated CI validates unwinding quality across 25 platform/JDK combinations. The unwinding test suite exercises compiler-heavy scenarios (C2 compilation, OSR, deopt, PLT resolution, veneer stubs) that trigger the exact code paths this PR improves.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

