### PR TITLE
Fix JVM crash when Thread::current() returns nullptr (PROF-13072)

### DIFF
--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -20,6 +20,7 @@
 #include "guards.h"
 #include "ctimer.h"
 #include "debugSupport.h"
+#include "jvmThread.h"
 #include "libraries.h"
 #include "profiler.h"
 #include "threadState.inline.h"
@@ -156,6 +157,17 @@ void CTimer::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
   int tid = 0;
   ProfiledThread *current = ProfiledThread::currentSignalSafe();
   assert(current == nullptr || !current->isDeepCrashHandler());
+  // If the JVM has initialized its thread TLS key but this thread has not yet
+  // called pd_set_thread() (race window between Profiler::registerThread() and
+  // thread_native_entry), Thread::current() inside ASGCT returns nullptr and
+  // crashes in JFR allocation paths.  Skip the sample instead.
+  // Side-effect: threads that never call pd_set_thread() (non-JVM native threads
+  // that were created before the JVM initialized) are also skipped, which is
+  // acceptable given the crash severity.
+  if (current != nullptr && JVMThread::isInitialized() && JVMThread::current() == nullptr) {
+    errno = saved_errno;
+    return;
+  }
   if (current != NULL) {
     current->noteCPUSample(Profiler::instance()->recordingEpoch());
     tid = current->tid();

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -157,14 +157,13 @@ void CTimer::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
   int tid = 0;
   ProfiledThread *current = ProfiledThread::currentSignalSafe();
   assert(current == nullptr || !current->isDeepCrashHandler());
-  // If the JVM has initialized its thread TLS key but this thread has not yet
-  // called pd_set_thread() (race window between Profiler::registerThread() and
-  // thread_native_entry), Thread::current() inside ASGCT returns nullptr and
-  // crashes in JFR allocation paths.  Skip the sample instead.
-  // Side-effect: threads that never call pd_set_thread() (non-JVM native threads
-  // that were created before the JVM initialized) are also skipped, which is
-  // acceptable given the crash severity.
-  if (current != nullptr && JVMThread::isInitialized() && JVMThread::current() == nullptr) {
+  // Guard against the race window between Profiler::registerThread() and
+  // thread_native_entry setting JVM TLS (PROF-13072): skip at most one signal
+  // per thread. Pure native threads (where JVMThread::current() is always null)
+  // are allowed through once the one-shot window expires.
+  if (current != nullptr && JVMThread::isInitialized() && JVMThread::current() == nullptr
+      && current->inInitWindow()) {
+    current->tickInitWindow();
     errno = saved_errno;
     return;
   }

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -82,12 +82,21 @@ static void init_thread_tls() {
 __attribute__((visibility("hidden")))
 static void* start_routine_wrapper_spec(void* args) {
     RoutineInfo* thr = (RoutineInfo*)args;
-    func_start_routine routine = thr->routine();
-    void* params = thr->args();
-    delete_routine_info(thr);
-    init_thread_tls();
-    int tid = ProfiledThread::currentTid();
-    Profiler::registerThread(tid);
+    func_start_routine routine;
+    void* params;
+    int tid;
+    {
+        // Keep signals blocked across delete_routine_info, init_thread_tls, and
+        // registerThread for the same reasons as start_routine_wrapper: ASAN
+        // lock-ordering and the JVM TLS race window (PROF-13072).
+        SignalBlocker blocker;
+        routine = thr->routine();
+        params = thr->args();
+        delete_routine_info(thr);
+        init_thread_tls();
+        tid = ProfiledThread::currentTid();
+        Profiler::registerThread(tid);
+    }
     void* result = routine(params);
     Profiler::unregisterThread(tid);
     ProfiledThread::release();
@@ -126,6 +135,7 @@ static void* start_routine_wrapper(void* args) {
     RoutineInfo* thr = (RoutineInfo*)args;
     func_start_routine routine;
     void* params;
+    int tid;
     {
         // Block profiling signals while accessing and freeing RoutineInfo
         // and during TLS initialization. Under ASAN, new/delete/
@@ -133,14 +143,19 @@ static void* start_routine_wrapper(void* args) {
         // allocator lock. A profiling signal during any of these calls
         // runs ASAN-instrumented code that tries to acquire the same
         // lock, causing deadlock.
+        // registerThread is also kept inside the blocker so that the CPU
+        // timer is armed while SIGPROF/SIGVTALRM are masked.  Any pending
+        // signal fires only after signals are re-enabled (when the blocker
+        // scope exits), at which point JVMThread::current() is still null
+        // and the guard in CTimer::signalHandler discards the sample safely.
         SignalBlocker blocker;
         routine = thr->routine();
         params = thr->args();
         delete thr;
         ProfiledThread::initCurrentThread();
+        tid = ProfiledThread::currentTid();
+        Profiler::registerThread(tid);
     }
-    int tid = ProfiledThread::currentTid();
-    Profiler::registerThread(tid);
     void* result = nullptr;
     // Handle pthread_exit() bypass - the thread calls pthread_exit()
     // instead of normal termination

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -72,6 +72,17 @@ static void init_thread_tls() {
     ProfiledThread::initCurrentThread();
 }
 
+// Arm the CPU timer with profiling signals blocked and open the init window
+// (PROF-13072). Kept noinline for the same stack-protector reason as
+// delete_routine_info: SignalBlocker's sigset_t must not appear in
+// start_routine_wrapper_spec's own stack frame on musl/aarch64.
+__attribute__((noinline))
+static void start_window_and_register(int tid) {
+    SignalBlocker blocker;
+    ProfiledThread::currentSignalSafe()->startInitWindow();
+    Profiler::registerThread(tid);
+}
+
 // Wrapper around the real start routine.
 // The wrapper:
 // 1. Register the newly created thread to profiler
@@ -82,22 +93,12 @@ static void init_thread_tls() {
 __attribute__((visibility("hidden")))
 static void* start_routine_wrapper_spec(void* args) {
     RoutineInfo* thr = (RoutineInfo*)args;
-    func_start_routine routine;
-    void* params;
-    int tid;
-    {
-        // Keep signals blocked across delete_routine_info, init_thread_tls, and
-        // registerThread for the same reasons as start_routine_wrapper: ASAN
-        // lock-ordering and the JVM TLS race window (PROF-13072).
-        SignalBlocker blocker;
-        routine = thr->routine();
-        params = thr->args();
-        delete_routine_info(thr);
-        init_thread_tls();
-        tid = ProfiledThread::currentTid();
-        ProfiledThread::currentSignalSafe()->startInitWindow();
-        Profiler::registerThread(tid);
-    }
+    func_start_routine routine = thr->routine();
+    void* params = thr->args();
+    delete_routine_info(thr);
+    init_thread_tls();
+    int tid = ProfiledThread::currentTid();
+    start_window_and_register(tid);
     void* result = routine(params);
     Profiler::unregisterThread(tid);
     ProfiledThread::release();

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -77,10 +77,12 @@ static void init_thread_tls() {
 // delete_routine_info: SignalBlocker's sigset_t must not appear in
 // start_routine_wrapper_spec's own stack frame on musl/aarch64.
 __attribute__((noinline))
-static void start_window_and_register(int tid) {
+static void start_window_and_register() {
     SignalBlocker blocker;
-    ProfiledThread::currentSignalSafe()->startInitWindow();
-    Profiler::registerThread(tid);
+    if (ProfiledThread *pt = ProfiledThread::currentSignalSafe()) {
+        pt->startInitWindow();
+    }
+    Profiler::registerThread(ProfiledThread::currentTid());
 }
 
 // Wrapper around the real start routine.
@@ -97,10 +99,9 @@ static void* start_routine_wrapper_spec(void* args) {
     void* params = thr->args();
     delete_routine_info(thr);
     init_thread_tls();
-    int tid = ProfiledThread::currentTid();
-    start_window_and_register(tid);
+    start_window_and_register();
     void* result = routine(params);
-    Profiler::unregisterThread(tid);
+    Profiler::unregisterThread(ProfiledThread::currentTid());
     ProfiledThread::release();
     return result;
 }

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -95,6 +95,7 @@ static void* start_routine_wrapper_spec(void* args) {
         delete_routine_info(thr);
         init_thread_tls();
         tid = ProfiledThread::currentTid();
+        ProfiledThread::currentSignalSafe()->startInitWindow();
         Profiler::registerThread(tid);
     }
     void* result = routine(params);
@@ -154,6 +155,7 @@ static void* start_routine_wrapper(void* args) {
         delete thr;
         ProfiledThread::initCurrentThread();
         tid = ProfiledThread::currentTid();
+        ProfiledThread::currentSignalSafe()->startInitWindow();
         Profiler::registerThread(tid);
     }
     void* result = nullptr;

--- a/ddprof-lib/src/main/cpp/thread.cpp
+++ b/ddprof-lib/src/main/cpp/thread.cpp
@@ -99,6 +99,7 @@ void ProfiledThread::releaseFromBuffer() {
     _call_trace_id = 0;
     _recording_epoch = 0;
     _filter_slot_id = -1;
+    _init_window = 0;
     _unwind_failures.clear();
 
     // Null the TLS pointer so external profilers that dereference the pointer

--- a/ddprof-lib/src/main/cpp/thread.h
+++ b/ddprof-lib/src/main/cpp/thread.h
@@ -65,6 +65,7 @@ private:
   u32 _recording_epoch;
   u32 _misc_flags;
   int _filter_slot_id; // Slot ID for thread filtering
+  uint8_t _init_window; // Countdown for JVM thread init race window (PROF-13072)
   UnwindFailures _unwind_failures;
   bool _otel_ctx_initialized;
   bool _crash_protection_active;
@@ -77,7 +78,8 @@ private:
 
   ProfiledThread(int buffer_pos, int tid)
       : ThreadLocalData(), _pc(0), _sp(0), _span_id(0), _crash_depth(0), _buffer_pos(buffer_pos), _tid(tid), _cpu_epoch(0),
-        _wall_epoch(0), _call_trace_id(0), _recording_epoch(0), _misc_flags(0), _filter_slot_id(-1), _otel_ctx_initialized(false), _crash_protection_active(false),
+        _wall_epoch(0), _call_trace_id(0), _recording_epoch(0), _misc_flags(0), _filter_slot_id(-1), _init_window(0),
+        _otel_ctx_initialized(false), _crash_protection_active(false),
         _otel_ctx_record{}, _otel_tag_encodings{}, _otel_local_root_span_id(0) {};
 
   virtual ~ProfiledThread() { }
@@ -176,7 +178,16 @@ public:
 
   int filterSlotId() { return _filter_slot_id; }
   void setFilterSlotId(int slotId) { _filter_slot_id = slotId; }
-  
+
+  // JVM thread init race window (PROF-13072): skip at most one signal that fires
+  // between Profiler::registerThread() and the JVM's pd_set_thread() call.
+  // Pure native threads (e.g. NativeThreadCreator) also see nullptr from
+  // JVMThread::current(), so the window auto-expires after one skip, allowing
+  // their subsequent samples through.
+  inline bool inInitWindow() const { return _init_window > 0; }
+  inline void startInitWindow() { _init_window = 1; }
+  inline void tickInitWindow() { if (_init_window > 0) --_init_window; }
+
   // Signal handler reentrancy protection
   bool tryEnterCriticalSection() {
     // Uses GCC atomic builtin (no malloc, async-signal-safe)

--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -11,6 +11,7 @@
 #include "context.h"
 #include "context_api.h"
 #include "debugSupport.h"
+#include "jvmThread.h"
 #include "libraries.h"
 #include "log.h"
 #include "profiler.h"
@@ -65,6 +66,11 @@ void WallClockASGCT::signalHandler(int signo, siginfo_t *siginfo, void *ucontext
     return;  // Another critical section is active, defer profiling
   }
   ProfiledThread *current = ProfiledThread::currentSignalSafe();
+  // Guard against the race window between Profiler::registerThread() and
+  // thread_native_entry setting JVM TLS (see PROF-13072 / CTimer::signalHandler).
+  if (current != nullptr && JVMThread::isInitialized() && JVMThread::current() == nullptr) {
+    return;
+  }
   int tid = current != NULL ? current->tid() : OS::threadId();
   Shims::instance().setSighandlerTid(tid);
   u64 call_trace_id = 0;

--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -67,8 +67,12 @@ void WallClockASGCT::signalHandler(int signo, siginfo_t *siginfo, void *ucontext
   }
   ProfiledThread *current = ProfiledThread::currentSignalSafe();
   // Guard against the race window between Profiler::registerThread() and
-  // thread_native_entry setting JVM TLS (see PROF-13072 / CTimer::signalHandler).
-  if (current != nullptr && JVMThread::isInitialized() && JVMThread::current() == nullptr) {
+  // thread_native_entry setting JVM TLS (PROF-13072): skip at most one signal
+  // per thread. Pure native threads (where JVMThread::current() is always null)
+  // are allowed through once the one-shot window expires.
+  if (current != nullptr && JVMThread::isInitialized() && JVMThread::current() == nullptr
+      && current->inInitWindow()) {
+    current->tickInitWindow();
     return;
   }
   int tid = current != NULL ? current->tid() : OS::threadId();


### PR DESCRIPTION
**What does this PR do?**:
Fixes a JVM crash where `Thread::current()` returns `nullptr` inside ASGCT/JFR allocation paths when a profiling signal fires during thread initialization.

**Motivation**:
There is a race window in `start_routine_wrapper` between `Profiler::registerThread()` (which arms the per-thread CPU timer, enabling SIGPROF delivery) and `routine(params)` (which calls `thread_native_entry` → `pd_set_thread()`, setting `Thread::current()` in JVM TLS). If SIGPROF or SIGVTALRM fires in this window, ASGCT can be invoked on a thread where `Thread::current()` (ELF TLS) is still `nullptr`, crashing in JFR allocation paths (`resource_allocate_bytes` called from JfrStackTrace, JfrArtifactSet, etc.). This only manifests in virtualized environments where OS scheduling makes the race window much more likely to be hit.

**Additional Notes**:
Two complementary changes:

1. **Narrow the race window** (`start_routine_wrapper`, `start_routine_wrapper_spec`): move `Profiler::registerThread()` inside the existing `SignalBlocker` scope. The timer is then armed while SIGPROF/SIGVTALRM are masked; any pending signal fires only after signals are re-enabled (but before `routine(params)`) and is discarded by the guard below.

2. **Signal handler guard with one-shot init window** (`CTimer::signalHandler`, `WallClockASGCT::signalHandler`): when `JVMThread::isInitialized() && JVMThread::current() == nullptr`, skip the sample — but only if the thread's `_init_window` countdown is still active (starts at 1, decremented on first skip). `JVMThread::current()` reads the JVM's own pthread TLS key (found during startup) — the same value `pd_set_thread()` writes.

   The one-shot countdown distinguishes the two cases where `JVMThread::current()` is null:
   - **JVM threads in the race window**: the first signal after the `SignalBlocker` exits is skipped. POSIX guarantees at most one pending signal of each type, so by the time the window expires, `pd_set_thread()` has been called.
   - **Pure native threads** (e.g. `NativeThreadCreator`): `JVMThread::current()` is always null. The countdown expires after one skip, and all subsequent signals are sampled normally — no permanent loss of native thread samples.

**How to test the change?**:
The crash reproduces only in virtualized environments. The benchmark at https://github.com/DataDog/java-profiler/tree/zgu/ctx_benchmark was used to trigger it originally. Unit-level reproduction is not feasible (race window requires specific scheduling that doesn't occur on bare metal reliably).

`DynamicNativeThread` and `NativeThreadTest` on J9/glibc/aarch64 verify that the guard does not permanently suppress native (non-JVM) thread samples.

**For Datadog employees**:
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-13072](https://datadoghq.atlassian.net/browse/PROF-13072)

[PROF-13072]: https://datadoghq.atlassian.net/browse/PROF-13072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ