### PR TITLE
fix: prevent memory leak in otel schema_version decode branch

### DIFF
--- a/ddprof-lib/src/main/cpp/otel_process_ctx.cpp
+++ b/ddprof-lib/src/main/cpp/otel_process_ctx.cpp
@@ -669,6 +669,8 @@ static otel_process_ctx_result otel_process_ctx_encode_protobuf_payload(char **o
   // Reads an AnyValue.array_value (field 5) from ptr; ptr must be at KeyValue.value (tag 2).
   // Allocates a NULL-terminated array of strings and sets *out_array immediately. On error the caller must free it.
   static bool read_protobuf_array_value_strings(char **ptr, char *end_ptr, char *value_buffer, const char ***out_array) {
+    // Reject duplicate fields — if the output pointer already holds a value, the protobuf data is malformed
+    if (*out_array) return false;
     uint8_t field;
     if (!read_protobuf_tag(ptr, end_ptr, &field) || field != 2) return false;
     uint16_t any_len;

--- a/ddprof-lib/src/main/cpp/otel_process_ctx.cpp
+++ b/ddprof-lib/src/main/cpp/otel_process_ctx.cpp
@@ -806,10 +806,16 @@ static otel_process_ctx_result otel_process_ctx_encode_protobuf_payload(char **o
 
         // Dispatch based on key
         if (strcmp(key_buffer, "threadlocal.schema_version") == 0) {
-          otel_thread_ctx_config_data *setup = (otel_thread_ctx_config_data *) calloc(1, sizeof(otel_thread_ctx_config_data));
-          if (!setup) { free(value); return false; }
-          setup->schema_version = value;
-          data_out->thread_ctx_config = setup;
+          if (!data_out->thread_ctx_config) {
+            otel_thread_ctx_config_data *setup = (otel_thread_ctx_config_data *) calloc(1, sizeof(otel_thread_ctx_config_data));
+            if (!setup) { free(value); return false; }
+            data_out->thread_ctx_config = setup;
+          } else {
+            if (((otel_thread_ctx_config_data *)data_out->thread_ctx_config)->schema_version) {
+              free((void *)((otel_thread_ctx_config_data *)data_out->thread_ctx_config)->schema_version);
+            }
+          }
+          ((otel_thread_ctx_config_data *)data_out->thread_ctx_config)->schema_version = value;
         } else {
           char *key = strdup(key_buffer);
           if (!key || extra_attributes_index + 2 >= extra_attributes_capacity) {


### PR DESCRIPTION
**What does this PR do?**:
Guards the `threadlocal.schema_version` decode branch in `otel_process_ctx_decode_payload` against leaking the existing `thread_ctx_config` allocation. When `data_out->thread_ctx_config` is already non-NULL, the fix reuses the existing struct instead of allocating a new one and silently losing the old pointer. It also frees the old `schema_version` value before assigning a new one (handles duplicate keys in a single payload).

**Motivation**:
The `schema_version` branch at lines 808-812 always executed `calloc` + unconditional assign, meaning every re-decode (or any payload that contained both `threadlocal.attribute_key_map` and `threadlocal.schema_version`) would leak the previously allocated `otel_thread_ctx_config_data` struct. The `attribute_key_map` branch directly above it already used the correct null-guard pattern; this fix mirrors that pattern for `schema_version`.

**Additional Notes**:
The fix is symmetric with the existing `attribute_key_map` branch (lines ~790-800) which already checked `!data_out->thread_ctx_config` before allocating. No new allocation strategy is introduced — the same `calloc` + null-guard pattern is applied consistently.

**How to test the change?**:
Acceptance test scenarios (manual or via a C unit test harness):
- Decode a payload containing `threadlocal.schema_version` twice — second decode must not leak the first allocation
- Decode a payload with `attribute_key_map` first, then `schema_version` — `thread_ctx_config` must be allocated exactly once
- Decode a payload with `schema_version` first, then `attribute_key_map` — same single-allocation requirement
- Run under ASan/Valgrind with a payload that exercises both keys; expect zero leak reports

**For Datadog employees**:
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-14142](https://datadoghq.atlassian.net/browse/PROF-14142)

[PROF-14142]: https://datadoghq.atlassian.net/browse/PROF-14142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ