### PR TITLE
Do not perform deep validity check of jmethodid on JDK 26+

### DIFF
--- a/ddprof-lib/src/main/cpp/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/vmStructs.cpp
@@ -873,6 +873,12 @@ bool VMMethod::check_jmethodID(jmethodID id) {
 }
 
 bool VMMethod::check_jmethodID_hotspot(jmethodID id) {
+    if (VM::hotspot_version() > 25) {
+        // In https://bugs.openjdk.org/browse/JDK-8268406 the jmethodids are completely reworked
+        // The assumption that jmethodid can be resolved to Method* is false and we really can
+        // not do any extra checks here
+        return true;
+    }
     const char *method_ptr = (const char *)SafeAccess::load((void **)id);
     // check for NULL ptr and 'empty' ptr (JNIMethodBlock::_free_method)
     if (method_ptr == NULL || (size_t)method_ptr == 55) {


### PR DESCRIPTION
**What does this PR do?**:
Fix completely dysfunctional Java frame symbolication on Java 26

**Motivation**:
https://bugs.openjdk.org/browse/JDK-8268406 changed how jmethodid was represented in Hotspot JVMs.
Although the original fix for this was provided with async-profiler, another, sneakier issue remained in DD Java profiler - we perform deep validation of jmethodid to avoid surprising crashes due to attempts to access an invalid memory.
However, this validation is completely wrong on JDK 26 and later because jmethodids are now just a monotonically increasing key to a side table and we can not really validate anything.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
Run a test load, capture profile and check the stacktraces. There should be no 'jvmtiError' frames.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-14087]

Unsure? Have a question? Request a review!


[PROF-14087]: https://datadoghq.atlassian.net/browse/PROF-14087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ