### PR TITLE
Detect per-library aarch64 frame layout from DWARF

### DIFF
--- a/ddprof-lib/src/main/cpp/codeCache.cpp
+++ b/ddprof-lib/src/main/cpp/codeCache.cpp
@@ -63,6 +63,7 @@ CodeCache::CodeCache(const char *name, short lib_index,
 
   _dwarf_table = NULL;
   _dwarf_table_length = 0;
+  _default_frame = &FrameDesc::default_frame;
 
   _capacity = INITIAL_CODE_CACHE_CAPACITY;
   _count = 0;
@@ -101,6 +102,7 @@ void CodeCache::copyFrom(const CodeCache& other) {
   _dwarf_table = new FrameDesc[_dwarf_table_length];
   memcpy(_dwarf_table, other._dwarf_table,
          _dwarf_table_length * sizeof(FrameDesc));
+  _default_frame = other._default_frame;
 
   _capacity = other._capacity;
   _count = other._count;
@@ -388,16 +390,15 @@ void CodeCache::makeImportsPatchable() {
   }
 }
 
-void CodeCache::setDwarfTable(FrameDesc *table, int length) {
+void CodeCache::setDwarfTable(FrameDesc *table, int length, const FrameDesc &default_frame) {
   _dwarf_table = table;
   _dwarf_table_length = length;
+  _default_frame = &default_frame;
 }
 
 FrameDesc CodeCache::findFrameDesc(const void *pc) {
   if (_dwarf_table == NULL || _dwarf_table_length == 0) {
-    // No DWARF data available - use default frame pointer unwinding
-    // This handles OpenJ9 and other VMs that don't provide DWARF info
-    return FrameDesc::default_frame;
+    return *_default_frame;
   }
 
   u32 target_loc = (const char *)pc - _text_base;
@@ -420,7 +421,7 @@ FrameDesc CodeCache::findFrameDesc(const void *pc) {
   } else if (target_loc - _plt_offset < _plt_size) {
     return FrameDesc::empty_frame;
   } else {
-    return FrameDesc::default_frame;
+    return *_default_frame;
   }
 }
 

--- a/ddprof-lib/src/main/cpp/codeCache.h
+++ b/ddprof-lib/src/main/cpp/codeCache.h
@@ -8,6 +8,7 @@
 
 #include "common.h"
 #include "counters.h"
+#include "dwarf.h"
 #include "utils.h"
 
 #include <jvmti.h>
@@ -116,8 +117,6 @@ public:
   }
 };
 
-class FrameDesc;
-
 class CodeCache {
 private:
   char *_name;
@@ -141,6 +140,7 @@ private:
 
   FrameDesc *_dwarf_table;
   int _dwarf_table_length;
+  const FrameDesc *_default_frame;
 
   int _capacity;
   int _count;
@@ -241,7 +241,7 @@ public:
   void findSymbolsByPrefix(std::vector<const char *> &prefixes,
                            std::vector<const void *> &symbols);
 
-  void setDwarfTable(FrameDesc *table, int length);
+  void setDwarfTable(FrameDesc *table, int length, const FrameDesc &default_frame = FrameDesc::default_frame);
   FrameDesc findFrameDesc(const void *pc);
 
   long long memoryUsage() {

--- a/ddprof-lib/src/main/cpp/dwarf.cpp
+++ b/ddprof-lib/src/main/cpp/dwarf.cpp
@@ -104,6 +104,7 @@ DwarfParser::DwarfParser(const char *name, const char *image_base,
 
   _code_align = sizeof(instruction_t);
   _data_align = -(int)sizeof(void *);
+  _linked_frame_size = -1;
 
   parse(eh_frame_hdr);
 }
@@ -410,6 +411,14 @@ void DwarfParser::addRecord(u32 loc, u32 cfa_reg, int cfa_off, int fp_off,
 
   // cfa_reg and cfa_off can be encoded to a single 32 bit value, considering the existing and supported systems
   u32 cfa = static_cast<u32>(cfa_off) << 8 | static_cast<u32>(cfa_reg & 0xff);
+
+  // Detect the linked frame size from the first FP-based entry with a non-zero offset.
+  // Both GCC and Clang emit DW_REG_FP with cfa_off = LINKED_FRAME_CLANG_SIZE in function
+  // bodies after the prologue completes. Terminal records use cfa_off = 0 (LINKED_FRAME_SIZE
+  // on aarch64) and do not influence detection.
+  if (_linked_frame_size < 0 && cfa_reg == DW_REG_FP && cfa_off > 0) {
+    _linked_frame_size = cfa_off;
+  }
 
   if (_prev == NULL || (_prev->loc == loc && --_count >= 0) ||
       _prev->cfa != cfa || _prev->fp_off != fp_off || _prev->pc_off != pc_off) {

--- a/ddprof-lib/src/main/cpp/dwarf.h
+++ b/ddprof-lib/src/main/cpp/dwarf.h
@@ -80,7 +80,7 @@ struct FrameDesc {
 
     static FrameDesc empty_frame;
     static FrameDesc default_frame;
-    static FrameDesc    default_clang_frame;
+    static FrameDesc default_clang_frame;
     static FrameDesc no_dwarf_frame;
 
     static int comparator(const void* p1, const void* p2) {

--- a/ddprof-lib/src/main/cpp/dwarf.h
+++ b/ddprof-lib/src/main/cpp/dwarf.h
@@ -83,6 +83,17 @@ struct FrameDesc {
     static FrameDesc default_clang_frame;
     static FrameDesc no_dwarf_frame;
 
+    // Best-guess fallback frame layout when a PC doesn't map to any known library.
+    // Per-library detection overrides this: on macOS via __eh_frame section presence,
+    // on Linux via DwarfParser::detectedDefaultFrame().
+    static const FrameDesc& fallback_default_frame() {
+#if defined(__APPLE__) && defined(__aarch64__)
+        return default_clang_frame;
+#else
+        return default_frame;
+#endif
+    }
+
     static int comparator(const void* p1, const void* p2) {
         FrameDesc* fd1 = (FrameDesc*)p1;
         FrameDesc* fd2 = (FrameDesc*)p2;

--- a/ddprof-lib/src/main/cpp/dwarf.h
+++ b/ddprof-lib/src/main/cpp/dwarf.h
@@ -80,7 +80,7 @@ struct FrameDesc {
 
     static FrameDesc empty_frame;
     static FrameDesc default_frame;
-    static FrameDesc default_clang_frame;
+    static FrameDesc    default_clang_frame;
     static FrameDesc no_dwarf_frame;
 
     static int comparator(const void* p1, const void* p2) {
@@ -104,6 +104,7 @@ class DwarfParser {
 
     u32 _code_align;
     int _data_align;
+    int _linked_frame_size;  // detected from FP-based DWARF entries; -1 = undetected
 
     const char* add(size_t size) {
         const char* ptr = _ptr;
@@ -184,6 +185,13 @@ class DwarfParser {
 
     int count() const {
         return _count;
+    }
+
+    const FrameDesc& detectedDefaultFrame() const {
+        if (_linked_frame_size == LINKED_FRAME_CLANG_SIZE && LINKED_FRAME_CLANG_SIZE != LINKED_FRAME_SIZE) {
+            return FrameDesc::default_clang_frame;
+        }
+        return FrameDesc::default_frame;
     }
 };
 

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -158,7 +158,11 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
 
         uintptr_t prev_sp = sp;
         CodeCache* cc = profiler->findLibraryByAddress(pc);
+#if defined(__APPLE__) && defined(__aarch64__)
+        FrameDesc f = cc != NULL ? cc->findFrameDesc(pc) : FrameDesc::default_clang_frame;
+#else
         FrameDesc f = cc != NULL ? cc->findFrameDesc(pc) : FrameDesc::default_frame;
+#endif
 
         u8 cfa_reg = (u8)f.cfa;
         int cfa_off = f.cfa >> 8;
@@ -694,7 +698,11 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
         dwarf_unwind:
         uintptr_t prev_sp = sp;
         CodeCache* cc = profiler->findLibraryByAddress(pc);
+#if defined(__APPLE__) && defined(__aarch64__)
+        FrameDesc f = cc != NULL ? cc->findFrameDesc(pc) : FrameDesc::default_clang_frame;
+#else
         FrameDesc f = cc != NULL ? cc->findFrameDesc(pc) : FrameDesc::default_frame;
+#endif
 
         u8 cfa_reg = (u8)f.cfa;
         int cfa_off = f.cfa >> 8;

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -158,11 +158,7 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
 
         uintptr_t prev_sp = sp;
         CodeCache* cc = profiler->findLibraryByAddress(pc);
-#if defined(__APPLE__) && defined(__aarch64__)
-        FrameDesc f = cc != NULL ? cc->findFrameDesc(pc) : FrameDesc::default_clang_frame;
-#else
-        FrameDesc f = cc != NULL ? cc->findFrameDesc(pc) : FrameDesc::default_frame;
-#endif
+        FrameDesc f = cc != NULL ? cc->findFrameDesc(pc) : FrameDesc::fallback_default_frame();
 
         u8 cfa_reg = (u8)f.cfa;
         int cfa_off = f.cfa >> 8;
@@ -698,11 +694,7 @@ __attribute__((no_sanitize("address"))) int StackWalker::walkVM(void* ucontext, 
         dwarf_unwind:
         uintptr_t prev_sp = sp;
         CodeCache* cc = profiler->findLibraryByAddress(pc);
-#if defined(__APPLE__) && defined(__aarch64__)
-        FrameDesc f = cc != NULL ? cc->findFrameDesc(pc) : FrameDesc::default_clang_frame;
-#else
-        FrameDesc f = cc != NULL ? cc->findFrameDesc(pc) : FrameDesc::default_frame;
-#endif
+        FrameDesc f = cc != NULL ? cc->findFrameDesc(pc) : FrameDesc::fallback_default_frame();
 
         u8 cfa_reg = (u8)f.cfa;
         int cfa_off = f.cfa >> 8;

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -604,6 +604,9 @@ void ElfParser::parseDwarfInfo() {
     ElfProgramHeader* eh_frame_hdr = findProgramHeader(PT_GNU_EH_FRAME);
     if (eh_frame_hdr != NULL) {
         if (eh_frame_hdr->p_vaddr != 0) {
+            // Parse per-PC frame descriptions and detect per-library default frame layout.
+            // On aarch64 this distinguishes GCC (LINKED_FRAME_SIZE=0) from clang
+            // (LINKED_FRAME_CLANG_SIZE=16) conventions for each shared library.
             DwarfParser dwarf(_cc->name(), _base, at(eh_frame_hdr));
             _cc->setDwarfTable(dwarf.table(), dwarf.count(), dwarf.detectedDefaultFrame());
         } else if (strcmp(_cc->name(), "[vdso]") == 0) {

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -605,7 +605,7 @@ void ElfParser::parseDwarfInfo() {
     if (eh_frame_hdr != NULL) {
         if (eh_frame_hdr->p_vaddr != 0) {
             DwarfParser dwarf(_cc->name(), _base, at(eh_frame_hdr));
-            _cc->setDwarfTable(dwarf.table(), dwarf.count());
+            _cc->setDwarfTable(dwarf.table(), dwarf.count(), dwarf.detectedDefaultFrame());
         } else if (strcmp(_cc->name(), "[vdso]") == 0) {
             FrameDesc* table = (FrameDesc*)malloc(sizeof(FrameDesc));
             *table = FrameDesc::empty_frame;

--- a/ddprof-lib/src/main/cpp/symbols_macos.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_macos.cpp
@@ -12,6 +12,7 @@
 #include <mach-o/loader.h>
 #include <mach-o/nlist.h>
 #include "symbols.h"
+#include "dwarf.h"
 #include "log.h"
 
 UnloadProtection::UnloadProtection(const CodeCache *cc) {
@@ -138,6 +139,7 @@ class MachOParser {
         const symtab_command* symtab = NULL;
         const dysymtab_command* dysymtab = NULL;
         const section_64* stubs_section = NULL;
+        bool has_eh_frame = false;
 
         for (uint32_t i = 0; i < header->ncmds; i++) {
             if (lc->cmd == LC_SEGMENT_64) {
@@ -145,6 +147,7 @@ class MachOParser {
                 if (strcmp(sc->segname, "__TEXT") == 0) {
                     _cc->updateBounds(_image_base, add(_image_base, sc->vmsize));
                     stubs_section = findSection(sc, "__stubs");
+                    has_eh_frame = findSection(sc, "__eh_frame") != NULL;
                 } else if (strcmp(sc->segname, "__LINKEDIT") == 0) {
                     link_base = _vmaddr_slide + sc->vmaddr - sc->fileoff;
                 } else if (strcmp(sc->segname, "__DATA") == 0 || strcmp(sc->segname, "__DATA_CONST") == 0) {
@@ -167,6 +170,12 @@ class MachOParser {
                 if (stubs_section != NULL) loadStubSymbols(symtab, dysymtab, stubs_section, link_base);
             }
         }
+
+        // GCC emits __eh_frame (DWARF CFI); clang emits __unwind_info (compact unwind).
+        // On aarch64, GCC and clang use different frame layouts, so detecting the
+        // compiler matters. On x86_64 both use the same layout (no-op distinction).
+        const FrameDesc& frame = has_eh_frame ? FrameDesc::default_frame : FrameDesc::fallback_default_frame();
+        _cc->setDwarfTable(NULL, 0, frame);
 
         return true;
     }


### PR DESCRIPTION
**What does this PR do?**:
Wires up the previously-defined-but-unused `FrameDesc::default_clang_frame` by detecting the correct linked-frame size per library from actual DWARF FDE entries, and using it as the fallback when a PC has no DWARF coverage.

**Motivation**:
On aarch64, GCC and Clang both produce standard frames (`stp x29, x30, [sp, #-16]!; mov x29, sp`) with `CFA = FP+16` in their DWARF FDE bodies. The existing fallback `default_frame` encoded `CFA = FP+0` (with a special-case path in the unwinder), which was a heuristic gamble. `default_clang_frame` with `CFA = FP+16` is the ABI-compliant encoding that correctly advances SP to the pre-frame value. The per-library detection was intended when `default_clang_frame` was introduced in #199 but was never implemented — it was lost during the `_dd` file consolidation in #340.

**Additional Notes**:

I am quite sure we already had this functionality before. Somehow got lost when merging with the upstream and redoing the source structure :/

- Detection fires on the first FDE entry with `cfa_reg == DW_REG_FP && cfa_off > 0` during DWARF parsing — terminal records (which use the hardcoded `LINKED_FRAME_SIZE = 0` on aarch64) are correctly skipped by the `cfa_off > 0` guard.
- `detectedDefaultFrame()` only returns `default_clang_frame` when `LINKED_FRAME_CLANG_SIZE != LINKED_FRAME_SIZE`, which is aarch64 only. On x86_64/i386 the two constants are equal so behaviour is unchanged.
- For the `cc == NULL` fallback (PC in a completely unknown library), macOS/aarch64 uses `default_clang_frame` unconditionally since Apple ships Clang-only code.
- `_default_frame` always points to a static `FrameDesc` — no lifetime or thread-safety concern. Verified by review.

**How to test the change?**:
Existing unwinding integration tests cover the aarch64 unwinding paths. The change is conservative: libraries with DWARF info already unwind correctly via the table; this only affects the rare fallback path (PC outside DWARF coverage or library has no `.eh_frame`). Testing on Apple Silicon (macOS/aarch64) and Linux/aarch64 with both GCC- and Clang-compiled JDKs exercises the detection path.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!