### PR TITLE
fix: auto-fixes from motley-crew ghost review (jb/netty_native_socket)

### DIFF
--- a/ddprof-lib/src/main/cpp/socketTracer.h
+++ b/ddprof-lib/src/main/cpp/socketTracer.h
@@ -82,6 +82,7 @@ public:
   static void patchLibraries() {}
   static void unpatchLibraries() {}
   static bool isInitialized() { return false; }
+  static bool isNettyLibrary(const char*) { return false; }
 };
 
 #endif  // __linux__

--- a/ddprof-lib/src/main/cpp/socketTracer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/socketTracer_linux.cpp
@@ -381,6 +381,7 @@ void SocketTracer::unpatchLibraries() {
 #undef UNPATCH
     }
     _patched_count = 0;
+    _initialized   = false;
     _orig_read       = nullptr;
     _orig_write      = nullptr;
     _orig_readv      = nullptr;


### PR DESCRIPTION
**What does this PR do?**:
Two high-confidence auto-fixes produced by the motley-crew ghost fleet review of `jb/netty_native_socket`.

**Motivation**:
Ghost fleet review (11 ghosts, 2 gossip rounds) identified these issues with ≥99% confidence — both are single-line fixes that are unambiguous and have zero challenges from any ghost reviewer.

**Additional Notes**:

### Fix 1 — `_initialized` never reset in `unpatchLibraries()` [confidence: 99%]

**File**: `ddprof-lib/src/main/cpp/socketTracer_linux.cpp`
**Originating ghosts**: rkennke, ivoanjo, MattAlp, AlexJF, mar-kolya, lilrex (6 validates, 0 challenges)

`unpatchLibraries()` resets all `_orig_xxx` pointers and `_patched_count` but never sets `_initialized = false`. A subsequent call to `initialize()` returns early thinking the tracer is already initialized; a subsequent call to `patchLibraries()` then silently does nothing because `_initialized` is still `true`.

Fix: `_initialized = false;` added inside `unpatchLibraries()` after resetting `_patched_count`.

---

### Fix 2 — Non-Linux stub missing `isNettyLibrary()` [confidence: 99%]

**File**: `ddprof-lib/src/main/cpp/socketTracer.h`
**Originating ghosts**: kaahos, ivoanjo, r1viollet, lilrex, MattAlp (5 validates, 0 challenges)

`socketTracer_ut.cpp` calls `SocketTracer::isNettyLibrary()`, which is declared only in the Linux `#ifdef` branch. On macOS / non-Linux CI, this causes a compile error.

Fix: `static bool isNettyLibrary(const char*) { return false; }` added to the non-Linux stub class.

**How to test the change?**:
- Build on macOS / non-Linux to confirm `socketTracer_ut.cpp` compiles.
- Run `socketTracer_ut` tests.
- On Linux: call `initialize()` → `patchLibraries()` → `unpatchLibraries()` → `initialize()` → `patchLibraries()` and verify patching works on the second cycle.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]