### PR TITLE
Harden CodeCacheArray and profiler against signal-handler races

### DIFF
--- a/.github/scripts/prepare_reports.sh
+++ b/.github/scripts/prepare_reports.sh
@@ -12,6 +12,7 @@ cp ddprof-test/javacore*.txt test-reports/ || true
 cp ddprof-test/build/hs_err* test-reports/ || true
 cp -r ddprof-lib/build/tmp test-reports/native_build || true
 cp -r ddprof-test/build/reports/tests test-reports/tests || true
+cp build/logs/gdb-watchdog.log test-reports/ || true
 cp -r /tmp/recordings test-reports/recordings || true
 find ddprof-lib/build -name 'libjavaProfiler.*' -exec cp {} test-reports/ \; || true
 

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -340,7 +340,7 @@ jobs:
           sudo apt update -y
           sudo apt remove -y g++
           sudo apt autoremove -y
-          sudo apt install -y curl zip unzip clang make build-essential binutils
+          sudo apt install -y curl zip unzip clang make build-essential binutils gdb
           # Install debug symbols for system libraries
           sudo apt install -y libc6-dbg
           if [[ ${{ matrix.java_version }} =~ "-zing" ]]; then
@@ -363,11 +363,44 @@ jobs:
           export LIBC=glibc
           export SANITIZER=${{ matrix.config }}
 
-          mkdir -p build/logs
-          ./gradlew -PCI -PkeepJFRs :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs 2>&1 \
-            | tee -a build/test-raw.log \
-            | python3 -u .github/scripts/filter_gradle_log.py
-          EXIT_CODE=${PIPESTATUS[0]}
+          # For ASAN: launch a gdb watchdog that dumps all native threads before the
+          # 30-minute Gradle timeout kills the JVM, so we can diagnose hangs in native code.
+          if [[ "${{ matrix.config }}" == "asan" ]]; then
+            mkdir -p build/logs
+            (
+              sleep 1500  # 25 minutes — fires before the 30-min Gradle timeout
+              echo "::warning::GDB watchdog triggered after 25 minutes"
+              for pid in $(pgrep -f 'java.*ddprof-test'); do
+                echo "=== Thread dump for PID $pid ===" >> build/logs/gdb-watchdog.log
+                gdb -batch -ex 'thread apply all bt full' -p "$pid" >> build/logs/gdb-watchdog.log 2>&1 || true
+              done
+            ) &
+            GDB_WATCHDOG_PID=$!
+          fi
+
+          MAX_ATTEMPTS=1
+          if [[ "${{ matrix.config }}" == "asan" && "${{ matrix.java_version }}" =~ (j9|ibm) ]]; then
+            MAX_ATTEMPTS=2
+          fi
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            mkdir -p build/logs
+            ./gradlew -PCI -PkeepJFRs :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs 2>&1 \
+              | tee -a build/test-raw.log \
+              | python3 -u .github/scripts/filter_gradle_log.py
+            EXIT_CODE=${PIPESTATUS[0]}
+
+            if [ $EXIT_CODE -eq 0 ]; then break; fi
+            if [ $attempt -lt $MAX_ATTEMPTS ]; then
+              echo "::warning::Attempt $attempt failed (exit $EXIT_CODE), retrying..."
+              ./gradlew --stop 2>/dev/null || true
+            fi
+          done
+
+          # Kill the watchdog if tests finished before it fired
+          if [[ -n "${GDB_WATCHDOG_PID:-}" ]]; then
+            kill "$GDB_WATCHDOG_PID" 2>/dev/null || true
+          fi
 
           if [ $EXIT_CODE -ne 0 ]; then
             echo "glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64" >> failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -104,12 +104,25 @@ jobs:
           export LIBC=glibc
           export SANITIZER=${{ matrix.config }}
 
-          mkdir -p build/logs
-          ./gradlew -PCI -PkeepJFRs :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs 2>&1 \
-            | tee -a build/test-raw.log \
-            | python3 -u .github/scripts/filter_gradle_log.py
-          EXIT_CODE=${PIPESTATUS[0]}
-      
+          MAX_ATTEMPTS=1
+          if [[ "${{ matrix.config }}" == "asan" && "${{ matrix.java_version }}" =~ (j9|ibm) ]]; then
+            MAX_ATTEMPTS=2
+          fi
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            mkdir -p build/logs
+            ./gradlew -PCI -PkeepJFRs :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs 2>&1 \
+              | tee -a build/test-raw.log \
+              | python3 -u .github/scripts/filter_gradle_log.py
+            EXIT_CODE=${PIPESTATUS[0]}
+
+            if [ $EXIT_CODE -eq 0 ]; then break; fi
+            if [ $attempt -lt $MAX_ATTEMPTS ]; then
+              echo "::warning::Attempt $attempt failed (exit $EXIT_CODE), retrying..."
+              ./gradlew --stop 2>/dev/null || true
+            fi
+          done
+
           if [ $EXIT_CODE -ne 0 ]; then
             echo "glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64" >> failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,6 +357,17 @@ The profiler uses a sophisticated double-buffered storage system for call traces
 - **Atomic Operations**: Instance ID management and counter updates use atomics
 - **Memory Allocation**: Minimize malloc() in hot paths, use pre-allocated containers
 
+### Atomic Memory Ordering (Critical for arm64)
+arm64 has a weakly-ordered memory model (unlike x86 TSO). Incorrect ordering causes real lockups on arm64 that never reproduce on x86.
+- **Cross-thread reads**: Always use `__ATOMIC_ACQUIRE` for loads that must see stores from another thread. Never use `__ATOMIC_RELAXED` for cross-thread visibility unless you can prove no ordering dependency exists.
+- **Cross-thread writes**: Use `__ATOMIC_RELEASE` for stores that must be visible to other threads. Pair with `__ATOMIC_ACQUIRE` loads.
+- **Count + pointer patterns**: When a data structure publishes a count and a separate pointer (two-phase add), both the count load and pointer load need acquire semantics so the reader sees the pointer store that preceded the count increment.
+- **Default stance**: When in doubt, use acquire/release. The performance cost is negligible; the correctness cost of relaxed ordering bugs is enormous (silent arm64-only lockups).
+
+### Concurrent Data Structure Iteration
+- **NULL gaps**: When iterating a concurrent array (e.g., `CodeCacheArray`), always NULL-check each slot — a slot may be count-allocated but pointer-not-yet-stored.
+- **Cursor advancement**: Never permanently advance an iteration cursor past NULL gaps. Stop at the first NULL or track the last contiguous non-NULL entry, so missing entries are retried on the next pass.
+
 ### 64-bit Trace ID System
 - **Collision Avoidance**: Instance-based IDs prevent collisions across storage swaps
 - **JFR Compatibility**: 64-bit IDs work with JFR constant pool indices
@@ -705,3 +716,9 @@ The CI caches JDKs via `.github/workflows/cache_java.yml`. When adding a new JDK
 - Always provide tests for bug fixes - test fails before the fix, passes after the fix
 - All code needs to strive to be lean in terms of resources consumption and easy to follow -
     do not shy away from factoring out self containing code to shorter functions with explicit name
+
+### C/C++ Code Style
+- **Indentation**: Match the exact indentation style of the surrounding code in each file. Do not introduce inconsistent indentation — reviewers will flag it.
+- **Minimal complexity**: Do not split inline logic into separate helper functions unless the helpers are reused or the original is genuinely hard to follow. Unnecessary splits add indirection without value.
+- **Comment precision**: Comments explaining "why" must reference concrete mechanisms (e.g., "ASAN's allocator lock is reentrant" not "internal bookkeeping"). Vague comments get challenged in review. Every claim in a comment must be verifiable from the code or documented behavior of the referenced system (ASAN, glibc NPTL, HotSpot, etc.).
+- **No speculative comments**: Do not claim a system (HotSpot, glibc, ASAN) uses a specific mechanism unless you are certain. If unsure, describe the observable symptom instead of guessing the cause.

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/util/PlatformUtils.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/util/PlatformUtils.kt
@@ -304,4 +304,22 @@ object PlatformUtils {
             "or specify one with -Pnative.forceCompiler=/path/to/compiler"
         )
     }
+
+    /**
+     * Returns true if the test JVM (from JAVA_TEST_HOME or JAVA_HOME) is an OpenJ9/J9 JVM.
+     * Probes `java -version` stderr output for "J9" or "OpenJ9".
+     */
+    fun isTestJvmJ9(): Boolean {
+        val javaHome = testJavaHome()
+        return try {
+            val process = ProcessBuilder("$javaHome/bin/java", "-version")
+                .redirectErrorStream(true)
+                .start()
+            val output = process.inputStream.bufferedReader().readText()
+            process.waitFor(10, TimeUnit.SECONDS)
+            output.contains("J9") || output.contains("OpenJ9")
+        } catch (_: Exception) {
+            false
+        }
+    }
 }

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/profiler/ProfilerTestPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/profiler/ProfilerTestPlugin.kt
@@ -15,6 +15,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.testing.Test
+import java.time.Duration
 import javax.inject.Inject
 
 /**
@@ -262,6 +263,8 @@ class ProfilerTestPlugin : Plugin<Project> {
                         testTask.setForkEvery(1)
                     }
                 }
+                // Kill hung ASAN test tasks after 30 minutes
+                testTask.timeout.set(Duration.ofMinutes(30))
             }
         }
     }

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/profiler/ProfilerTestPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/profiler/ProfilerTestPlugin.kt
@@ -254,6 +254,15 @@ class ProfilerTestPlugin : Plugin<Project> {
                 "asan" -> testTask.onlyIf { PlatformUtils.locateLibasan() != null }
                 "tsan" -> testTask.onlyIf { PlatformUtils.locateLibtsan() != null }
             }
+
+            // J9+ASAN: isolate each test class in its own JVM to limit crash blast radius
+            if (testConfig.configName == "asan") {
+                testTask.doFirst {
+                    if (PlatformUtils.isTestJvmJ9()) {
+                        testTask.setForkEvery(1)
+                    }
+                }
+            }
         }
     }
 

--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -264,24 +264,28 @@ public:
 
   CodeCache *operator[](int index) const { return __atomic_load_n(&_libs[index], __ATOMIC_ACQUIRE); }
 
+  // Returns a count that may include indices whose pointer has not yet been
+  // stored by a concurrent add(). Callers using operator[] must handle NULL.
   int count() const { return __atomic_load_n(&_count, __ATOMIC_RELAXED); }
 
+  // Two-phase add: _count is CAS-incremented first, then the pointer is stored.
+  // This creates a window where operator[]/at() may return NULL for valid indices.
   void add(CodeCache *lib) {
-    int index = __atomic_fetch_add(&_count, 1, __ATOMIC_RELAXED);
-    if (index < MAX_NATIVE_LIBS) {
-      __atomic_fetch_add(&_used_memory, lib->memoryUsage(), __ATOMIC_RELAXED);
-       __atomic_store_n(&_libs[index], lib, __ATOMIC_RELEASE);
-    }
+    int old = __atomic_load_n(&_count, __ATOMIC_RELAXED);
+    do {
+      if (old >= MAX_NATIVE_LIBS) return;
+    } while (!__atomic_compare_exchange_n(&_count, &old, old + 1,
+                                          true, __ATOMIC_RELAXED, __ATOMIC_RELAXED));
+    __atomic_fetch_add(&_used_memory, lib->memoryUsage(), __ATOMIC_RELAXED);
+    __atomic_store_n(&_libs[old], lib, __ATOMIC_RELEASE);
   }
 
+  // Non-blocking read; may return NULL if the slot has not been stored yet.
   CodeCache* at(int index) const {
     if (index >= MAX_NATIVE_LIBS) {
-        return nullptr;
+      return nullptr;
     }
-    CodeCache* lib = nullptr;
-    while ((lib = __atomic_load_n(&_libs[index], __ATOMIC_ACQUIRE)) == nullptr);
-
-    return lib;
+    return __atomic_load_n(&_libs[index], __ATOMIC_ACQUIRE);
   }
 
   size_t memoryUsage() const {

--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -266,7 +266,7 @@ public:
 
   // Returns a count that may include indices whose pointer has not yet been
   // stored by a concurrent add(). Callers using operator[] must handle NULL.
-  int count() const { return __atomic_load_n(&_count, __ATOMIC_RELAXED); }
+  int count() const { return __atomic_load_n(&_count, __ATOMIC_ACQUIRE); }
 
   // Two-phase add: _count is CAS-incremented first, then the pointer is stored.
   // This creates a window where operator[]/at() may return NULL for valid indices.
@@ -276,6 +276,7 @@ public:
       if (old >= MAX_NATIVE_LIBS) return;
     } while (!__atomic_compare_exchange_n(&_count, &old, old + 1,
                                           true, __ATOMIC_RELAXED, __ATOMIC_RELAXED));
+    assert(__atomic_load_n(&_libs[old], __ATOMIC_RELAXED) == nullptr);
     __atomic_fetch_add(&_used_memory, lib->memoryUsage(), __ATOMIC_RELAXED);
     __atomic_store_n(&_libs[old], lib, __ATOMIC_RELEASE);
   }

--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -254,34 +254,42 @@ public:
 class CodeCacheArray {
 private:
   CodeCache *_libs[MAX_NATIVE_LIBS];
-  volatile int _count;
+  volatile int _reserved;       // next slot to reserve (CAS by writers)
+  volatile int _count;          // published count (all indices < _count have non-NULL pointers)
   volatile size_t _used_memory;
 
 public:
-  CodeCacheArray() : _count(0), _used_memory(0) {
+  CodeCacheArray() : _reserved(0), _count(0), _used_memory(0) {
     memset(_libs, 0, MAX_NATIVE_LIBS * sizeof(CodeCache *));
   }
 
   CodeCache *operator[](int index) const { return __atomic_load_n(&_libs[index], __ATOMIC_ACQUIRE); }
 
-  // Returns a count that may include indices whose pointer has not yet been
-  // stored by a concurrent add(). Callers using operator[] must handle NULL.
+  // All indices < count() are guaranteed to have a non-NULL pointer.
   int count() const { return __atomic_load_n(&_count, __ATOMIC_ACQUIRE); }
 
-  // Two-phase add: _count is CAS-incremented first, then the pointer is stored.
-  // This creates a window where operator[]/at() may return NULL for valid indices.
+  // Pointer-first add: reserve a slot via CAS on _reserved, store the
+  // pointer with RELEASE, then advance _count. Readers see count() grow
+  // only after the pointer is visible, so indices < count() never yield NULL.
   void add(CodeCache *lib) {
-    int old = __atomic_load_n(&_count, __ATOMIC_RELAXED);
+    int slot = __atomic_load_n(&_reserved, __ATOMIC_RELAXED);
     do {
-      if (old >= MAX_NATIVE_LIBS) return;
-    } while (!__atomic_compare_exchange_n(&_count, &old, old + 1,
+      if (slot >= MAX_NATIVE_LIBS) return;
+    } while (!__atomic_compare_exchange_n(&_reserved, &slot, slot + 1,
                                           true, __ATOMIC_RELAXED, __ATOMIC_RELAXED));
-    assert(__atomic_load_n(&_libs[old], __ATOMIC_RELAXED) == nullptr);
+    assert(__atomic_load_n(&_libs[slot], __ATOMIC_RELAXED) == nullptr);
     __atomic_fetch_add(&_used_memory, lib->memoryUsage(), __ATOMIC_RELAXED);
-    __atomic_store_n(&_libs[old], lib, __ATOMIC_RELEASE);
+    // Store pointer before publishing count. The RELEASE here pairs with
+    // the ACQUIRE load in operator[]/at() and count().
+    __atomic_store_n(&_libs[slot], lib, __ATOMIC_RELEASE);
+    // Advance _count to publish the new slot. Spin until our slot is next
+    // in line, preserving contiguous ordering when multiple adds race.
+    while (__atomic_load_n(&_count, __ATOMIC_RELAXED) != slot) {
+      // wait for preceding slots to publish
+    }
+    __atomic_store_n(&_count, slot + 1, __ATOMIC_RELEASE);
   }
 
-  // Non-blocking read; may return NULL if the slot has not been stored yet.
   CodeCache* at(int index) const {
     if (index >= MAX_NATIVE_LIBS) {
       return nullptr;

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1110,14 +1110,17 @@ void Recording::writeNativeLibraries(Buffer *buf) {
   const CodeCacheArray &native_libs = libraries->native_libs();
   int native_lib_count = native_libs.count();
 
-  int last_recorded = _recorded_lib_count;
-  for (int i = _recorded_lib_count; i < native_lib_count; i++) {
+  // Emit jdk.NativeLibrary events for newly loaded libraries.
+  // Stop at the first NULL slot — a concurrent add() may have incremented
+  // count() but not stored the pointer yet. Unrecorded entries will be
+  // picked up on the next flush.
+  int i;
+  for (i = _recorded_lib_count; i < native_lib_count; i++) {
     CodeCache* lib = native_libs[i];
     if (lib == NULL) {
       break;
     }
 
-    // Emit jdk.NativeLibrary event with extended fields (buildId and loadBias)
     flushIfNeeded(buf, RECORDING_BUFFER_LIMIT - MAX_STRING_LENGTH);
     int start = buf->skip(5);
     buf->putVar64(T_NATIVE_LIBRARY);
@@ -1129,10 +1132,9 @@ void Recording::writeNativeLibraries(Buffer *buf) {
     buf->putVar64((uintptr_t)lib->loadBias());
     buf->putVar32(start, buf->offset() - start);
     flushIfNeeded(buf);
-    last_recorded = i + 1;
   }
 
-  _recorded_lib_count = last_recorded;
+  _recorded_lib_count = i;
 }
 
 void Recording::writeCpool(Buffer *buf) {

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1110,8 +1110,12 @@ void Recording::writeNativeLibraries(Buffer *buf) {
   const CodeCacheArray &native_libs = libraries->native_libs();
   int native_lib_count = native_libs.count();
 
+  int last_recorded = _recorded_lib_count;
   for (int i = _recorded_lib_count; i < native_lib_count; i++) {
     CodeCache* lib = native_libs[i];
+    if (lib == NULL) {
+      break;
+    }
 
     // Emit jdk.NativeLibrary event with extended fields (buildId and loadBias)
     flushIfNeeded(buf, RECORDING_BUFFER_LIMIT - MAX_STRING_LENGTH);
@@ -1125,9 +1129,10 @@ void Recording::writeNativeLibraries(Buffer *buf) {
     buf->putVar64((uintptr_t)lib->loadBias());
     buf->putVar32(start, buf->offset() - start);
     flushIfNeeded(buf);
+    last_recorded = i + 1;
   }
 
-  _recorded_lib_count = native_lib_count;
+  _recorded_lib_count = last_recorded;
 }
 
 void Recording::writeCpool(Buffer *buf) {

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1111,15 +1111,10 @@ void Recording::writeNativeLibraries(Buffer *buf) {
   int native_lib_count = native_libs.count();
 
   // Emit jdk.NativeLibrary events for newly loaded libraries.
-  // Stop at the first NULL slot — a concurrent add() may have incremented
-  // count() but not stored the pointer yet. Unrecorded entries will be
-  // picked up on the next flush.
-  int i;
-  for (i = _recorded_lib_count; i < native_lib_count; i++) {
+  // CodeCacheArray::add() stores the pointer before advancing count(),
+  // so all indices < native_lib_count are guaranteed non-NULL.
+  for (int i = _recorded_lib_count; i < native_lib_count; i++) {
     CodeCache* lib = native_libs[i];
-    if (lib == NULL) {
-      break;
-    }
 
     flushIfNeeded(buf, RECORDING_BUFFER_LIMIT - MAX_STRING_LENGTH);
     int start = buf->skip(5);
@@ -1134,7 +1129,7 @@ void Recording::writeNativeLibraries(Buffer *buf) {
     flushIfNeeded(buf);
   }
 
-  _recorded_lib_count = i;
+  _recorded_lib_count = native_lib_count;
 }
 
 void Recording::writeCpool(Buffer *buf) {

--- a/ddprof-lib/src/main/cpp/guards.h
+++ b/ddprof-lib/src/main/cpp/guards.h
@@ -121,16 +121,12 @@ public:
     sigset_t prof_signals;
     sigemptyset(&prof_signals);
 
-    // Add all profiling signals that could interrupt us
+    // Block only the profiling signals that the profiler actually registers.
+    // No profiler engine uses RT signals, so blocking them is unnecessary
+    // and risks interfering with glibc NPTL internals (SIGRTMIN, SIGRTMIN+1)
+    // or other JVM-internal signal usage.
     sigaddset(&prof_signals, SIGPROF);     // Used by ITimer and CTimer
     sigaddset(&prof_signals, SIGVTALRM);   // Used by WallClock
-#ifdef __linux__
-    // Block RT signals (Linux-only)
-    // This prevents any RT signal handler from interrupting TLS initialization
-    for (int sig = SIGRTMIN; sig <= SIGRTMIN + 5 && sig <= SIGRTMAX; sig++) {
-      sigaddset(&prof_signals, sig);
-    }
-#endif
 
     if (pthread_sigmask(SIG_BLOCK, &prof_signals, &_old_mask) == 0) {
       _active = true;

--- a/ddprof-lib/src/main/cpp/libraries.cpp
+++ b/ddprof-lib/src/main/cpp/libraries.cpp
@@ -54,16 +54,22 @@ const void *Libraries::resolveSymbol(const char *name) {
   int native_lib_count = _native_libs.count();
   if (len > 0 && name[len - 1] == '*') {
     for (int i = 0; i < native_lib_count; i++) {
-      const void *address = _native_libs[i]->findSymbolByPrefix(name, len - 1);
-      if (address != NULL) {
-        return address;
+      CodeCache *lib = _native_libs[i];
+      if (lib != NULL) {
+        const void *address = lib->findSymbolByPrefix(name, len - 1);
+        if (address != NULL) {
+          return address;
+        }
       }
     }
   } else {
     for (int i = 0; i < native_lib_count; i++) {
-      const void *address = _native_libs[i]->findSymbol(name);
-      if (address != NULL) {
-        return address;
+      CodeCache *lib = _native_libs[i];
+      if (lib != NULL) {
+        const void *address = lib->findSymbol(name);
+        if (address != NULL) {
+          return address;
+        }
       }
     }
   }
@@ -79,11 +85,14 @@ CodeCache *Libraries::findLibraryByName(const char *lib_name) {
   const size_t lib_name_len = strlen(lib_name);
   const int native_lib_count = _native_libs.count();
   for (int i = 0; i < native_lib_count; i++) {
-    const char *s = _native_libs[i]->name();
-    if (s != NULL) {
-      const char *p = strrchr(s, '/');
-      if (p != NULL && strncmp(p + 1, lib_name, lib_name_len) == 0) {
-        return _native_libs[i];
+    CodeCache *lib = _native_libs[i];
+    if (lib != NULL) {
+      const char *s = lib->name();
+      if (s != NULL) {
+        const char *p = strrchr(s, '/');
+        if (p != NULL && strncmp(p + 1, lib_name, lib_name_len) == 0) {
+          return lib;
+        }
       }
     }
   }
@@ -93,8 +102,9 @@ CodeCache *Libraries::findLibraryByName(const char *lib_name) {
 CodeCache *Libraries::findLibraryByAddress(const void *address) {
   const int native_lib_count = _native_libs.count();
   for (int i = 0; i < native_lib_count; i++) {
-    if (_native_libs[i]->contains(address)) {
-      return _native_libs[i];
+    CodeCache *lib = _native_libs[i];
+    if (lib != NULL && lib->contains(address)) {
+      return lib;
     }
   }
   return NULL;

--- a/ddprof-lib/src/main/cpp/libraries.h
+++ b/ddprof-lib/src/main/cpp/libraries.h
@@ -24,7 +24,7 @@ class Libraries {
   // Note: Parameter is uint32_t to match lib_index packing (17 bits = max 131K libraries)
   CodeCache *getLibraryByIndex(uint32_t index) const {
     if (index < _native_libs.count()) {
-      return _native_libs[index];
+      return _native_libs[index];  // may be NULL during concurrent add()
     }
     return nullptr;
   }

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -48,16 +48,19 @@ public:
 };
 
 #ifdef __aarch64__
+// Delete RoutineInfo with profiling signals blocked to prevent ASAN
+// allocator lock reentrancy. Kept noinline so SignalBlocker's sigset_t
+// does not trigger stack-protector canary in the caller on aarch64.
+__attribute__((noinline))
+static void delete_routine_info(RoutineInfo* thr) {
+    SignalBlocker blocker;
+    delete thr;
+}
+
 // Initialize the current thread's TLS with profiling signals blocked.
-// Kept in a separate noinline function so that SignalBlocker's 128-byte
-// sigset_t lives in its own frame and does not trigger stack-protector
-// canary placement in start_routine_wrapper on aarch64.
+// Kept noinline for the same stack-protector reason as delete_routine_info.
 __attribute__((noinline))
 static void init_thread_tls() {
-    // Block profiling signals during TLS initialization: TLS init
-    // (pthread_once, pthread_key_create, pthread_setspecific) is not
-    // async-signal-safe. A profiling signal here can corrupt
-    // internal TLS bookkeeping on the stack.
     SignalBlocker blocker;
     ProfiledThread::initCurrentThread();
 }
@@ -74,7 +77,7 @@ static void* start_routine_wrapper_spec(void* args) {
     RoutineInfo* thr = (RoutineInfo*)args;
     func_start_routine routine = thr->routine();
     void* params = thr->args();
-    delete thr;
+    delete_routine_info(thr);
     init_thread_tls();
     int tid = ProfiledThread::currentTid();
     Profiler::registerThread(tid);
@@ -88,9 +91,16 @@ static int pthread_create_hook_spec(pthread_t* thread,
                           const pthread_attr_t* attr,
                           func_start_routine start_routine,
                           void* args) {
-  RoutineInfo* thr = new RoutineInfo(start_routine, args);
+  RoutineInfo* thr;
+  {
+    SignalBlocker blocker;
+    thr = new RoutineInfo(start_routine, args);
+  }
   int ret = pthread_create(thread, attr, start_routine_wrapper_spec, (void*)thr);
-  if (ret != 0) delete thr;
+  if (ret != 0) {
+    SignalBlocker blocker;
+    delete thr;
+  }
   return ret;
 }
 
@@ -107,15 +117,18 @@ static void thread_cleanup(void* arg) {
 __attribute__((visibility("hidden")))
 static void* start_routine_wrapper(void* args) {
     RoutineInfo* thr = (RoutineInfo*)args;
-    func_start_routine routine = thr->routine();
-    void* params = thr->args();
-    delete thr;
+    func_start_routine routine;
+    void* params;
     {
-        // Block profiling signals during TLS initialization: TLS init
-        // (pthread_once, pthread_key_create, pthread_setspecific) is not
-        // async-signal-safe. A profiling signal here can corrupt
-        // internal TLS bookkeeping on the stack.
+        // Block profiling signals while accessing and freeing RoutineInfo
+        // and during TLS initialization: these operations are not
+        // async-signal-safe. A profiling signal here can deadlock under
+        // ASAN (allocator lock reentrancy) or corrupt internal TLS
+        // bookkeeping on the stack.
         SignalBlocker blocker;
+        routine = thr->routine();
+        params = thr->args();
+        delete thr;
         ProfiledThread::initCurrentThread();
     }
     int tid = ProfiledThread::currentTid();
@@ -133,9 +146,16 @@ static int pthread_create_hook(pthread_t* thread,
                           const pthread_attr_t* attr,
                           func_start_routine start_routine,
                           void* args) {
-  RoutineInfo* thr = new RoutineInfo(start_routine, args);
+  RoutineInfo* thr;
+  {
+    SignalBlocker blocker;
+    thr = new RoutineInfo(start_routine, args);
+  }
   int ret = pthread_create(thread, attr, start_routine_wrapper, (void*)thr);
-  if (ret != 0) delete thr;
+  if (ret != 0) {
+    SignalBlocker blocker;
+    delete thr;
+  }
   return ret;
 }
 

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -121,10 +121,11 @@ static void* start_routine_wrapper(void* args) {
     void* params;
     {
         // Block profiling signals while accessing and freeing RoutineInfo
-        // and during TLS initialization: these operations are not
-        // async-signal-safe. A profiling signal here can deadlock under
-        // ASAN (allocator lock reentrancy) or corrupt internal TLS
-        // bookkeeping on the stack.
+        // and during TLS initialization. Under ASAN, new/delete/
+        // pthread_setspecific are intercepted and acquire ASAN's internal
+        // allocator lock. A profiling signal during any of these calls
+        // runs ASAN-instrumented code that tries to acquire the same
+        // lock, causing deadlock.
         SignalBlocker blocker;
         routine = thr->routine();
         params = thr->args();

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -151,10 +151,22 @@ void LibraryPatcher::patch_libraries() {
 }
 
 void LibraryPatcher::patch_library_unlocked(CodeCache* lib) {
+  if (lib->name() == nullptr) return;
+
   char path[PATH_MAX];
   char* resolved_path = realpath(lib->name(), path);
   if (resolved_path != nullptr &&     //  filter out virtual file, e.g. [vdso], etc.
       strcmp(resolved_path, _profiler_name) == 0) { // Don't patch self
+    return;
+  }
+
+  // Don't patch sanitizer runtime libraries — intercepting their internal
+  // pthread_create calls causes reentrancy and heap corruption under ASAN.
+  const char* base = strrchr(lib->name(), '/');
+  base = (base != nullptr) ? base + 1 : lib->name();
+  if (strncmp(base, "libasan", 7) == 0 ||
+      strncmp(base, "libtsan", 7) == 0 ||
+      strncmp(base, "libubsan", 8) == 0) {
     return;
   }
 
@@ -200,7 +212,9 @@ void LibraryPatcher::patch_pthread_create() {
   ExclusiveLockGuard locker(&_lock);
   for (int index = 0; index < num_of_libs; index++) {
      CodeCache* lib = native_libs.at(index);
-     patch_library_unlocked(lib);
+     if (lib != nullptr) {
+       patch_library_unlocked(lib);
+     }
   }
 }
 #endif // __linux__

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -240,16 +240,22 @@ const void *Profiler::resolveSymbol(const char *name) {
   int native_lib_count = native_libs.count();
   if (len > 0 && name[len - 1] == '*') {
     for (int i = 0; i < native_lib_count; i++) {
-      const void *address = native_libs[i]->findSymbolByPrefix(name, len - 1);
-      if (address != NULL) {
-        return address;
+      CodeCache *lib = native_libs[i];
+      if (lib != NULL) {
+        const void *address = lib->findSymbolByPrefix(name, len - 1);
+        if (address != NULL) {
+          return address;
+        }
       }
     }
   } else {
     for (int i = 0; i < native_lib_count; i++) {
-      const void *address = native_libs[i]->findSymbol(name);
-      if (address != NULL) {
-        return address;
+      CodeCache *lib = native_libs[i];
+      if (lib != NULL) {
+        const void *address = lib->findSymbol(name);
+        if (address != NULL) {
+          return address;
+        }
       }
     }
   }
@@ -262,10 +268,13 @@ const char *Profiler::getLibraryName(const char *native_symbol) {
   short lib_index = NativeFunc::libIndex(native_symbol);
   const CodeCacheArray& native_libs = _libs->native_libs();
   if (lib_index >= 0 && lib_index < native_libs.count()) {
-    const char *s = native_libs[lib_index]->name();
-    if (s != NULL) {
-      const char *p = strrchr(s, '/');
-      return p != NULL ? p + 1 : s;
+    CodeCache *lib = native_libs[lib_index];
+    if (lib != NULL) {
+      const char *s = lib->name();
+      if (s != NULL) {
+        const char *p = strrchr(s, '/');
+        return p != NULL ? p + 1 : s;
+      }
     }
   }
   return NULL;
@@ -554,12 +563,15 @@ int Profiler::getJavaTraceAsync(void *ucontext, ASGCT_CallFrame *frames,
   if (in_java && java_ctx->sp != 0) {
     // skip ahead to the Java frames before calling AGCT
     frame.restore((uintptr_t)java_ctx->pc, java_ctx->sp, java_ctx->fp);
-  } else if (state != 0 && (vm_thread->anchor() == nullptr || vm_thread->anchor()->lastJavaSP() == 0)) {
-    // we haven't found the top Java frame ourselves, and the lastJavaSP wasn't
-    // recorded either when not in the Java state, lastJava ucontext will be
-    // used by AGCT
-    Counters::increment(AGCT_NATIVE_NO_JAVA_CONTEXT);
-    return 0;
+  } else if (state != 0) {
+    VMJavaFrameAnchor* a = vm_thread->anchor();
+    if (a == nullptr || a->lastJavaSP() == 0) {
+      // we haven't found the top Java frame ourselves, and the lastJavaSP wasn't
+      // recorded either when not in the Java state, lastJava ucontext will be
+      // used by AGCT
+      Counters::increment(AGCT_NATIVE_NO_JAVA_CONTEXT);
+      return 0;
+    }
   }
   bool blocked_in_vm = (state == 10 || state == 11);
   // avoid unwinding during deoptimization
@@ -635,6 +647,7 @@ int Profiler::getJavaTraceAsync(void *ucontext, ASGCT_CallFrame *frames,
   } else if (trace.num_frames == ticks_unknown_not_Java &&
              !(_safe_mode & LAST_JAVA_PC)) {
     VMJavaFrameAnchor* anchor = vm_thread->anchor();
+    if (anchor == NULL) return 0;
     uintptr_t sp = anchor->lastJavaSP();
     const void* pc = anchor->lastJavaPC();
     if (sp != 0 && pc == NULL) {
@@ -662,6 +675,7 @@ int Profiler::getJavaTraceAsync(void *ucontext, ASGCT_CallFrame *frames,
   } else if (trace.num_frames == ticks_not_walkable_not_Java &&
              !(_safe_mode & LAST_JAVA_PC)) {
     VMJavaFrameAnchor* anchor = vm_thread->anchor();
+    if (anchor == NULL) return 0;
     uintptr_t sp = anchor->lastJavaSP();
     const void* pc = anchor->lastJavaPC();
     if (sp != 0 && pc != NULL) {
@@ -675,7 +689,8 @@ int Profiler::getJavaTraceAsync(void *ucontext, ASGCT_CallFrame *frames,
       }
     }
   } else if (trace.num_frames == ticks_GC_active && !(_safe_mode & GC_TRACES)) {
-    if (vm_thread->anchor()->lastJavaSP() == 0) {
+    VMJavaFrameAnchor* anchor = vm_thread->anchor();
+    if (anchor == NULL || anchor->lastJavaSP() == 0) {
       // Do not add 'GC_active' for threads with no Java frames, e.g. Compiler
       // threads
       frame.restore(saved_pc, saved_sp, saved_fp);

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -292,6 +292,7 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
     volatile int depth = 0;
     int actual_max_depth = truncated ? max_depth + 1 : max_depth;
     bool fp_chain_fallback = false;
+    int fp_chain_depth = 0;
 
     ProfiledThread* profiled_thread = ProfiledThread::currentSignalSafe();
 
@@ -321,9 +322,12 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
 
     // Saved anchor data — preserved across anchor consumption so inline
     // recovery can redirect even after the anchor pointer has been set to NULL.
+    // Recovery is one-shot: once attempted, we do not retry to avoid
+    // ping-ponging between CodeHeap and unmapped native regions.
     const void* saved_anchor_pc = NULL;
     uintptr_t saved_anchor_sp = 0;
     uintptr_t saved_anchor_fp = 0;
+    bool anchor_recovery_used = false;
 
     // Show extended frame types and stub frames for execution-type events
     bool details = event_type <= MALLOC_SAMPLE || features.mixed;
@@ -341,6 +345,7 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
             if (fp_chain_fallback) {
                 Counters::increment(WALKVM_FP_CHAIN_REACHED_CODEHEAP);
                 fp_chain_fallback = false;
+                fp_chain_depth = 0;
             }
             // If we're in JVM-generated code but don't have a VMThread, we cannot safely
             // walk the Java stack because crash protection is not set up.
@@ -581,8 +586,10 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
                     Counters::increment(THREAD_ENTRY_MARK_DETECTIONS);
                     break;
                 }
-            } else if (method_name == NULL && details && profiler->findLibraryByAddress(pc) == NULL) {
+            } else if (method_name == NULL && details && !anchor_recovery_used
+                       && profiler->findLibraryByAddress(pc) == NULL) {
                 // Try anchor recovery — prefer live anchor, fall back to saved data
+                anchor_recovery_used = true;
                 const void* recovery_pc = NULL;
                 uintptr_t recovery_sp = 0;
                 uintptr_t recovery_fp = 0;
@@ -676,6 +683,9 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
                 // which can bridge symbol-less gaps in libjvm.so.
                 Counters::increment(WALKVM_FP_CHAIN_ATTEMPT);
                 fp_chain_fallback = true;
+                if (++fp_chain_depth > actual_max_depth) {
+                    break;
+                }
                 goto dwarf_unwind;
             }
             fillFrame(frames[depth++], frame_bci, (void*)method_name);

--- a/ddprof-lib/src/main/cpp/vmEntry.cpp
+++ b/ddprof-lib/src/main/cpp/vmEntry.cpp
@@ -328,7 +328,10 @@ bool VM::initShared(JavaVM* vm) {
   // walker a clean stopping point for any pthread-managed thread.
   const CodeCacheArray& all_native_libs = libraries->native_libs();
   for (int i = 0; i < all_native_libs.count(); i++) {
-      all_native_libs[i]->mark(isThreadEntry, MARK_THREAD_ENTRY);
+      CodeCache *cc = all_native_libs[i];
+      if (cc != NULL) {
+          cc->mark(isThreadEntry, MARK_THREAD_ENTRY);
+      }
   }
 
   if (isOpenJ9()) {


### PR DESCRIPTION
**What does this PR do?**:

Hardens `CodeCacheArray` readers and `getJavaTraceAsync()` against races in signal-handler context, fixes ASAN heap corruption caused by patching sanitizer runtime libraries, prevents ASAN deadlocks from unprotected allocator calls in library patcher wrappers, and fixes arm64-specific lockups in stack walking and signal handling.

**Changes:**

1. **CodeCacheArray reentrancy** — Guard all reader call sites against NULL during concurrent `add()`. Convert `at()` from spin-wait to non-blocking return. Replace `fetch_add` overflow in `add()` with a correct CAS loop.

2. **anchor() NULL guards in getJavaTraceAsync()** — Cache `anchor()` result in a local to eliminate TOCTOU between two calls. Add NULL guards at all 4 dereference sites (lines 566, 649, 677, 692) to prevent SIGSEGV when `cachedIsJavaThread()` returns false or thread memory becomes unreadable.

3. **Skip patching sanitizer libraries** — The library patcher was intercepting `pthread_create` in `libasan.so` itself, causing reentrancy in ASAN's internal thread tracking and heap corruption. This manifested as intermittent J9 GC assertions (`Pointer not object aligned`) and GPFs at ASAN shadow memory addresses in nightly CI. Fix: skip libraries matching `libasan*`, `libtsan*`, `libubsan*`.

4. **writeNativeLibraries() NULL handling** — Stop at first NULL slot instead of `continue`, and only advance `_recorded_lib_count` to the last contiguous entry so missing entries get retried on the next flush.

5. **SignalBlocker around RoutineInfo new/delete** — In `libraryPatcher_linux.cpp`, `delete thr` in `start_routine_wrapper` / `start_routine_wrapper_spec` ran with profiling signals unblocked. Under ASAN, `delete` calls `__interceptor_free` which acquires ASAN's internal allocator lock. If a profiling signal fires in this window, the signal handler runs ASAN-instrumented code that also tries to acquire the same lock, causing deadlock. Fix: wrap all `new`/`delete` RoutineInfo calls in `SignalBlocker` scopes. In `start_routine_wrapper`, a single `SignalBlocker` block covers field reads, delete, and TLS init. In `start_routine_wrapper_spec` (the musl/aarch64/jdk11 variant), fields are read as plain loads and only the `delete` is wrapped via a noinline `delete_routine_info` helper — this avoids address-taken locals and `SignalBlocker`'s 128-byte `sigset_t` in the wrapper's frame, which would trigger `-fstack-protector` canary placement and the `__stack_chk_fail` crash on musl/aarch64.

6. **ASAN CI hardening** — Added 30-minute Gradle-level timeout for ASAN test tasks to prevent hung tests from burning the full 3-hour job budget. Added retry logic to aarch64 glibc tests (parity with amd64). Added a gdb watchdog that captures native thread backtraces 25 minutes into an ASAN run, to help diagnose an intermittent lockup observed on aarch64.

7. **Fix arm64 lockups** — Three fixes targeting intermittent lockups observed exclusively on aarch64 in stress tests and dd-trace-java integration tests:
   - **Remove RT signal blocking from SignalBlocker** — `SignalBlocker` was blocking `SIGRTMIN..SIGRTMIN+5` despite no profiler engine using RT signals. This risked interfering with glibc NPTL internals (`SIGRTMIN`, `SIGRTMIN+1`) or other JVM-internal signal usage. Now only blocks SIGPROF and SIGVTALRM.
   - **Cap FP-chain fallback depth** — The `goto dwarf_unwind` FP-chain fallback path bypasses the normal `depth++` bound, creating a potential unbounded loop when FP doesn't advance monotonically (more likely on arm64 due to weak memory ordering). Capped at max stack depth.
   - **One-shot anchor recovery** — Anchor recovery in walkVM could ping-pong between CodeHeap and unmapped native regions, producing thousands of expensive iterations. Now limited to a single attempt per walkVM call.

**Motivation**:

- Reentrancy crash in production: wall-clock signal fires during `dlopen_hook` → `parseLibraries` → `add()`, causing NULL deref in `findLibraryByAddress`
- Intermittent `vmStructs.h:221` assertion in debug builds from unguarded `anchor()` calls
- Intermittent J9 ASAN nightly failures: `GC Assertion: Pointer E8C148F6894CD889 has is not object aligned` caused by patching `libasan.so`
- Intermittent ASAN deadlock: profiling signal during `delete thr` in thread wrapper hits ASAN allocator lock reentrancy
- `__stack_chk_fail` SIGSEGV on musl/aarch64/jdk11 debug CI when `start_routine_wrapper_spec` frame gets a stack-protector canary
- Intermittent arm64-exclusive lockups in stress tests and dd-trace-java integration tests, not observed on amd64. Suspected causes: unnecessary RT signal blocking interfering with thread management, unbounded FP-chain walking loops, and repeated anchor recovery attempts in walkVM.

**Additional Notes**:

- The `at()` non-blocking change has no functional impact: both callers run on the same thread after all `add()` stores complete (sequential call chain through `dlopen_hook`)
- The anchor() guards are on AGCT error-recovery paths, not the fast path — negligible overhead
- The sanitizer skip uses prefix matching which is sufficient since no real libraries collide with `libasan`/`libtsan`/`libubsan` prefixes
- The SignalBlocker cost is one `pthread_sigmask` syscall per scope — no behavioral change in non-ASAN builds
- In `start_routine_wrapper_spec`, reading `thr->routine()` and `thr->args()` are plain memory loads with no lock/deadlock risk — only `delete` needs signal blocking
- The gdb watchdog only runs for ASAN configs and is killed automatically if tests complete normally
- The FP-chain depth cap uses the same max stack depth as the main loop, ensuring the FP-chain fallback cannot exceed the overall walk budget
- One-shot anchor recovery has no impact on normal stacks; it only prevents pathological ping-pong patterns

**How to test the change?**:

- All fixes are defensive NULL checks and filtering — existing tests continue to pass
- The CodeCacheArray race requires precise signal timing during `dlopen` which is not feasible to reproduce deterministically
- The ASAN fix is verified by nightly sanitized CI runs (previously failing intermittently on J9)
- The SignalBlocker fix eliminates the signal window around allocator calls — verified by ASAN CI
- The `__stack_chk_fail` fix verified by `test-linux-musl-aarch64 (11-librca, debug)` CI job
- The gdb watchdog and timeout are verified by CI runs — if a hang occurs, `build/logs/gdb-watchdog.log` will contain native thread backtraces
- The arm64 lockup fixes are verified by CI aarch64 runs and will be validated by stress tests and dd-trace-java integration
- Compiled in both debug and release configurations

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-13978](https://datadoghq.atlassian.net/browse/PROF-13978)

Unsure? Have a question? Request a review!

[PROF-13978]: https://datadoghq.atlassian.net/browse/PROF-13978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
