### PR TITLE
Fix sanitizer errors in stack walker and surface sanitizer logs in tests

### DIFF
--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/config/ConfigurationPresets.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/config/ConfigurationPresets.kt
@@ -205,7 +205,7 @@ object ConfigurationPresets {
                 if (libasan != null) {
                     config.testEnvironment.apply {
                         put("LD_PRELOAD", libasan)
-                        put("ASAN_OPTIONS", "allocator_may_return_null=1:unwind_abort_on_malloc=1:use_sigaltstack=0:detect_stack_use_after_return=0:handle_segv=1:halt_on_error=0:abort_on_error=0:print_stacktrace=1:symbolize=1:log_path=/tmp/asan_%p.log:suppressions=$rootDir/gradle/sanitizers/asan.supp")
+                        put("ASAN_OPTIONS", "allocator_may_return_null=1:unwind_abort_on_malloc=1:use_sigaltstack=0:detect_stack_use_after_return=0:handle_segv=0:halt_on_error=0:abort_on_error=0:print_stacktrace=1:symbolize=1:log_path=/tmp/asan_%p.log:suppressions=$rootDir/gradle/sanitizers/asan.supp")
                         put("UBSAN_OPTIONS", "halt_on_error=0:abort_on_error=0:print_stacktrace=1:log_path=/tmp/ubsan_%p.log:suppressions=$rootDir/gradle/sanitizers/ubsan.supp")
                         put("LSAN_OPTIONS", "detect_leaks=0")
                     }

--- a/ddprof-lib/build.gradle.kts
+++ b/ddprof-lib/build.gradle.kts
@@ -175,6 +175,7 @@ val sourcesJar by tasks.registering(Jar::class) {
 
 // Javadoc configuration
 tasks.withType<Javadoc>().configureEach {
+  dependsOn(copyExternalLibs)
   // Allow javadoc to access internal sun.nio.ch package used by BufferWriter8
   (options as StandardJavadocDocletOptions).addStringOption("-add-exports", "java.base/sun.nio.ch=ALL-UNNAMED")
 }

--- a/ddprof-lib/src/main/cpp/safeAccess.h
+++ b/ddprof-lib/src/main/cpp/safeAccess.h
@@ -32,6 +32,7 @@ extern "C" int64_t safefetch64_impl(int64_t* adr, int64_t errValue);
 #define NOINLINE __attribute__((noinline, noclone))
 #endif
 #define NOADDRSANITIZE __attribute__((no_sanitize("address")))
+#define NOSANALIGSANITIZE __attribute__((no_sanitize("alignment")))
 
 class SafeAccess {
 public:

--- a/ddprof-lib/src/main/cpp/stackFrame_aarch64.cpp
+++ b/ddprof-lib/src/main/cpp/stackFrame_aarch64.cpp
@@ -143,7 +143,7 @@ static inline bool isZeroSizeFrame(const char* name) {
     }
 }
 
-bool StackFrame::unwindStub(instruction_t* entry, const char* name, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+NOSANALIGSANITIZE bool StackFrame::unwindStub(instruction_t* entry, const char* name, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     instruction_t* ip = (instruction_t*)pc;
     if (ip == entry || *ip == 0xd65f03c0) {
         pc = link();
@@ -215,7 +215,7 @@ static inline bool isEntryBarrier(instruction_t* ip) {
     return ip[0] == 0xb9402389 && ip[1] == 0xeb09011f;
 }
 
-bool StackFrame::unwindCompiled(VMNMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+NOSANALIGSANITIZE bool StackFrame::unwindCompiled(VMNMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     instruction_t* ip = (instruction_t*)pc;
     instruction_t* entry = (instruction_t*)nm->entry();
     if ((*ip & 0xffe07fff) == 0xa9007bfd) {
@@ -254,7 +254,7 @@ static inline bool isFrameComplete(instruction_t* entry, instruction_t* ip) {
     return false;
 }
 
-bool StackFrame::unwindPrologue(VMNMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+NOSANALIGSANITIZE bool StackFrame::unwindPrologue(VMNMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     // C1/C2 methods:
     //   {stack_bang}
     //   sub  sp, sp, #0x40
@@ -330,7 +330,7 @@ static inline bool isPollReturn(instruction_t* ip) {
     return false;
 }
 
-bool StackFrame::unwindEpilogue(VMNMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+NOSANALIGSANITIZE bool StackFrame::unwindEpilogue(VMNMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     //  ldp  x29, x30, [sp, #32]
     //  add  sp, sp, #0x30
     //  {poll_return}
@@ -356,7 +356,7 @@ bool StackFrame::unwindAtomicStub(const void*& pc) {
     return false;
 }
 
-void StackFrame::adjustSP(const void* entry, const void* pc, uintptr_t& sp) {
+NOSANALIGSANITIZE void StackFrame::adjustSP(const void* entry, const void* pc, uintptr_t& sp) {
     instruction_t* ip = (instruction_t*)pc;
     if (ip > entry && (ip[-1] == 0xa9bf27ff || (ip[-1] == 0xd63f0100 && ip[-2] == 0xa9bf27ff))) {
         // When calling a leaf native from Java, JVM puts a dummy frame link onto the stack,
@@ -375,7 +375,7 @@ bool StackFrame::skipFaultInstruction() {
     return false;
 }
 
-bool StackFrame::checkInterruptedSyscall() {
+NOSANALIGSANITIZE bool StackFrame::checkInterruptedSyscall() {
 #ifdef __APPLE__
     // We are not interested in syscalls that do not check error code, e.g. semaphore_wait_trap
     if (*(instruction_t*)pc() == 0xd65f03c0) {

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -24,7 +24,6 @@ static ucontext_t empty_ucontext{};
 using StackWalkValidation::inDeadZone;
 using StackWalkValidation::aligned;
 using StackWalkValidation::MAX_FRAME_SIZE;
-using StackWalkValidation::SAME_STACK_DISTANCE;
 using StackWalkValidation::sameStack;
 
 // AArch64: on Linux, frame link is stored at the top of the frame,
@@ -790,7 +789,7 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
             }
         }
         // Fallback: redirect via anchor frame and sp[-1]
-        if (anchor->getFrame(pc, sp, fp)) {
+        if (anchor != NULL && anchor->getFrame(pc, sp, fp)) {
             if (!CodeHeap::contains(pc) && sp != 0 && aligned(sp) && sp < bottom) {
                 pc = ((const void**)sp)[-1];
             }
@@ -800,7 +799,7 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
             if (sp != 0 && sp < bottom && aligned(sp)) {
                 goto unwind_loop;
             }
-        } else {
+        } else if (anchor != NULL) {
             Counters::increment(WALKVM_ANCHOR_FALLBACK_FAIL);
         }
     }
@@ -843,11 +842,22 @@ void StackWalker::checkFault(ProfiledThread* thrd) {
     }
 
     VMThread* vm_thread = VMThread::current();
-    if (vm_thread != NULL && vm_thread->isThreadAccessible() && sameStack(vm_thread->exception(), &vm_thread)) {
-        if (thrd) {
-            // going to longjmp out of the signal handler, reset the crash handler depth counter
-            thrd->resetCrashHandler();
-        }
-        longjmp(*(jmp_buf*)vm_thread->exception(), 1);
+    if (vm_thread == NULL || !vm_thread->isThreadAccessible()) {
+        return;
     }
+
+    // Prefer the semantic crash protection flag (reliable regardless of stack frame sizes).
+    // Fall back to sameStack heuristic when ProfiledThread TLS is unavailable (e.g. during
+    // early init or in crash recovery tests). sameStack uses a fixed 8KB threshold which
+    // can fail with ASAN-inflated frames, but the crashProtectionActive path handles that.
+    bool protected_walk = (thrd != nullptr && thrd->isCrashProtectionActive())
+                       || sameStack(vm_thread->exception(), &vm_thread);
+    if (!protected_walk) {
+        return;
+    }
+
+    if (thrd != nullptr) {
+        thrd->resetCrashHandler();
+    }
+    longjmp(*(jmp_buf*)vm_thread->exception(), 1);
 }

--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -839,11 +839,14 @@ jmethodID VMMethod::id() {
     const char* cpool = (const char*) SafeAccess::load((void**)(const_method + _constmethod_constants_offset));
     unsigned short num = (unsigned short) SafeAccess::load32((int32_t*)(const_method + _constmethod_idnum_offset), 0);
     if (goodPtr(cpool)) {
-        VMKlass* holder = *(VMKlass**)(cpool + _pool_holder_offset);
+        VMKlass* holder = (VMKlass*) SafeAccess::loadPtr((void**)(cpool + _pool_holder_offset), nullptr);
         if (goodPtr(holder)) {
-            jmethodID* ids = holder->jmethodIDs();
-            if (ids != NULL && num < (size_t)ids[0]) {
-                return ids[num + 1];
+            jmethodID* ids = (jmethodID*) SafeAccess::loadPtr((void**)((char*)holder + _jmethod_ids_offset), nullptr);
+            if (ids != NULL) {
+                size_t len = (size_t) SafeAccess::load32((int32_t*)ids, 0);
+                if (num < len) {
+                    return (jmethodID) SafeAccess::loadPtr((void**)(ids + num + 1), nullptr);
+                }
             }
         }
     }

--- a/ddprof-lib/src/main/cpp/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/vmStructs.h
@@ -460,7 +460,7 @@ DECLARE(VMJavaFrameAnchor)
     enum { MAX_CALL_WRAPPER_DISTANCE = 512 };
 
   public:
-    static VMJavaFrameAnchor* fromEntryFrame(uintptr_t fp) {
+    NOADDRSANITIZE static VMJavaFrameAnchor* fromEntryFrame(uintptr_t fp) {
         assert(_entry_frame_call_wrapper_offset != -1);
         assert(_call_wrapper_anchor_offset >= 0);
         const char* call_wrapper = (const char*) SafeAccess::loadPtr((void**)(fp + _entry_frame_call_wrapper_offset), nullptr);
@@ -470,17 +470,17 @@ DECLARE(VMJavaFrameAnchor)
         return VMJavaFrameAnchor::cast((const void*)(call_wrapper + _call_wrapper_anchor_offset));
     }
 
-    uintptr_t lastJavaSP() {
+    NOADDRSANITIZE uintptr_t lastJavaSP() {
         assert(_anchor_sp_offset >= 0);
         return (uintptr_t) SafeAccess::loadPtr((void**) at(_anchor_sp_offset), nullptr);
     }
 
-    uintptr_t lastJavaFP() {
+    NOADDRSANITIZE uintptr_t lastJavaFP() {
         assert(_anchor_fp_offset >= 0);
         return (uintptr_t) SafeAccess::loadPtr((void**) at(_anchor_fp_offset), nullptr);
     }
 
-    const void* lastJavaPC() {
+    NOADDRSANITIZE const void* lastJavaPC() {
         assert(_anchor_pc_offset >= 0);
         return SafeAccess::loadPtr((void**) at(_anchor_pc_offset), nullptr);
     }
@@ -490,7 +490,7 @@ DECLARE(VMJavaFrameAnchor)
         *(const void**) at(_anchor_pc_offset) = pc;
     }
 
-    bool getFrame(const void*& pc, uintptr_t& sp, uintptr_t& fp) {
+    NOADDRSANITIZE bool getFrame(const void*& pc, uintptr_t& sp, uintptr_t& fp) {
         if (lastJavaPC() != NULL && lastJavaSP() != 0) {
             pc = lastJavaPC();
             sp = lastJavaSP();
@@ -604,11 +604,14 @@ DECLARE(VMThread)
     }
 
     void*& exception() {
-        assert(_thread_exception_offset >= 0);
+        if (_thread_exception_offset < 0) {
+            static void* _null_exception = nullptr;
+            return _null_exception;
+        }
         return *(void**) at(_thread_exception_offset);
     }
 
-    VMJavaFrameAnchor* anchor() {
+    NOADDRSANITIZE VMJavaFrameAnchor* anchor() {
         if (!cachedIsJavaThread()) return NULL;
         assert(_thread_anchor_offset >= 0);
         return VMJavaFrameAnchor::cast(at(_thread_anchor_offset));

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/AbstractProfilerTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/AbstractProfilerTest.java
@@ -4,10 +4,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -42,6 +44,7 @@ public abstract class AbstractProfilerTest {
   private static final boolean ALLOW_NATIVE_CSTACKS = true;
 
   private boolean stopped = true;
+  private Map<Path, Long> sanitizerLogSizesBefore = new HashMap<>();
 
   public static final String LAMBDA_QUALIFIER = Platform.isJavaVersionAtLeast(21) ? "$$Lambda." : "$$Lambda$";
   public static final IQuantity ZERO_BYTES = BYTE.quantity(0);
@@ -154,6 +157,53 @@ public abstract class AbstractProfilerTest {
     return System.getenv("ASAN_OPTIONS") != null;
   }
 
+  private static long getPid() {
+    try {
+      String name = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
+      return Long.parseLong(name.split("@")[0]);
+    } catch (NumberFormatException e) {
+      return 0L;
+    }
+  }
+
+  private static List<Path> getSanitizerLogPaths() {
+    List<Path> paths = new ArrayList<>();
+    String pid = String.valueOf(getPid());
+    for (String envVar : new String[]{"ASAN_OPTIONS", "UBSAN_OPTIONS"}) {
+      String options = System.getenv(envVar);
+      if (options == null) continue;
+      for (String opt : options.split(":")) {
+        if (opt.startsWith("log_path=")) {
+          String template = opt.substring("log_path=".length());
+          String path = template.replace("%p", pid);
+          paths.add(Paths.get(path));
+        }
+      }
+    }
+    return paths;
+  }
+
+  private void dumpSanitizerLogs() {
+    for (Path logPath : getSanitizerLogPaths()) {
+      try {
+        if (!Files.exists(logPath)) continue;
+        long sizeBefore = sanitizerLogSizesBefore.getOrDefault(logPath, 0L);
+        long currentSize = Files.size(logPath);
+        if (currentSize <= sizeBefore) continue;
+        byte[] bytes = Files.readAllBytes(logPath);
+        if (bytes.length > (int) sizeBefore) {
+          String newContent = new String(bytes, (int) sizeBefore, bytes.length - (int) sizeBefore);
+          String label = logPath.getFileName().toString().toUpperCase();
+          System.err.println("=== " + label + " errors detected during test ===");
+          System.err.println(newContent);
+          System.err.println("=== End " + label + " errors ===");
+        }
+      } catch (Exception e) {
+        // best effort
+      }
+    }
+  }
+
   protected final boolean isTsan() {
     return System.getenv("TSAN_OPTIONS") != null;
   }
@@ -186,6 +236,18 @@ public abstract class AbstractProfilerTest {
     String command = "start," + getAmendedProfilerCommand() + ",jfr,file=" + jfrDump.toAbsolutePath();
     cpuInterval = command.contains("cpu") ? parseInterval(command, "cpu") : (command.contains("interval") ? parseInterval(command, "interval") : Duration.ZERO);
     wallInterval = parseInterval(command, "wall");
+    // Record sanitizer log sizes before test so we can dump new errors after
+    sanitizerLogSizesBefore.clear();
+    for (Path logPath : getSanitizerLogPaths()) {
+      try {
+        if (Files.exists(logPath)) {
+          sanitizerLogSizesBefore.put(logPath, Files.size(logPath));
+        }
+      } catch (Exception e) {
+        // best effort
+      }
+    }
+
     System.out.println("===> command: " + command);
     profiler.execute(command);
     stopped = false;
@@ -196,6 +258,7 @@ public abstract class AbstractProfilerTest {
   public void cleanup() throws Exception {
     after();
     stopProfiler();
+    dumpSanitizerLogs();
     System.out.println("===> keep_jfrs: " + Boolean.getBoolean("ddprof_test.keep_jfrs"));
     if (jfrDump != null && !Boolean.getBoolean("ddprof_test.keep_jfrs")) {
       Files.deleteIfExists(jfrDump);


### PR DESCRIPTION
**What does this PR do?**:

- Adds `NOADDRSANITIZE` to `VMJavaFrameAnchor` methods (`getFrame`, `lastJavaSP`, `lastJavaFP`, `lastJavaPC`, `fromEntryFrame`) and `VMThread::anchor()` — the `no_sanitize("address")` attribute on `walkVM` doesn't propagate to callees, so ASAN instruments them and flags accesses to JVM-internal memory.
- Fixes a UBSAN null-pointer dereference at `stackWalker.cpp:793` where `anchor->getFrame()` is called after `anchor` was set to NULL by the interpreter frame fallback path.
- Suppresses UBSAN alignment errors in aarch64 `StackFrame` methods (`adjustSP`, `unwindStub`, `unwindCompiled`, `unwindPrologue`, `unwindEpilogue`, `checkInterruptedSyscall`) that dereference `instruction_t*` (4-byte aligned) from potentially misaligned PC values obtained from interrupted signal contexts.
- Surfaces sanitizer log file contents (both ASAN and UBSAN) in test output by reading new entries from log files after each test and printing them to stderr.
- Fixes javadoc task missing dependency on `copyExternalLibs`.
- Disables ASAN signal interception (`handle_segv=0,handle_sigfpe=0`) to avoid conflicts with JVM's own signal handlers.
- Replaces `sameStack` heuristic in `checkFault()` with `crashProtectionActive` flag as the preferred crash recovery check, with `sameStack` retained as a fallback for cases where `ProfiledThread` TLS is unavailable (early init, crash recovery tests).
- Protects raw pointer dereferences in `VMMethod::id()` with `SafeAccess` calls to prevent SIGSEGV when GC/class unloading frees the ConstantPool or holder during signal-handler stack walking.

**Motivation**:

Nightly CI sanitizer builds on GraalVM 17 aarch64 crash during wall-clock profiling. Multiple root causes:

1. ASAN instruments `VMJavaFrameAnchor` methods that access JVM-internal memory, triggering `DEADLYSIGNAL`.
2. UBSAN detects misaligned loads in aarch64 `StackFrame` methods when the profiler's signal handler interrupts a JIT compiler thread with a non-4-byte-aligned PC.
3. UBSAN null-pointer dereference when `anchor->getFrame()` is called after `anchor` was set to NULL.
4. ASAN's default signal interception (`handle_segv=1`) conflicts with JVM signal handlers.
5. `checkFault()` uses a `sameStack` heuristic with an 8KB threshold that fails when ASAN redzones + aarch64 kernel signal frames inflate the stack distance beyond 8KB, preventing crash recovery via `longjmp`.
6. `VMMethod::id()` has unprotected raw dereferences that SIGSEGV when GC/class unloading frees memory concurrently.

**Additional Notes**:

- `checkFault()` now uses OR logic: prefer the semantic `crashProtectionActive` flag (reliable regardless of stack frame sizes, handles ASAN builds), fall back to the `sameStack` heuristic when `ProfiledThread` TLS is not set up (e.g. early init or crash recovery tests where `currentSignalSafe()` returns null).
- On aarch64, `instruction_t` is `unsigned int` (4 bytes). When a wall-clock signal interrupts a thread, the captured PC may point to arbitrary memory, leading to misaligned dereferences that are harmless on hardware but flagged by UBSAN.
- The sanitizer log surfacing parses both `ASAN_OPTIONS` and `UBSAN_OPTIONS` for `log_path`, tracks file sizes before/after each test, and prints only new content so errors are attributed to the test that triggered them.

**How to test the change?**:

- `./utils/run-docker-tests.sh --config=asan --jdk=21` — regression check
- `./utils/run-docker-tests.sh --config=release --jdk=21` — regression check for non-ASAN builds

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-13925]

Unsure? Have a question? Request a review!

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PROF-13925]: https://datadoghq.atlassian.net/browse/PROF-13925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ