### PR TITLE
Fix signal-handler crash in Libraries::findLibraryByAddress

### DIFF
--- a/ddprof-lib/src/main/cpp/findLibraryImpl.h
+++ b/ddprof-lib/src/main/cpp/findLibraryImpl.h
@@ -28,7 +28,7 @@
 // that falls through to the O(n) linear scan.
 
 template<typename CacheEntry, typename CacheArray>
-static inline CacheEntry* findLibraryByAddressImpl(const CacheArray& libs, const void* address) {
+inline CacheEntry* findLibraryByAddressImpl(const CacheArray& libs, const void* address) {
     static volatile int last_hit = 0;
     const int count = libs.count();
     int hint = last_hit;

--- a/ddprof-lib/src/main/cpp/findLibraryImpl.h
+++ b/ddprof-lib/src/main/cpp/findLibraryImpl.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _FINDLIBRARYIMPL_H
+#define _FINDLIBRARYIMPL_H
+
+// Signal-handler-safe last-hit-index cache for findLibraryByAddress.
+//
+// Templated on CacheArray and CacheEntry so that the exact same algorithm
+// can be exercised from benchmarks (using lightweight fake types) without
+// pulling in JVM headers, while production uses CodeCacheArray/CodeCache.
+//
+// Requirements on CacheArray:
+//   int          count()     const  — number of live entries
+//   CacheEntry*  operator[](int i) const  — entry at index i (may be nullptr)
+//
+// Requirements on CacheEntry:
+//   bool  contains(const void* address) const
+//
+// Signal-safety: the last-hit index is a plain static volatile int.
+// DTLS initialisation for shared libraries calls calloc internally; if a
+// profiler signal fires on a thread whose TLS block has not been set up yet
+// while that thread is inside malloc, any thread_local access deadlocks on
+// the allocator lock.  A plain static volatile int avoids TLS entirely.
+// A benign race on the index is acceptable — the worst case is a cache miss
+// that falls through to the O(n) linear scan.
+
+template<typename CacheEntry, typename CacheArray>
+static inline CacheEntry* findLibraryByAddressImpl(const CacheArray& libs, const void* address) {
+    static volatile int last_hit = 0;
+    const int count = libs.count();
+    int hint = last_hit;
+    if (hint < count) {
+        CacheEntry* lib = libs[hint];
+        if (lib != nullptr && lib->contains(address)) {
+            return lib;
+        }
+    }
+    for (int i = 0; i < count; i++) {
+        CacheEntry* lib = libs[i];
+        if (lib != nullptr && lib->contains(address)) {
+            last_hit = i;
+            return lib;
+        }
+    }
+    return nullptr;
+}
+
+#endif // _FINDLIBRARYIMPL_H

--- a/ddprof-lib/src/main/cpp/libraries.cpp
+++ b/ddprof-lib/src/main/cpp/libraries.cpp
@@ -1,5 +1,6 @@
 #include "codeCache.h"
 #include "common.h"
+#include "findLibraryImpl.h"
 #include "hotspot/vmStructs.h"
 #include "libraries.h"
 #include "libraryPatcher.h"
@@ -100,12 +101,5 @@ CodeCache *Libraries::findLibraryByName(const char *lib_name) {
 }
 
 CodeCache *Libraries::findLibraryByAddress(const void *address) const {
-  const int native_lib_count = _native_libs.count();
-  for (int i = 0; i < native_lib_count; i++) {
-    CodeCache *lib = _native_libs[i];
-    if (lib != NULL && lib->contains(address)) {
-      return lib;
-    }
-  }
-  return NULL;
+  return findLibraryByAddressImpl<CodeCache>(_native_libs, address);
 }

--- a/ddprof-lib/src/test/cpp/libraries_ut.cpp
+++ b/ddprof-lib/src/test/cpp/libraries_ut.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include "../../main/cpp/codeCache.h"
+#include "../../main/cpp/findLibraryImpl.h"
+#include "../../main/cpp/gtest_crash_handler.h"
+
+static constexpr char LIBRARIES_TEST_NAME[] = "LibrariesTest";
+
+// Three static buffers to serve as fake "text segments".
+// Using static storage ensures the addresses are stable and non-overlapping.
+static char g_lib0_text[1024];
+static char g_lib1_text[1024];
+static char g_lib2_text[1024];
+
+class LibrariesTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        installGtestCrashHandler<LIBRARIES_TEST_NAME>();
+
+        _lib0 = new CodeCache("libfake0.so", 0, g_lib0_text, g_lib0_text + sizeof(g_lib0_text));
+        _lib1 = new CodeCache("libfake1.so", 1, g_lib1_text, g_lib1_text + sizeof(g_lib1_text));
+        _lib2 = new CodeCache("libfake2.so", 2, g_lib2_text, g_lib2_text + sizeof(g_lib2_text));
+
+        _libs.add(_lib0);
+        _libs.add(_lib1);
+        _libs.add(_lib2);
+    }
+
+    void TearDown() override {
+        restoreDefaultSignalHandlers();
+        delete _lib0;
+        delete _lib1;
+        delete _lib2;
+    }
+
+    CodeCacheArray _libs;
+    CodeCache* _lib0 = nullptr;
+    CodeCache* _lib1 = nullptr;
+    CodeCache* _lib2 = nullptr;
+};
+
+TEST_F(LibrariesTest, KnownAddress) {
+    // Address inside lib1's range should return lib1.
+    const void* addr = g_lib1_text + 512;
+    CodeCache* result = findLibraryByAddressImpl<CodeCache>(_libs, addr);
+    EXPECT_EQ(result, _lib1);
+}
+
+TEST_F(LibrariesTest, NullAddress) {
+    // NULL should return nullptr without crashing.
+    CodeCache* result = findLibraryByAddressImpl<CodeCache>(_libs, nullptr);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(LibrariesTest, InvalidAddress) {
+    // An address outside all known ranges should return nullptr.
+    const void* addr = reinterpret_cast<const void*>(0x1);
+    CodeCache* result = findLibraryByAddressImpl<CodeCache>(_libs, addr);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(LibrariesTest, FirstLibrary) {
+    const void* addr = g_lib0_text + 100;
+    CodeCache* result = findLibraryByAddressImpl<CodeCache>(_libs, addr);
+    EXPECT_EQ(result, _lib0);
+}
+
+TEST_F(LibrariesTest, LastLibrary) {
+    const void* addr = g_lib2_text + 900;
+    CodeCache* result = findLibraryByAddressImpl<CodeCache>(_libs, addr);
+    EXPECT_EQ(result, _lib2);
+}
+
+TEST_F(LibrariesTest, CacheHitOnRepeatedLookup) {
+    // First lookup primes the cache for lib1.
+    const void* addr = g_lib1_text + 256;
+    CodeCache* first = findLibraryByAddressImpl<CodeCache>(_libs, addr);
+    EXPECT_EQ(first, _lib1);
+
+    // Second lookup with the same range should still return lib1 (cache hit path).
+    CodeCache* second = findLibraryByAddressImpl<CodeCache>(_libs, g_lib1_text + 700);
+    EXPECT_EQ(second, _lib1);
+}
+
+TEST_F(LibrariesTest, CacheMissFallsBackToLinearScan) {
+    // Prime cache for lib0.
+    findLibraryByAddressImpl<CodeCache>(_libs, g_lib0_text + 10);
+
+    // Now look up an address in lib2 — cache miss, linear scan must find it.
+    const void* addr = g_lib2_text + 500;
+    CodeCache* result = findLibraryByAddressImpl<CodeCache>(_libs, addr);
+    EXPECT_EQ(result, _lib2);
+}


### PR DESCRIPTION
**What does this PR do?**:

Fixes a crash/hang in `Libraries::findLibraryByAddress` triggered when a profiler signal fires on a thread whose thread-local storage (TLS) block has not been initialized yet.

The fix extracts the lookup algorithm into `findLibraryImpl.h` as a signal-handler-safe template using a plain `static volatile int` last-hit index instead of any `thread_local` storage.

| File | Change |
|------|--------|
| `ddprof-lib/src/main/cpp/findLibraryImpl.h` | New: signal-safe template `findLibraryByAddressImpl` with `static volatile int` last-hit cache |
| `ddprof-lib/src/main/cpp/libraries.cpp` | Delegate `findLibraryByAddress` to the template (one-liner) |
| `ddprof-lib/src/test/cpp/libraries_ut.cpp` | New: unit tests covering known/null/invalid address and cache hit/miss paths |

**Motivation**:

DTLS initialisation for shared libraries calls `calloc` internally. If a profiler signal fires on a thread whose TLS block has not been set up yet while that thread is inside `malloc`, any `thread_local` access in the signal-handler call chain deadlocks on the allocator lock — manifesting as a crash in `Libraries::findLibraryByAddress`. The `static volatile int` last-hit index avoids TLS entirely: a benign race on the index is acceptable — worst case is a cache miss that falls through to the O(n) linear scan.

The template is also reusable by benchmarks (hotPathBenchmark.cpp can instantiate it with lightweight fake types) without pulling in JVM headers.

Fixes [PROF-13630](https://datadoghq.atlassian.net/browse/PROF-13630).

**Additional Notes**:

The signal-safety guarantee depends on two properties:
1. `static volatile int` reads/writes do not require TLS initialization — there is no DTLS access on any supported target (linux-x64, linux-arm64, macos-arm64).
2. `CodeCacheArray::count()` and `operator[]` use `__atomic_load_n` compiler builtins that expand to a single load instruction — these are signal-safe on glibc, musl, and macOS.

A stale `last_hit` index (e.g., after a concurrent `updateSymbols` adds more libraries) simply falls through to the linear scan. Since `CodeCacheArray` never removes entries, `last_hit < count()` is the only safety check needed.

**How to test the change?**:

- `./gradlew :ddprof-lib:buildDebug` — must compile cleanly
- `./gradlew :ddprof-lib:testDebug` (Linux/musl CI) — new `LibrariesTest.*` cases exercise known/null/invalid addresses and cache hit/miss paths
- Signal-safety under uninitialized TLS cannot be automated in GTest; verified by code inspection (no `thread_local` in signal-handler paths).

**For Datadog employees**:

- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-13630](https://datadoghq.atlassian.net/browse/PROF-13630)

[PROF-13630]: https://datadoghq.atlassian.net/browse/PROF-13630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ