### PR TITLE
Fix J9 ASGCT version guard to require OpenJ9 0.51

### DIFF
--- a/ddprof-lib/src/main/cpp/j9/j9Support.h
+++ b/ddprof-lib/src/main/cpp/j9/j9Support.h
@@ -85,12 +85,16 @@ private:
 
 public:
   static bool can_use_ASGCT() {
-    // as of 21.0.6 the use of ASGCT will lead to almost immediate crash
-    //   or livelock on J9
-    return (VM::java_version() == 8 && VM::java_update_version() >= 361) ||
-           (VM::java_version() == 11 && VM::java_update_version() >= 18) ||
-           (VM::java_version() == 17 && VM::java_update_version() >= 6) ||
-           (VM::java_version() >= 18 && VM::java_version() < 21);
+    // J9's ASGCT is not async-signal-safe prior to OpenJ9 0.51. Calling ASGCT
+    // from a signal handler that interrupted a thread inside jitMethodMonitorEntry
+    // causes a livelock: jitWalkStackFrames calls getSendSlotsFromSignature which
+    // acquires a non-reentrant JIT lock already held by the interrupted thread.
+    // Fixed upstream in eclipse-openj9/openj9#20577 (0.51, April 2025 refresh):
+    //   JDK 8u452, JDK 11.0.27, JDK 17.0.15, JDK 21.0.7
+    return (VM::java_version() == 8 && VM::java_update_version() >= 452) ||
+           (VM::java_version() == 11 && VM::java_update_version() >= 27) ||
+           (VM::java_version() == 17 && VM::java_update_version() >= 15) ||
+           (VM::java_version() == 21 && VM::java_update_version() >= 7);
   }
 
   static bool is_jvmti_jmethodid_safe() {

--- a/ddprof-lib/src/main/cpp/j9/j9Support.h
+++ b/ddprof-lib/src/main/cpp/j9/j9Support.h
@@ -90,8 +90,9 @@ public:
     // causes a livelock: jitWalkStackFrames calls getSendSlotsFromSignature which
     // acquires a non-reentrant JIT lock already held by the interrupted thread.
     // Fixed upstream in eclipse-openj9/openj9#20577 (0.51, April 2025 refresh):
-    //   JDK 8u452, JDK 11.0.27, JDK 17.0.15, JDK 21.0.7
-    return (VM::java_version() == 8 && VM::java_update_version() >= 452) ||
+    //   JDK 8u451 (IBM SDK SR8 FP45) / 8u452 (IBM Semeru), JDK 11.0.27,
+    //   JDK 17.0.15, JDK 21.0.7
+    return (VM::java_version() == 8 && VM::java_update_version() >= 451) ||
            (VM::java_version() == 11 && VM::java_update_version() >= 27) ||
            (VM::java_version() == 17 && VM::java_update_version() >= 15) ||
            (VM::java_version() == 21 && VM::java_update_version() >= 7);

--- a/ddprof-lib/src/main/cpp/vmEntry.cpp
+++ b/ddprof-lib/src/main/cpp/vmEntry.cpp
@@ -142,17 +142,19 @@ JavaFullVersion JavaVersionAccess::get_java_version(char* prop_value) {
     version.major = 8;
     version.update = atoi(prop_value + 3);
   } else if (strncmp(prop_value, "JRE 1.8.0", 9) == 0) {
-    // IBM JDK 8 does not report the 'real' version in any property accessible
-    // from JVMTI The only piece of info we can use has the following format
-    // `JRE 1.8.0 <some text> 20230313_47323 <some more text>`
-    // Considering that JDK 8.0.361 is the only release in 2023 we can use
-    // that part of the version string to pretend anything after year 2023
-    // inclusive is 8.0.361. Not perfect, but this is the only thing we have.
+    // Old IBM SDK JDK 8 embeds only a build date (YYYYMMDD) in its version
+    // string, not the update number. Map known date ranges to update numbers:
+    //   >= 20250328: IBM SDK SR8 FP45 (JDK 8u451, J9 VM build date for OpenJ9
+    //                0.51 which fixes the ASGCT livelock; eclipse-openj9#20577)
+    //   >= 20230313: IBM SDK SR6 FP11 (JDK 8u361, first 2023 quarterly release)
+    //   otherwise:   IBM SDK SR6 FP10 or earlier (JDK 8u351)
     version.major = 8;
     char *idx = strstr(prop_value, " 202");
     if (idx != NULL) {
-      int year = atol(idx + 1);
-      if (year >= 2023) {
+      long date = atol(idx + 1);
+      if (date >= 20250328L) {
+        version.update = 451;
+      } else if (date >= 20230313L) {
         version.update = 361;
       } else {
         version.update = 351;

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/JavaProfilerTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/JavaProfilerTest.java
@@ -48,12 +48,15 @@ public class JavaProfilerTest extends AbstractProcessProfilerTest {
         Path jfr = Files.createTempFile("j9", ".jfr");
         jfr.toFile().deleteOnExit();
 
+        // ASGCT re-enabled for versions containing the OpenJ9 0.51 fix (eclipse-openj9/openj9#20577)
         String sampler = "jvmti";
-        if (Platform.isJavaVersion(8) && Platform.isJavaVersionAtLeast(8, 0, 432)) {
+        if (Platform.isJavaVersion(8) && Platform.isJavaVersionAtLeast(8, 0, 452)) {
             sampler = "asgct";
-        } else if (Platform.isJavaVersion(11) && Platform.isJavaVersionAtLeast(11, 0, 25)) {
+        } else if (Platform.isJavaVersion(11) && Platform.isJavaVersionAtLeast(11, 0, 27)) {
             sampler = "asgct";
-        } else if (Platform.isJavaVersion(17) && Platform.isJavaVersionAtLeast(17, 0, 13)) {
+        } else if (Platform.isJavaVersion(17) && Platform.isJavaVersionAtLeast(17, 0, 15)) {
+            sampler = "asgct";
+        } else if (Platform.isJavaVersion(21) && Platform.isJavaVersionAtLeast(21, 0, 7)) {
             sampler = "asgct";
         }
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/JavaProfilerTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/JavaProfilerTest.java
@@ -50,7 +50,7 @@ public class JavaProfilerTest extends AbstractProcessProfilerTest {
 
         // ASGCT re-enabled for versions containing the OpenJ9 0.51 fix (eclipse-openj9/openj9#20577)
         String sampler = "jvmti";
-        if (Platform.isJavaVersion(8) && Platform.isJavaVersionAtLeast(8, 0, 452)) {
+        if (Platform.isJavaVersion(8) && Platform.isJavaVersionAtLeast(8, 0, 451)) {
             sampler = "asgct";
         } else if (Platform.isJavaVersion(11) && Platform.isJavaVersionAtLeast(11, 0, 27)) {
             sampler = "asgct";


### PR DESCRIPTION
**What does this PR do?**:
Updates `J9Support::can_use_ASGCT()` to allow ASGCT only on OpenJ9 versions that contain the upstream fix for the JIT monitor-enter livelock (eclipse-openj9/openj9#20577). Updates the corresponding test thresholds to match.

**Motivation**:
J9's ASGCT is not async-signal-safe prior to OpenJ9 0.51. Calling ASGCT from a signal handler that interrupted a thread inside `jitMethodMonitorEntry` causes a livelock: `jitWalkStackFrames` calls `getSendSlotsFromSignature` which attempts to acquire a non-reentrant JIT lock already held by the interrupted thread. The upstream fix landed in OpenJ9 0.51 (April 2025 refresh): JDK 8u452, JDK 11.0.27, JDK 17.0.15, JDK 21.0.7. The previous version thresholds in `can_use_ASGCT()` (8u361, 11.0.18, 17.0.6) predated the fix and left users on intermediate releases exposed. The test thresholds were also wrong (matched OpenJ9 0.49, not 0.51).

**Additional Notes**:
Upstream issue filed by @jbachorik and resolved: https://github.com/eclipse-openj9/openj9/issues/20577

**How to test the change?**:
`testJ9DefaultSanity` in `JavaProfilerTest` covers the sampler-selection logic. Run on an OpenJ9 JDK (both below and at/above the 0.51 thresholds) and verify `jvmti` is selected on older versions and `asgct` on 0.51+.

**For Datadog employees**:
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-10153](https://datadoghq.atlassian.net/browse/PROF-10153)

[PROF-10153]: https://datadoghq.atlassian.net/browse/PROF-10153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ