### PR TITLE
Port async-profiler#1701: optimize nmethod type checks

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -96,7 +96,9 @@ void Profiler::addRuntimeStub(const void *address, int length,
   _runtime_stubs.add(address, length, name, true);
   _stubs_lock.unlock();
 
-  if (strcmp(name, "call_stub") == 0) {
+  if (name[0] == 'I' && strcmp(name, "Interpreter") == 0) {
+    CodeHeap::setInterpreterStart(address);
+  } else if (strcmp(name, "call_stub") == 0) {
     _call_stub_begin = address;
     _call_stub_end = (const char *)address + length;
   }

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -394,7 +394,53 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
                 anchor = NULL;
             }
 
-            if (nm->isNMethod()) {
+            if (nm->isInterpreter()) {
+                if (vm_thread != NULL && vm_thread->inDeopt()) {
+                    fillFrame(frames[depth++], BCI_ERROR, "break_deopt");
+                    break;
+                }
+
+                bool is_plausible_interpreter_frame = StackWalkValidation::isPlausibleInterpreterFrame(fp, sp, bcp_offset);
+                if (is_plausible_interpreter_frame) {
+                    VMMethod* method = ((VMMethod**)fp)[InterpreterFrame::method_offset];
+                    jmethodID method_id = getMethodId(method);
+                    if (method_id != NULL) {
+                        Counters::increment(WALKVM_JAVA_FRAME_OK);
+                        const char* bytecode_start = method->bytecode();
+                        const char* bcp = ((const char**)fp)[bcp_offset];
+                        int bci = bytecode_start == NULL || bcp < bytecode_start ? 0 : bcp - bytecode_start;
+                        fillFrame(frames[depth++], FRAME_INTERPRETED, bci, method_id);
+
+                        sp = ((uintptr_t*)fp)[InterpreterFrame::sender_sp_offset];
+                        pc = stripPointer(((void**)fp)[FRAME_PC_SLOT]);
+                        fp = *(uintptr_t*)fp;
+                        continue;
+                    }
+                }
+
+                if (depth == 0) {
+                    VMMethod* method = (VMMethod*)frame.method();
+                    jmethodID method_id = getMethodId(method);
+                    if (method_id != NULL) {
+                        Counters::increment(WALKVM_JAVA_FRAME_OK);
+                        fillFrame(frames[depth++], FRAME_INTERPRETED, 0, method_id);
+
+                        if (is_plausible_interpreter_frame) {
+                            pc = stripPointer(((void**)fp)[FRAME_PC_SLOT]);
+                            sp = frame.senderSP();
+                            fp = *(uintptr_t*)fp;
+                        } else {
+                            pc = stripPointer(SafeAccess::load((void**)sp));
+                            sp = frame.senderSP();
+                        }
+                        continue;
+                    }
+                }
+
+                Counters::increment(WALKVM_BREAK_INTERPRETED);
+                fillFrame(frames[depth++], BCI_ERROR, "break_interpreted");
+                break;
+            } else if (nm->isNMethod()) {
                 // Check if deoptimization is in progress before walking compiled frames
                 if (vm_thread != NULL && vm_thread->inDeopt()) {
                     fillFrame(frames[depth++], BCI_ERROR, "break_deopt_compiled");
@@ -452,52 +498,6 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
 
                 Counters::increment(WALKVM_BREAK_COMPILED);
                 fillFrame(frames[depth++], BCI_ERROR, "break_compiled");
-                break;
-            } else if (nm->isInterpreter()) {
-                if (vm_thread != NULL && vm_thread->inDeopt()) {
-                    fillFrame(frames[depth++], BCI_ERROR, "break_deopt");
-                    break;
-                }
-
-                bool is_plausible_interpreter_frame = StackWalkValidation::isPlausibleInterpreterFrame(fp, sp, bcp_offset);
-                if (is_plausible_interpreter_frame) {
-                    VMMethod* method = ((VMMethod**)fp)[InterpreterFrame::method_offset];
-                    jmethodID method_id = getMethodId(method);
-                    if (method_id != NULL) {
-                        Counters::increment(WALKVM_JAVA_FRAME_OK);
-                        const char* bytecode_start = method->bytecode();
-                        const char* bcp = ((const char**)fp)[bcp_offset];
-                        int bci = bytecode_start == NULL || bcp < bytecode_start ? 0 : bcp - bytecode_start;
-                        fillFrame(frames[depth++], FRAME_INTERPRETED, bci, method_id);
-
-                        sp = ((uintptr_t*)fp)[InterpreterFrame::sender_sp_offset];
-                        pc = stripPointer(((void**)fp)[FRAME_PC_SLOT]);
-                        fp = *(uintptr_t*)fp;
-                        continue;
-                    }
-                }
-
-                if (depth == 0) {
-                    VMMethod* method = (VMMethod*)frame.method();
-                    jmethodID method_id = getMethodId(method);
-                    if (method_id != NULL) {
-                        Counters::increment(WALKVM_JAVA_FRAME_OK);
-                        fillFrame(frames[depth++], FRAME_INTERPRETED, 0, method_id);
-
-                        if (is_plausible_interpreter_frame) {
-                            pc = stripPointer(((void**)fp)[FRAME_PC_SLOT]);
-                            sp = frame.senderSP();
-                            fp = *(uintptr_t*)fp;
-                        } else {
-                            pc = stripPointer(SafeAccess::load((void**)sp));
-                            sp = frame.senderSP();
-                        }
-                        continue;
-                    }
-                }
-
-                Counters::increment(WALKVM_BREAK_INTERPRETED);
-                fillFrame(frames[depth++], BCI_ERROR, "break_interpreted");
                 break;
             } else if (nm->isEntryFrame(pc) && !features.mixed) {
                 VMJavaFrameAnchor* next_anchor = VMJavaFrameAnchor::fromEntryFrame(fp);

--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <pthread.h>
+#include <string.h>
 #include <unistd.h>
 #include <stdarg.h>
 #include "vmStructs.h"
@@ -33,6 +34,8 @@ int VMStructs::_narrow_klass_shift = -1;
 int VMStructs::_interpreter_frame_bcp_offset = 0;
 unsigned char VMStructs::_unsigned5_base = 0;
 const void* VMStructs::_call_stub_return = nullptr;
+const void* VMStructs::_interpreter_start = nullptr;
+VMNMethod* VMStructs::_interpreter_nm = nullptr;
 const void* VMStructs::_interpreted_frame_valid_start = nullptr;
 const void* VMStructs::_interpreted_frame_valid_end = nullptr;
 
@@ -436,6 +439,9 @@ void VMStructs::resolveOffsets() {
         _code_heap_segment_shift < 0 || _code_heap_segment_shift > 16 ||
         _heap_block_used_offset < 0) {
         memset(_code_heap, 0, sizeof(_code_heap));
+    }
+    if (_interpreter_nm == NULL && _interpreter_start != NULL) {
+        _interpreter_nm = CodeHeap::findNMethod(_interpreter_start);
     }
 }
 

--- a/ddprof-lib/src/main/cpp/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/vmStructs.h
@@ -10,7 +10,6 @@
 #include <initializer_list>
 #include <jvmti.h>
 #include <stdint.h>
-#include <string.h>
 #include <type_traits>
 #include "codeCache.h"
 #include "counters.h"
@@ -21,6 +20,7 @@
 
 class GCHeapSummary;
 class HeapUsage;
+class VMNMethod;
 
 
 // During stack walking in the profiler's signal handler, GC or class unloading
@@ -310,6 +310,8 @@ class VMStructs {
     static int _interpreter_frame_bcp_offset;
     static unsigned char _unsigned5_base;
     static const void* _call_stub_return;
+    static const void* _interpreter_start;
+    static VMNMethod* _interpreter_nm;
     static const void* _interpreted_frame_valid_start;
     static const void* _interpreted_frame_valid_end;
 
@@ -829,6 +831,16 @@ DECLARE(VMMethod)
 DECLARE_END
 
 DECLARE(VMNMethod)
+  private:
+    // Inline string comparison to avoid indirect call to strncmp
+    template<size_t N>
+    static bool startsWith(const char* s, const char (&pattern)[N]) {
+        for (size_t i = 0; i < N - 1; i++) {
+            if (s[i] != pattern[i]) return false;
+        }
+        return true;
+    }
+
   public:
     int size() {
         assert(_blob_size_offset >= 0);
@@ -902,24 +914,23 @@ DECLARE(VMNMethod)
         return *(const char**) at(_nmethod_name_offset);
     }
 
-    bool isNMethod() {
-        const char* n = name();
-        return n != NULL && (strcmp(n, "nmethod") == 0 || strcmp(n, "native nmethod") == 0);
+    bool isInterpreter() {
+        return this == _interpreter_nm;
     }
 
-    bool isInterpreter() {
+    bool isNMethod() {
         const char* n = name();
-        return n != NULL && strcmp(n, "Interpreter") == 0;
+        return n != NULL && (startsWith(n, "nmethod\0") || startsWith(n, "native nmethod\0"));
     }
 
     bool isStub() {
         const char* n = name();
-        return n != NULL && strncmp(n, "StubRoutines", 12) == 0;
+        return n != NULL && startsWith(n, "StubRoutines");
     }
 
     bool isVTableStub() {
         const char* n = name();
-        return n != NULL && strcmp(n, "vtable chunks") == 0;
+        return n != NULL && startsWith(n, "vtable chunks");
     }
 
     VMMethod* method() {
@@ -983,6 +994,11 @@ class CodeHeap : VMStructs {
         for (const void* high = _code_heap_high;
              end > high && !__sync_bool_compare_and_swap(&_code_heap_high, high, end);
              high = _code_heap_high);
+    }
+
+    static void setInterpreterStart(const void* start) {
+        _interpreter_start = start;
+        _interpreter_nm = findNMethod(start);
     }
 
     static VMNMethod* findNMethod(const void* pc) {

--- a/ddprof-lib/src/main/cpp/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/vmStructs.h
@@ -830,17 +830,16 @@ DECLARE(VMMethod)
     static bool check_jmethodID(jmethodID id);
 DECLARE_END
 
-DECLARE(VMNMethod)
-  private:
-    // Inline string comparison to avoid indirect call to strncmp
-    template<size_t N>
-    static bool startsWith(const char* s, const char (&pattern)[N]) {
-        for (size_t i = 0; i < N - 1; i++) {
-            if (s[i] != pattern[i]) return false;
-        }
-        return true;
+// Inline string comparison to avoid indirect call to strncmp
+template<size_t N>
+static inline bool startsWith(const char* s, const char (&pattern)[N]) {
+    for (size_t i = 0; i < N - 1; i++) {
+        if (s[i] != pattern[i]) return false;
     }
+    return true;
+}
 
+DECLARE(VMNMethod)
   public:
     int size() {
         assert(_blob_size_offset >= 0);


### PR DESCRIPTION
**What does this PR do?**:
Ports [async-profiler#1701](https://github.com/async-profiler/async-profiler/pull/1701) (commit [`cc0eab1`](https://github.com/async-profiler/async-profiler/commit/cc0eab17890faaf20faa5842c6e5685ab6277238)) into the Datadog fork, adapting it for our `VMNMethod`-based class structure.

**Motivation**:
Upstream measured up to ~11% improvement in average stack-walking speed on real benchmarks (spring-petclinic, renaissance dotty). The two main micro-optimizations are:

1. **`isInterpreter()` pointer comparison** — HotSpot has exactly one `Interpreter` code blob. We now record its `VMNMethod*` at JVM startup (via `addRuntimeStub`) and compare with `this` instead of calling `strcmp`. O(1) instead of O(n).
2. **Inline `startsWith` template** — Replaces `strcmp`/`strncmp` calls in `isNMethod`, `isStub`, and `isVTableStub` with a compile-time-unrolled character loop, avoiding the indirect PLT call to the standard library.
3. **Branch reordering in `stackWalker.cpp`** — `isInterpreter()` is now checked before `isNMethod()` since it is now a single pointer comparison.

**Additional Notes**:
- `_interpreter_start` is stored separately so that `resolveOffsets()` can retry `findNMethod` if the code heap was not yet initialized when `addRuntimeStub("Interpreter", ...)` was called.
- The improvement can be observed via the existing `WALKVM_*` counters (e.g. `walkvm_java_frame_ok`) recorded during profiling runs.
- Closes #421.

**How to test the change?**:
Existing CI covers the stack-walking paths. The performance gain can be measured by comparing stack-walk throughput on a CPU-heavy workload before and after.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!