### PR TITLE
feat(sframe): complete SFrame V2 parser — replace stub with full implementation

### DIFF
--- a/ddprof-lib/src/main/cpp/sframe.cpp
+++ b/ddprof-lib/src/main/cpp/sframe.cpp
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "sframe.h"
+#include <climits>
+#include <cstdlib>
+#include <cstring>
+
+SFrameParser::SFrameParser(const char* name, const char* section_base,
+                           size_t section_size, u32 section_offset)
+    : _name(name),
+      _section_base(section_base),
+      _section_size(section_size),
+      _section_offset(section_offset),
+      _capacity(128),
+      _count(0),
+      _table(static_cast<FrameDesc*>(malloc(128 * sizeof(FrameDesc)))),
+      _linked_frame_size(-1) {}
+
+SFrameParser::~SFrameParser() {
+    free(_table);  // safe: free(nullptr) is a no-op; table() nulls _table on success
+}
+
+FrameDesc* SFrameParser::table() {
+    FrameDesc* t = _table;
+    _table = nullptr;
+    return t;
+}
+
+const FrameDesc& SFrameParser::detectedDefaultFrame() const {
+    if (_linked_frame_size == LINKED_FRAME_CLANG_SIZE &&
+        LINKED_FRAME_CLANG_SIZE != LINKED_FRAME_SIZE) {
+        return FrameDesc::default_clang_frame;
+    }
+    return FrameDesc::default_frame;
+}
+
+FrameDesc* SFrameParser::addRecord(u32 loc, u32 cfa, int fp_off, int pc_off) {
+    if (!_table) return nullptr;  // constructor malloc failed
+    if (_count >= _capacity) {
+        if (_capacity > (INT_MAX / 2)) return nullptr;  // overflow guard
+        FrameDesc* resized = static_cast<FrameDesc*>(
+            realloc(_table, _capacity * 2 * sizeof(FrameDesc)));
+        if (!resized) return nullptr;
+        _capacity *= 2;
+        _table = resized;
+    }
+    FrameDesc* fd = &_table[_count++];
+    fd->loc    = loc;
+    fd->cfa    = cfa;
+    fd->fp_off = fp_off;
+    fd->pc_off = pc_off;
+    return fd;
+}
+
+bool SFrameParser::parseFDE(const SFrameHeader* hdr, const SFrameFDE* fde,
+                             const char* fre_section, const char* fre_end) {
+    // Determine FRE start address size
+    int addr_size;
+    switch (SFRAME_FUNC_FRE_TYPE(fde->info)) {
+        case SFRAME_FRE_TYPE_ADDR1: addr_size = 1; break;
+        case SFRAME_FRE_TYPE_ADDR2: addr_size = 2; break;
+        case SFRAME_FRE_TYPE_ADDR4: addr_size = 4; break;
+        default: return false;
+    }
+
+    const char* fre_ptr = fre_section + fde->fre_off;
+
+    for (uint32_t j = 0; j < fde->fre_num; j++) {
+        // (a) Entry-level bounds check
+        if (fre_ptr >= fre_end) return false;
+
+        // (b) Read FRE start address offset (unsigned)
+        if (fre_ptr + addr_size > fre_end) return false;
+        uint32_t fre_start = 0;
+        if (addr_size == 1) {
+            fre_start = *reinterpret_cast<const uint8_t*>(fre_ptr);
+        } else if (addr_size == 2) {
+            uint16_t v; memcpy(&v, fre_ptr, 2); fre_start = v;
+        } else {
+            memcpy(&fre_start, fre_ptr, 4);
+        }
+        fre_ptr += addr_size;
+
+        // (c) Read FRE info byte
+        if (fre_ptr + 1 > fre_end) return false;
+        uint8_t fre_info = *reinterpret_cast<const uint8_t*>(fre_ptr);
+        fre_ptr += 1;
+
+        // (d) Determine offset encoding size
+        int off_size;
+        switch (SFRAME_FRE_OFFSET_SIZE(fre_info)) {
+            case SFRAME_FRE_OFFSET_1B: off_size = 1; break;
+            case SFRAME_FRE_OFFSET_2B: off_size = 2; break;
+            case SFRAME_FRE_OFFSET_4B: off_size = 4; break;
+            default: return false;
+        }
+
+        // Decide what to read from the stream (governed by FRE info byte alone)
+        bool fp_tracked = SFRAME_FRE_FP_TRACKED(fre_info);
+        bool ra_in_fre  = SFRAME_FRE_RA_TRACKED(fre_info);
+
+        // (e) Bounds check all remaining reads for this FRE
+        int n_offsets = 1 + (fp_tracked ? 1 : 0) + (ra_in_fre ? 1 : 0);
+        if (fre_ptr + n_offsets * off_size > fre_end) return false;
+
+        // (f) Read CFA offset (signed)
+        int32_t cfa_offset = 0;
+        if (off_size == 1) {
+            cfa_offset = *reinterpret_cast<const int8_t*>(fre_ptr);
+        } else if (off_size == 2) {
+            int16_t v; memcpy(&v, fre_ptr, 2); cfa_offset = v;
+        } else {
+            memcpy(&cfa_offset, fre_ptr, 4);
+        }
+        fre_ptr += off_size;
+
+        // (g) Read FP offset if tracked
+        int32_t fp_offset = 0;
+        if (fp_tracked) {
+            if (off_size == 1) {
+                fp_offset = *reinterpret_cast<const int8_t*>(fre_ptr);
+            } else if (off_size == 2) {
+                int16_t v; memcpy(&v, fre_ptr, 2); fp_offset = v;
+            } else {
+                memcpy(&fp_offset, fre_ptr, 4);
+            }
+            fre_ptr += off_size;
+        }
+
+        // (h) Read RA offset if present in FRE (always consume to keep fre_ptr aligned)
+        int32_t ra_offset = 0;
+        if (ra_in_fre) {
+            if (off_size == 1) {
+                ra_offset = *reinterpret_cast<const int8_t*>(fre_ptr);
+            } else if (off_size == 2) {
+                int16_t v; memcpy(&v, fre_ptr, 2); ra_offset = v;
+            } else {
+                memcpy(&ra_offset, fre_ptr, 4);
+            }
+            fre_ptr += off_size;
+        }
+
+        // (i) Translate to FrameDesc fields
+        u32 loc = _section_offset +
+                  static_cast<u32>(static_cast<int32_t>(fde->start_addr) +
+                                   static_cast<int32_t>(fre_start));
+
+        u32 cfa_reg = SFRAME_FRE_BASE_REG(fre_info) ? static_cast<u32>(DW_REG_FP)
+                                                     : static_cast<u32>(DW_REG_SP);
+        u32 cfa = (static_cast<u32>(cfa_offset) << 8) | cfa_reg;
+
+        // aarch64 GCC vs Clang detection: first FP-based entry with cfa_offset > 0
+        if (_linked_frame_size < 0 && cfa_reg == static_cast<u32>(DW_REG_FP) && cfa_offset > 0) {
+            _linked_frame_size = cfa_offset;
+        }
+
+        int fp_off = fp_tracked ? static_cast<int>(fp_offset) : DW_SAME_FP;
+
+        // Header fixed RA offset takes priority over per-FRE value
+        int pc_off;
+        if (hdr->cfa_fixed_ra_offset != 0) {
+            pc_off = static_cast<int>(hdr->cfa_fixed_ra_offset);
+        } else if (ra_in_fre) {
+            pc_off = static_cast<int>(ra_offset);
+        } else {
+            pc_off = DW_LINK_REGISTER;
+        }
+
+        // (j) Append record
+        if (!addRecord(loc, cfa, fp_off, pc_off)) return false;
+    }
+
+    return true;
+}
+
+bool SFrameParser::parse() {
+    // 1. Size check
+    if (_section_size < sizeof(SFrameHeader)) return false;
+
+    const SFrameHeader* hdr = reinterpret_cast<const SFrameHeader*>(_section_base);
+
+    // 2-4. Header field validation
+    if (hdr->magic   != SFRAME_MAGIC)     return false;
+    if (hdr->version != SFRAME_VERSION_2) return false;
+
+#if defined(__x86_64__)
+    if (hdr->abi_arch != SFRAME_ABI_AMD64_ENDIAN_LITTLE)   return false;
+#elif defined(__aarch64__)
+    if (hdr->abi_arch != SFRAME_ABI_AARCH64_ENDIAN_LITTLE) return false;
+#else
+    return false;
+#endif
+
+    // 5. Bounds check auxhdr_len before computing data_start
+    if (sizeof(SFrameHeader) + hdr->auxhdr_len > _section_size) return false;
+
+    const char* data_start  = _section_base + sizeof(SFrameHeader) + hdr->auxhdr_len;
+    const char* section_end = _section_base + _section_size;
+
+    // Bounds-check fdeoff, freoff, and fre_len before pointer arithmetic
+    size_t data_len = static_cast<size_t>(section_end - data_start);
+    if (hdr->fdeoff > data_len) return false;
+    if (hdr->freoff > data_len) return false;
+    if (hdr->fre_len > data_len - hdr->freoff) return false;
+
+    const SFrameFDE* fde_array   = reinterpret_cast<const SFrameFDE*>(data_start + hdr->fdeoff);
+    const char*      fre_section = data_start + hdr->freoff;
+    const char*      fre_end     = fre_section + hdr->fre_len;
+
+    // 6-7. Bounds checks for FDE array and FRE section
+    if (reinterpret_cast<const char*>(fde_array) +
+            (size_t)hdr->num_fdes * sizeof(SFrameFDE) > section_end) return false;
+    if (fre_end > section_end) return false;
+
+    // 8. Iterate FDEs
+    for (uint32_t i = 0; i < hdr->num_fdes; i++) {
+        const SFrameFDE* fde = &fde_array[i];
+        if (SFRAME_FUNC_FDE_TYPE(fde->info) != 0) continue;  // skip PCMASK
+        if (fde->fre_num == 0)                    continue;  // empty FDE
+        parseFDE(hdr, fde, fre_section, fre_end);            // ignore return; skip corrupt FDE
+    }
+
+    // 9. Sort
+    qsort(_table, _count, sizeof(FrameDesc), FrameDesc::comparator);
+
+    return _count > 0;
+}

--- a/ddprof-lib/src/main/cpp/sframe.cpp
+++ b/ddprof-lib/src/main/cpp/sframe.cpp
@@ -4,6 +4,8 @@
  */
 
 #include "sframe.h"
+#include "log.h"
+#include <climits>
 #include <cstdlib>
 #include <cstring>
 
@@ -16,7 +18,8 @@ SFrameParser::SFrameParser(const char* name, const char* section_base,
       _capacity(128),
       _count(0),
       _table(static_cast<FrameDesc*>(malloc(128 * sizeof(FrameDesc)))),
-      _linked_frame_size(-1) {}
+      _linked_frame_size(-1),
+      _oom(false) {}
 
 SFrameParser::~SFrameParser() {
     free(_table);  // safe: free(nullptr) is a no-op; table() nulls _table on success
@@ -37,10 +40,15 @@ const FrameDesc& SFrameParser::detectedDefaultFrame() const {
 }
 
 FrameDesc* SFrameParser::addRecord(u32 loc, u32 cfa, int fp_off, int pc_off) {
+    if (!_table) return nullptr;  // constructor malloc failed
     if (_count >= _capacity) {
+        if (_capacity > (INT_MAX / 2)) return nullptr;  // overflow guard
         FrameDesc* resized = static_cast<FrameDesc*>(
             realloc(_table, _capacity * 2 * sizeof(FrameDesc)));
-        if (!resized) return nullptr;
+        if (!resized) {
+            _oom = true;
+            return nullptr;
+        }
         _capacity *= 2;
         _table = resized;
     }
@@ -52,34 +60,197 @@ FrameDesc* SFrameParser::addRecord(u32 loc, u32 cfa, int fp_off, int pc_off) {
     return fd;
 }
 
-bool SFrameParser::parseFDE(const SFrameHeader* /*hdr*/, const SFrameFDE* /*fde*/,
-                             const char* /*fre_section*/, const char* /*fre_end*/) {
-    return true;  // stub — implemented in Task 4
+bool SFrameParser::parseFDE(const SFrameHeader* hdr, const SFrameFDE* fde,
+                             const char* fre_section, const char* fre_end) {
+    // Determine FRE start address size
+    int addr_size;
+    switch (SFRAME_FUNC_FRE_TYPE(fde->info)) {
+        case SFRAME_FRE_TYPE_ADDR1: addr_size = 1; break;
+        case SFRAME_FRE_TYPE_ADDR2: addr_size = 2; break;
+        case SFRAME_FRE_TYPE_ADDR4: addr_size = 4; break;
+        default: return false;
+    }
+
+    // Bounds-check fre_off before pointer arithmetic
+    size_t fre_section_len = static_cast<size_t>(fre_end - fre_section);
+    if (fde->fre_off >= fre_section_len) return false;
+
+    const char* fre_ptr = fre_section + fde->fre_off;
+
+    for (uint32_t j = 0; j < fde->fre_num; j++) {
+        // (a) Entry-level bounds check
+        if (fre_ptr >= fre_end) return false;
+
+        // (b) Read FRE start address offset (unsigned)
+        if (fre_ptr + addr_size > fre_end) return false;
+        uint32_t fre_start = 0;
+        if (addr_size == 1) {
+            fre_start = *reinterpret_cast<const uint8_t*>(fre_ptr);
+        } else if (addr_size == 2) {
+            uint16_t v; memcpy(&v, fre_ptr, 2); fre_start = v;
+        } else {
+            memcpy(&fre_start, fre_ptr, 4);
+        }
+        fre_ptr += addr_size;
+
+        // (c) Read FRE info byte
+        if (fre_ptr + 1 > fre_end) return false;
+        uint8_t fre_info = *reinterpret_cast<const uint8_t*>(fre_ptr);
+        fre_ptr += 1;
+
+        // (d) Determine offset encoding size
+        int off_size;
+        switch (SFRAME_FRE_OFFSET_SIZE(fre_info)) {
+            case SFRAME_FRE_OFFSET_1B: off_size = 1; break;
+            case SFRAME_FRE_OFFSET_2B: off_size = 2; break;
+            case SFRAME_FRE_OFFSET_4B: off_size = 4; break;
+            default: return false;
+        }
+
+        // Decide what to read from the stream (governed by FRE info byte alone)
+        bool fp_tracked = SFRAME_FRE_FP_TRACKED(fre_info);
+        bool ra_in_fre  = SFRAME_FRE_RA_TRACKED(fre_info);
+
+        // (e) Bounds check all remaining reads for this FRE
+        int n_offsets = 1 + (fp_tracked ? 1 : 0) + (ra_in_fre ? 1 : 0);
+        if (fre_ptr + n_offsets * off_size > fre_end) return false;
+
+        // (f) Read CFA offset (signed)
+        int32_t cfa_offset = 0;
+        if (off_size == 1) {
+            cfa_offset = *reinterpret_cast<const int8_t*>(fre_ptr);
+        } else if (off_size == 2) {
+            int16_t v; memcpy(&v, fre_ptr, 2); cfa_offset = v;
+        } else {
+            memcpy(&cfa_offset, fre_ptr, 4);
+        }
+        fre_ptr += off_size;
+
+        // Guard: CFA offset must fit in the 24-bit field packed into FrameDesc::cfa
+        if (cfa_offset < -8388608 || cfa_offset > 8388607) return false;
+
+        // (g) Read FP offset if tracked
+        int32_t fp_offset = 0;
+        if (fp_tracked) {
+            if (off_size == 1) {
+                fp_offset = *reinterpret_cast<const int8_t*>(fre_ptr);
+            } else if (off_size == 2) {
+                int16_t v; memcpy(&v, fre_ptr, 2); fp_offset = v;
+            } else {
+                memcpy(&fp_offset, fre_ptr, 4);
+            }
+            fre_ptr += off_size;
+        }
+
+        // (h) Read RA offset if present in FRE (always consume to keep fre_ptr aligned)
+        int32_t ra_offset = 0;
+        if (ra_in_fre) {
+            if (off_size == 1) {
+                ra_offset = *reinterpret_cast<const int8_t*>(fre_ptr);
+            } else if (off_size == 2) {
+                int16_t v; memcpy(&v, fre_ptr, 2); ra_offset = v;
+            } else {
+                memcpy(&ra_offset, fre_ptr, 4);
+            }
+            fre_ptr += off_size;
+        }
+
+        // (i) Translate to FrameDesc fields
+        // Use unsigned arithmetic to avoid implementation-defined signed cast for large offsets
+        u32 loc = _section_offset + static_cast<u32>(fde->start_addr) + fre_start;
+
+        u32 cfa_reg = SFRAME_FRE_BASE_REG(fre_info) ? static_cast<u32>(DW_REG_FP)
+                                                     : static_cast<u32>(DW_REG_SP);
+        u32 cfa = (static_cast<u32>(cfa_offset) << 8) | cfa_reg;
+
+        // aarch64 GCC vs Clang detection: first FP-based entry with cfa_offset > 0
+        if (_linked_frame_size < 0 && cfa_reg == static_cast<u32>(DW_REG_FP) && cfa_offset > 0) {
+            _linked_frame_size = cfa_offset;
+        }
+
+        // Determine fp_off: per-FRE value takes priority; fall back to header fixed offset
+        int fp_off;
+        if (fp_tracked) {
+            fp_off = static_cast<int>(fp_offset);
+        } else if (hdr->cfa_fixed_fp_offset != 0) {
+            fp_off = static_cast<int>(hdr->cfa_fixed_fp_offset);
+        } else {
+            fp_off = DW_SAME_FP;
+        }
+
+        // Header fixed RA offset takes priority over per-FRE value
+        int pc_off;
+        if (hdr->cfa_fixed_ra_offset != 0) {
+            pc_off = static_cast<int>(hdr->cfa_fixed_ra_offset);
+        } else if (ra_in_fre) {
+            pc_off = static_cast<int>(ra_offset);
+        } else {
+            pc_off = DW_LINK_REGISTER;
+        }
+
+        // (j) Append record
+        if (!addRecord(loc, cfa, fp_off, pc_off)) return false;
+    }
+
+    return true;
 }
 
 bool SFrameParser::parse() {
     // 1. Size check
-    if (_section_size < sizeof(SFrameHeader)) return false;
+    if (_section_size < sizeof(SFrameHeader)) {
+        Log::warn("SFrame section too small in %s", _name);
+        return false;
+    }
 
     const SFrameHeader* hdr = reinterpret_cast<const SFrameHeader*>(_section_base);
 
     // 2-4. Header field validation
-    if (hdr->magic   != SFRAME_MAGIC)     return false;
-    if (hdr->version != SFRAME_VERSION_2) return false;
+    if (hdr->magic != SFRAME_MAGIC) {
+        Log::warn("SFrame bad magic in %s", _name);
+        return false;
+    }
+    if (hdr->version != SFRAME_VERSION_2) {
+        Log::warn("SFrame unsupported version %d in %s", (int)hdr->version, _name);
+        return false;
+    }
 
 #if defined(__x86_64__)
-    if (hdr->abi_arch != SFRAME_ABI_AMD64_ENDIAN_LITTLE)   return false;
+    if (hdr->abi_arch != SFRAME_ABI_AMD64_ENDIAN_LITTLE) {
+        Log::warn("SFrame wrong ABI 0x%x in %s", (int)hdr->abi_arch, _name);
+        return false;
+    }
 #elif defined(__aarch64__)
-    if (hdr->abi_arch != SFRAME_ABI_AARCH64_ENDIAN_LITTLE) return false;
+    if (hdr->abi_arch != SFRAME_ABI_AARCH64_ENDIAN_LITTLE) {
+        Log::warn("SFrame wrong ABI 0x%x in %s", (int)hdr->abi_arch, _name);
+        return false;
+    }
 #else
     return false;
 #endif
 
     // 5. Bounds check auxhdr_len before computing data_start
-    if (sizeof(SFrameHeader) + hdr->auxhdr_len > _section_size) return false;
+    if (sizeof(SFrameHeader) + hdr->auxhdr_len > _section_size) {
+        Log::warn("SFrame auxhdr_len overflows section in %s", _name);
+        return false;
+    }
 
     const char* data_start  = _section_base + sizeof(SFrameHeader) + hdr->auxhdr_len;
     const char* section_end = _section_base + _section_size;
+
+    // Bounds-check fdeoff, freoff, and fre_len before pointer arithmetic
+    size_t data_len = static_cast<size_t>(section_end - data_start);
+    if (hdr->fdeoff > data_len) {
+        Log::warn("SFrame fdeoff out of bounds in %s", _name);
+        return false;
+    }
+    if (hdr->freoff > data_len) {
+        Log::warn("SFrame freoff out of bounds in %s", _name);
+        return false;
+    }
+    if (hdr->fre_len > data_len - hdr->freoff) {
+        Log::warn("SFrame fre_len overflows section in %s", _name);
+        return false;
+    }
 
     const SFrameFDE* fde_array   = reinterpret_cast<const SFrameFDE*>(data_start + hdr->fdeoff);
     const char*      fre_section = data_start + hdr->freoff;
@@ -87,19 +258,40 @@ bool SFrameParser::parse() {
 
     // 6-7. Bounds checks for FDE array and FRE section
     if (reinterpret_cast<const char*>(fde_array) +
-            (size_t)hdr->num_fdes * sizeof(SFrameFDE) > section_end) return false;
-    if (fre_end > section_end) return false;
+            (size_t)hdr->num_fdes * sizeof(SFrameFDE) > section_end) {
+        Log::warn("SFrame FDE array overflows section in %s", _name);
+        return false;
+    }
+    if (fre_end > section_end) {
+        Log::warn("SFrame FRE section overflows in %s", _name);
+        return false;
+    }
 
-    // 8. Iterate FDEs
+    // 8. FDE array / FRE section overlap check
+    if (hdr->num_fdes > 0 && hdr->fre_len > 0) {
+        const char* fde_start_ptr = reinterpret_cast<const char*>(fde_array);
+        const char* fde_end_ptr   = fde_start_ptr + (size_t)hdr->num_fdes * sizeof(SFrameFDE);
+        if (fde_end_ptr > fre_section && fde_start_ptr < fre_end) {
+            Log::warn("SFrame FDE array overlaps FRE section in %s", _name);
+            return false;
+        }
+    }
+
+    // 9. Iterate FDEs
     for (uint32_t i = 0; i < hdr->num_fdes; i++) {
         const SFrameFDE* fde = &fde_array[i];
         if (SFRAME_FUNC_FDE_TYPE(fde->info) != 0) continue;  // skip PCMASK
         if (fde->fre_num == 0)                    continue;  // empty FDE
-        parseFDE(hdr, fde, fre_section, fre_end);            // ignore return; skip corrupt FDE
+        if (!parseFDE(hdr, fde, fre_section, fre_end)) {
+            if (_oom) return false;  // OOM: partial table is not safe to use
+            // else: corrupt FDE, skip and continue
+        }
     }
 
-    // 9. Sort
-    qsort(_table, _count, sizeof(FrameDesc), FrameDesc::comparator);
+    // 10. Sort (skip if the section header guarantees sorted order)
+    if (_count > 0 && !(hdr->flags & SFRAME_F_FDE_SORTED)) {
+        qsort(_table, _count, sizeof(FrameDesc), FrameDesc::comparator);
+    }
 
     return _count > 0;
 }

--- a/ddprof-lib/src/main/cpp/sframe.cpp
+++ b/ddprof-lib/src/main/cpp/sframe.cpp
@@ -129,20 +129,7 @@ bool SFrameParser::parseFDE(const SFrameHeader* hdr, const SFrameFDE* fde,
         // Guard: CFA offset must fit in the 24-bit field packed into FrameDesc::cfa
         if (cfa_offset < -8388608 || cfa_offset > 8388607) return false;
 
-        // (g) Read FP offset if tracked
-        int32_t fp_offset = 0;
-        if (fp_tracked) {
-            if (off_size == 1) {
-                fp_offset = *reinterpret_cast<const int8_t*>(fre_ptr);
-            } else if (off_size == 2) {
-                int16_t v; memcpy(&v, fre_ptr, 2); fp_offset = v;
-            } else {
-                memcpy(&fp_offset, fre_ptr, 4);
-            }
-            fre_ptr += off_size;
-        }
-
-        // (h) Read RA offset if present in FRE (always consume to keep fre_ptr aligned)
+        // (g) Read RA offset if tracked
         int32_t ra_offset = 0;
         if (ra_in_fre) {
             if (off_size == 1) {
@@ -151,6 +138,19 @@ bool SFrameParser::parseFDE(const SFrameHeader* hdr, const SFrameFDE* fde,
                 int16_t v; memcpy(&v, fre_ptr, 2); ra_offset = v;
             } else {
                 memcpy(&ra_offset, fre_ptr, 4);
+            }
+            fre_ptr += off_size;
+        }
+
+        // (h) Read FP offset if tracked
+        int32_t fp_offset = 0;
+        if (fp_tracked) {
+            if (off_size == 1) {
+                fp_offset = *reinterpret_cast<const int8_t*>(fre_ptr);
+            } else if (off_size == 2) {
+                int16_t v; memcpy(&v, fre_ptr, 2); fp_offset = v;
+            } else {
+                memcpy(&fp_offset, fre_ptr, 4);
             }
             fre_ptr += off_size;
         }
@@ -282,9 +282,13 @@ bool SFrameParser::parse() {
         const SFrameFDE* fde = &fde_array[i];
         if (SFRAME_FUNC_FDE_TYPE(fde->info) != 0) continue;  // skip PCMASK
         if (fde->fre_num == 0)                    continue;  // empty FDE
+        int saved_count             = _count;
+        int saved_linked_frame_size = _linked_frame_size;
         if (!parseFDE(hdr, fde, fre_section, fre_end)) {
             if (_oom) return false;  // OOM: partial table is not safe to use
-            // else: corrupt FDE, skip and continue
+            // Corrupt FDE: roll back any partially-added records.
+            _count             = saved_count;
+            _linked_frame_size = saved_linked_frame_size;
         }
     }
 

--- a/ddprof-lib/src/main/cpp/sframe.cpp
+++ b/ddprof-lib/src/main/cpp/sframe.cpp
@@ -234,6 +234,14 @@ bool SFrameParser::parse() {
         return false;
     }
 
+    // SFrame V2 PCREL func-start encoding makes start_addr field-relative, which
+    // our section-relative loc arithmetic (parseFDE) does not implement. Bail so
+    // the caller falls back to DWARF rather than building a scrambled table.
+    if (hdr->flags & SFRAME_F_FDE_FUNC_START_PCREL) {
+        Log::warn("SFrame PCREL func-start encoding unsupported in %s; falling back to DWARF", _name);
+        return false;
+    }
+
     const char* data_start  = _section_base + sizeof(SFrameHeader) + hdr->auxhdr_len;
     const char* section_end = _section_base + _section_size;
 
@@ -286,13 +294,21 @@ bool SFrameParser::parse() {
         int saved_linked_frame_size = _linked_frame_size;
         if (!parseFDE(hdr, fde, fre_section, fre_end)) {
             if (_oom) return false;  // OOM: partial table is not safe to use
-            // Corrupt FDE: roll back any partially-added records.
+            // Intentional divergence from DwarfParser::addRecord, which drops only the
+            // offending record and keeps going. Here a single bad FRE fails the whole
+            // FDE: we conservatively discard all FREs added for this function rather
+            // than ship a partially-decoded function with a coverage gap. Cost: one
+            // out-of-range FRE forfeits unwinding for the entire function.
             _count             = saved_count;
             _linked_frame_size = saved_linked_frame_size;
         }
     }
 
-    // 10. Sort (skip if the section header guarantees sorted order)
+    // 10. Sort, unless the producer asserts sorted order via SFRAME_F_FDE_SORTED.
+    // findFrameDesc binary-searches by loc, so the flattened table must be
+    // globally sorted. We trust the flag here (qsort of a real, large table is
+    // non-trivial). A malformed file that sets SORTED without honoring FDE/FRE
+    // ordering and non-overlap yields silent lookup misses (not memory-unsafe).
     if (_count > 0 && !(hdr->flags & SFRAME_F_FDE_SORTED)) {
         qsort(_table, _count, sizeof(FrameDesc), FrameDesc::comparator);
     }

--- a/ddprof-lib/src/main/cpp/sframe.h
+++ b/ddprof-lib/src/main/cpp/sframe.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _SFRAME_H
+#define _SFRAME_H
+
+#include "dwarf.h"
+#include <stdint.h>
+
+#ifndef PT_GNU_SFRAME
+#define PT_GNU_SFRAME 0x6474e554
+#endif
+
+// SFrame V2 magic, version, flags
+const uint16_t SFRAME_MAGIC        = 0xDEE2;
+const uint8_t  SFRAME_VERSION_2    = 2;
+const uint8_t  SFRAME_F_FDE_SORTED = 0x01;
+
+// ABI/architecture identifiers
+const uint8_t SFRAME_ABI_AARCH64_ENDIAN_LITTLE = 2;
+const uint8_t SFRAME_ABI_AMD64_ENDIAN_LITTLE   = 3;
+
+// FDE info byte: bit 0 = FDE type (0=PCINC,1=PCMASK), bits 1-2 = FRE start address size
+#define SFRAME_FUNC_FDE_TYPE(info) ((info) & 0x1)
+#define SFRAME_FUNC_FRE_TYPE(info) (((info) >> 1) & 0x3)
+
+// FRE info byte: bit 0 = CFA base (0=SP,1=FP), bits 1-2 = offset size, bit 3 = RA tracked, bit 4 = FP tracked
+#define SFRAME_FRE_BASE_REG(info)    ((info) & 0x1)
+#define SFRAME_FRE_OFFSET_SIZE(info) (((info) >> 1) & 0x3)
+#define SFRAME_FRE_RA_TRACKED(info)  (((info) >> 3) & 0x1)
+#define SFRAME_FRE_FP_TRACKED(info)  (((info) >> 4) & 0x1)
+
+// FRE offset size codes
+const int SFRAME_FRE_OFFSET_1B = 0;
+const int SFRAME_FRE_OFFSET_2B = 1;
+const int SFRAME_FRE_OFFSET_4B = 2;
+
+// FRE start address size codes (from FDE info bits 1-2)
+const int SFRAME_FRE_TYPE_ADDR1 = 0;
+const int SFRAME_FRE_TYPE_ADDR2 = 1;
+const int SFRAME_FRE_TYPE_ADDR4 = 2;
+
+struct __attribute__((packed)) SFrameHeader {  // 28 bytes
+    uint16_t magic;
+    uint8_t  version;
+    uint8_t  flags;
+    uint8_t  abi_arch;
+    int8_t   cfa_fixed_fp_offset;
+    int8_t   cfa_fixed_ra_offset;  // -8 on x86_64; 0 on aarch64
+    uint8_t  auxhdr_len;
+    uint32_t num_fdes;
+    uint32_t num_fres;
+    uint32_t fre_len;
+    uint32_t fdeoff;
+    uint32_t freoff;
+};
+
+struct __attribute__((packed)) SFrameFDE {  // 20 bytes
+    int32_t  start_addr;   // signed, relative to .sframe section start (V2)
+    uint32_t func_size;
+    uint32_t fre_off;      // byte offset into FRE sub-section
+    uint32_t fre_num;      // number of FREs
+    uint8_t  info;         // FDE type (bit 0) | FRE addr size (bits 1-2)
+    uint8_t  rep_size;
+    uint16_t padding;
+};
+
+class SFrameParser {
+  private:
+    const char* _name;
+    const char* _section_base;
+    size_t      _section_size;
+    u32         _section_offset;
+
+    int        _capacity;
+    int        _count;
+    FrameDesc* _table;
+    int        _linked_frame_size;  // for aarch64 GCC vs Clang detection; -1 = undetected
+
+    bool       parseFDE(const SFrameHeader* hdr, const SFrameFDE* fde,
+                        const char* fre_section, const char* fre_end);
+    FrameDesc* addRecord(u32 loc, u32 cfa, int fp_off, int pc_off);
+
+  public:
+    SFrameParser(const char* name, const char* section_base,
+                 size_t section_size, u32 section_offset);
+    ~SFrameParser();
+
+    // Returns false when the section is invalid or unsupported (triggers DWARF fallback).
+    bool parse();
+
+    // Transfers table ownership to caller. Nulls _table so the destructor does not double-free.
+    // Call only after a successful parse(). Caller must free() the returned pointer.
+    FrameDesc* table();
+    int count() const { return _count; }
+
+    const FrameDesc& detectedDefaultFrame() const;
+};
+
+#endif  // _SFRAME_H

--- a/ddprof-lib/src/main/cpp/sframe.h
+++ b/ddprof-lib/src/main/cpp/sframe.h
@@ -42,7 +42,7 @@ const int SFRAME_FRE_TYPE_ADDR1 = 0;
 const int SFRAME_FRE_TYPE_ADDR2 = 1;
 const int SFRAME_FRE_TYPE_ADDR4 = 2;
 
-struct __attribute__((packed)) SFrameHeader {  // 28 bytes
+struct __attribute__((packed, may_alias)) SFrameHeader {  // 28 bytes
     uint16_t magic;
     uint8_t  version;
     uint8_t  flags;
@@ -57,7 +57,7 @@ struct __attribute__((packed)) SFrameHeader {  // 28 bytes
     uint32_t freoff;
 };
 
-struct __attribute__((packed)) SFrameFDE {  // 20 bytes
+struct __attribute__((packed, may_alias)) SFrameFDE {  // 20 bytes
     int32_t  start_addr;   // signed, relative to .sframe section start (V2)
     uint32_t func_size;
     uint32_t fre_off;      // byte offset into FRE sub-section
@@ -78,6 +78,7 @@ class SFrameParser {
     int        _count;
     FrameDesc* _table;
     int        _linked_frame_size;  // for aarch64 GCC vs Clang detection; -1 = undetected
+    bool       _oom;                // set by addRecord on realloc failure
 
     bool       parseFDE(const SFrameHeader* hdr, const SFrameFDE* fde,
                         const char* fre_section, const char* fre_end);

--- a/ddprof-lib/src/main/cpp/sframe.h
+++ b/ddprof-lib/src/main/cpp/sframe.h
@@ -17,6 +17,9 @@
 const uint16_t SFRAME_MAGIC        = 0xDEE2;
 const uint8_t  SFRAME_VERSION_2    = 2;
 const uint8_t  SFRAME_F_FDE_SORTED = 0x01;
+// SFrame V2 erratum: when set, FDE start_addr is relative to the start_addr
+// field location, not the section start. Unsupported here -> DWARF fallback.
+const uint8_t  SFRAME_F_FDE_FUNC_START_PCREL = 0x04;
 
 // ABI/architecture identifiers
 const uint8_t SFRAME_ABI_AARCH64_ENDIAN_LITTLE = 2;

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -24,6 +24,7 @@
 #include <sys/auxv.h>
 #include "symbols.h"
 #include "dwarf.h"
+#include "sframe.h"
 #include "fdtransferClient.h"
 #include "log.h"
 #include "os.h"
@@ -593,6 +594,22 @@ void ElfParser::parseDynamicSection() {
 void ElfParser::parseDwarfInfo() {
     if (!DWARF_SUPPORTED) return;
 
+    // Try SFrame first (simpler format, faster parsing, no opcode interpretation).
+    ElfProgramHeader* sframe_phdr = findProgramHeader(PT_GNU_SFRAME);
+    if (sframe_phdr != NULL && sframe_phdr->p_vaddr != 0) {
+        const char* section_base = at(sframe_phdr);
+        u32 section_offset = static_cast<u32>(section_base - _base);
+        SFrameParser sframe(_cc->name(), section_base,
+                            static_cast<size_t>(sframe_phdr->p_memsz), section_offset);
+        if (sframe.parse()) {
+            _cc->setDwarfTable(sframe.table(), sframe.count(),
+                               sframe.detectedDefaultFrame());
+            return;
+        }
+        // SFrame parse failed; fall through to DWARF
+    }
+
+    // Existing DWARF path (unchanged).
     ElfProgramHeader* eh_frame_hdr = findProgramHeader(PT_GNU_EH_FRAME);
     if (eh_frame_hdr != NULL) {
         if (eh_frame_hdr->p_vaddr != 0) {
@@ -602,7 +619,7 @@ void ElfParser::parseDwarfInfo() {
             DwarfParser dwarf(_cc->name(), _base, at(eh_frame_hdr));
             _cc->setDwarfTable(dwarf.table(), dwarf.count(), dwarf.detectedDefaultFrame());
         } else if (strcmp(_cc->name(), "[vdso]") == 0) {
-            FrameDesc* table = (FrameDesc*)malloc(sizeof(FrameDesc));
+            FrameDesc* table = static_cast<FrameDesc*>(malloc(sizeof(FrameDesc)));
             *table = FrameDesc::empty_frame;
             _cc->setDwarfTable(table, 1);
         }

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -708,6 +708,10 @@ void ElfParser::parseDwarfInfo() {
     if (sframe_phdr != NULL && sframe_phdr->p_vaddr != 0) {
         const char* section_base = at(sframe_phdr);
         uintptr_t section_offset_full = static_cast<uintptr_t>(section_base - _base);
+        if (section_offset_full > static_cast<uintptr_t>(UINT32_MAX)) {
+            Log::warn("SFrame section offset too large for u32 in %s; falling back to DWARF", _cc->name());
+            goto dwarf_fallback;
+        }
         u32 section_offset = static_cast<u32>(section_offset_full);
         SFrameParser sframe(_cc->name(), section_base,
                             static_cast<size_t>(sframe_phdr->p_filesz), section_offset);
@@ -719,6 +723,7 @@ void ElfParser::parseDwarfInfo() {
         // SFrame parse failed; fall through to DWARF
     }
 
+    dwarf_fallback:
     ElfProgramHeader* eh_frame_hdr = findProgramHeader(PT_GNU_EH_FRAME);
     if (eh_frame_hdr != NULL) {
         if (eh_frame_hdr->p_vaddr != 0) {

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -22,9 +22,9 @@
 #include <linux/limits.h>
 #include <pthread.h>
 #include <sys/auxv.h>
-#include "common.h"
 #include "symbols.h"
 #include "dwarf.h"
+#include "sframe.h"
 #include "fdtransferClient.h"
 #include "log.h"
 #include "os.h"
@@ -348,105 +348,29 @@ class ElfParser {
     ElfHeader* _header;
     const char* _sections;
     const char* _vaddr_diff;
-    const char* _image_end;  // one-past-the-end of the mapped ELF image; bounds file-relative reads
 
-    ElfParser(CodeCache* cc, const char* base, const void* addr, size_t image_size, const char* file_name, bool relocate_dyn) {
+    ElfParser(CodeCache* cc, const char* base, const void* addr, const char* file_name, bool relocate_dyn) {
         _cc = cc;
         _base = base;
         _file_name = file_name;
         _relocate_dyn = relocate_dyn;
         _header = (ElfHeader*)addr;
-        _image_end = (const char*)addr + image_size;
-        // e_shoff sits at a fixed offset inside the header; only compute the pointer
-        // when the image is at least header-sized AND e_shoff is within the image,
-        // so the addition cannot overflow and sectionAt()/inImage() can reject it
-        // cleanly without UB.
-        _sections = (image_size >= sizeof(ElfHeader) && _header->e_shoff < image_size)
-            ? (const char*)addr + _header->e_shoff
-            : NULL;
+        _sections = (const char*)addr + _header->e_shoff;
     }
 
     bool validHeader() {
-        // A valid ELF image is at least a full header; this also makes the
-        // e_ident / e_shstrndx reads below in-bounds for tiny inputs.
-        if (_image_end < (const char*)_header + sizeof(ElfHeader)) {
-            return false;
-        }
         unsigned char* ident = _header->e_ident;
         return ident[0] == 0x7f && ident[1] == 'E' && ident[2] == 'L' && ident[3] == 'F'
             && ident[4] == ELFCLASS_SUPPORTED && ident[5] == ELFDATA2LSB && ident[6] == EV_CURRENT
             && _header->e_shstrndx != SHN_UNDEF;
     }
 
-    // --- Bounds-checked accessors for the file/section path -----------------
-    // These guard parsing of section headers, symbol tables and string tables,
-    // all of which use file-offset-relative pointers that must lie inside the
-    // mapped image [_header, _image_end). The dynamic-section path uses
-    // virtual-address-relative pointers into live memory and is intentionally
-    // NOT routed through inImage().
-
-    // True when [ptr, ptr+len) lies entirely within the mapped image.
-    bool inImage(const void* ptr, size_t len) const {
-        const char* p = (const char*)ptr;
-        return p >= (const char*)_header
-            && p <= _image_end
-            && len <= (size_t)(_image_end - p);
+    ElfSection* section(int index) {
+        return (ElfSection*)(_sections + index * _header->e_shentsize);
     }
 
-    // Section header at `index`, or NULL when the index or entry is out of bounds.
-    ElfSection* sectionAt(int index) {
-        if (_sections == NULL || index < 0 || index >= _header->e_shnum
-                || _header->e_shentsize < sizeof(ElfSection)) {
-            return NULL;
-        }
-        ElfSection* s = (ElfSection*)(_sections + (size_t)index * _header->e_shentsize);
-        return inImage(s, sizeof(ElfSection)) ? s : NULL;
-    }
-
-    // Start of a section's first `want` content bytes, or NULL if not fully mapped.
-    const char* contentAt(ElfSection* s, size_t want) {
-        if (s == NULL) {
-            return NULL;
-        }
-        // Validate sh_offset in integer space before forming the pointer so that
-        // a large attacker-controlled offset cannot cause pointer-overflow UB
-        // (the project builds with -fsanitize=pointer-overflow -fno-sanitize-recover).
-        size_t img_size = (size_t)(_image_end - (const char*)_header);
-        if (s->sh_offset > img_size || want > img_size - s->sh_offset) {
-            return NULL;
-        }
-        return (const char*)_header + s->sh_offset;
-    }
-
-    // NUL-terminated string at `off` within a [strtab, strtab+size) string table,
-    // or NULL if the offset is out of range or the string is not terminated in it.
-    static const char* strAt(const char* strtab, size_t size, uint32_t off) {
-        if (strtab == NULL || off >= size) {
-            return NULL;
-        }
-        if (memchr(strtab + off, '\0', size - off) == NULL) {
-            return NULL;
-        }
-        return strtab + off;
-    }
-
-    // Program-header entry at `index`, or NULL when the index or entry is out of bounds.
-    ElfProgramHeader* phdrAt(int index) {
-        if (index < 0 || index >= _header->e_phnum
-                || _header->e_phentsize < sizeof(ElfProgramHeader)) {
-            return NULL;
-        }
-        // Validate entirely in integer space before forming any pointer.
-        // Both e_phoff and index*e_phentsize are attacker-controlled; either
-        // can be large enough to wrap a pointer under -fsanitize=pointer-overflow.
-        size_t img_size = (size_t)(_image_end - (const char*)_header);
-        size_t phoff = _header->e_phoff;
-        size_t stride = (size_t)index * _header->e_phentsize;
-        if (phoff > img_size || stride > img_size - phoff) {
-            return NULL;
-        }
-        ElfProgramHeader* ph = (ElfProgramHeader*)((const char*)_header + phoff + stride);
-        return inImage(ph, sizeof(ElfProgramHeader)) ? ph : NULL;
+    const char* at(ElfSection* section) {
+        return (const char*)_header + section->sh_offset;
     }
 
     const char* at(ElfProgramHeader* pheader) {
@@ -482,7 +406,7 @@ class ElfParser {
     bool loadSymbolsFromDebuginfodCache(const char* build_id, const int build_id_len);
     bool loadSymbolsUsingBuildId();
     bool loadSymbolsUsingDebugLink();
-    void loadSymbolTable(const char* symbols, size_t total_size, size_t ent_size, const char* strings, size_t strings_size);
+    void loadSymbolTable(const char* symbols, size_t total_size, size_t ent_size, const char* strings);
     void addRelocationSymbols(ElfSection* reltab, const char* plt);
     const char* getDebuginfodCache();
 
@@ -493,27 +417,12 @@ class ElfParser {
 
 
 ElfSection* ElfParser::findSection(uint32_t type, const char* name) {
-    // The section-header string table must be present and fully mapped before
-    // any section name can be resolved. Untrusted e_shoff/e_shentsize/e_shstrndx
-    // and sh_offset values are all validated here.
-    ElfSection* shstr = sectionAt(_header->e_shstrndx);
-    if (shstr == NULL) {
-        return NULL;
-    }
-    size_t strtab_size = shstr->sh_size;
-    const char* strtab = contentAt(shstr, strtab_size);
-    if (strtab == NULL) {
-        return NULL;
-    }
+    const char* strtab = at(section(_header->e_shstrndx));
 
     for (int i = 0; i < _header->e_shnum; i++) {
-        ElfSection* section = sectionAt(i);
-        if (section == NULL) {
-            continue;
-        }
+        ElfSection* section = this->section(i);
         if (section->sh_type == type && section->sh_name != 0) {
-            const char* sname = strAt(strtab, strtab_size, section->sh_name);
-            if (sname != NULL && strcmp(sname, name) == 0) {
+            if (strcmp(strtab + section->sh_name, name) == 0) {
                 return section;
             }
         }
@@ -523,12 +432,15 @@ ElfSection* ElfParser::findSection(uint32_t type, const char* name) {
 }
 
 ElfProgramHeader* ElfParser::findProgramHeader(uint32_t type) {
+    const char* pheaders = (const char*)_header + _header->e_phoff;
+
     for (int i = 0; i < _header->e_phnum; i++) {
-        ElfProgramHeader* pheader = phdrAt(i);
-        if (pheader != NULL && pheader->p_type == type) {
+        ElfProgramHeader* pheader = (ElfProgramHeader*)(pheaders + i * _header->e_phentsize);
+        if (pheader->p_type == type) {
             return pheader;
         }
     }
+
     return NULL;
 }
 
@@ -545,7 +457,7 @@ bool ElfParser::parseFile(CodeCache* cc, const char* base, const char* file_name
     if (addr == MAP_FAILED) {
         Log::warn("Could not parse symbols from %s: %s", file_name, strerror(errno));
     } else {
-        ElfParser elf(cc, base, addr, length, file_name, false);
+        ElfParser elf(cc, base, addr, file_name, false);
         if (elf.validHeader()) {
             elf.calcVirtualLoadAddress();
             elf.loadSymbols(use_debug);
@@ -556,7 +468,7 @@ bool ElfParser::parseFile(CodeCache* cc, const char* base, const char* file_name
 }
 
 void ElfParser::parseProgramHeaders(CodeCache* cc, const char* base, const char* end, bool relocate_dyn) {
-    ElfParser elf(cc, base, base, (size_t)(end - base), NULL, relocate_dyn);
+    ElfParser elf(cc, base, base, NULL, relocate_dyn);
     if (elf.validHeader() && base + elf._header->e_phoff < end) {
         cc->setTextBase(base);
         elf.calcVirtualLoadAddress();
@@ -571,9 +483,10 @@ void ElfParser::calcVirtualLoadAddress() {
         _vaddr_diff = NULL;
         return;
     }
+    const char* pheaders = (const char*)_header + _header->e_phoff;
     for (int i = 0; i < _header->e_phnum; i++) {
-        ElfProgramHeader* pheader = phdrAt(i);
-        if (pheader != NULL && pheader->p_type == PT_LOAD) {
+        ElfProgramHeader* pheader = (ElfProgramHeader*)(pheaders + i * _header->e_phentsize);
+        if (pheader->p_type == PT_LOAD) {
             _vaddr_diff = _base - pheader->p_vaddr;
             return;
         }
@@ -593,7 +506,6 @@ void ElfParser::parseDynamicSection() {
         size_t relent = 0;
         size_t relcount = 0;
         size_t syment = 0;
-        size_t strsz = 0;
         uint32_t nsyms = 0;
 
         const char* dyn_start = at(dynamic);
@@ -608,9 +520,6 @@ void ElfParser::parseDynamicSection() {
                     break;
                 case DT_SYMENT:
                     syment = dyn->d_un.d_val;
-                    break;
-                case DT_STRSZ:
-                    strsz = dyn->d_un.d_val;
                     break;
                 case DT_HASH:
                     nsyms = ((uint32_t*)dyn_ptr(dyn))[1];
@@ -649,19 +558,8 @@ void ElfParser::parseDynamicSection() {
             return;
         }
 
-        // DT_STRSZ is required by the ELF spec whenever DT_STRTAB is present.
-        // When it is absent (strsz == 0) all string lookups via strAt() would
-        // be rejected, silently dropping every symbol. Cap to 1 MB: real dynamic
-        // string tables are well under that, and live linker memory guarantees
-        // NUL termination, so memchr will always find a terminator before the cap.
-        if (strsz == 0) {
-            Log::warn("DT_STRSZ absent from dynamic section in %s; capping string-table scan to 1 MB",
-                      _file_name != NULL ? _file_name : "unknown");
-            strsz = 1u << 20;
-        }
-
         if (!_cc->hasDebugSymbols() && nsyms > 0) {
-            loadSymbolTable(symtab, syment * nsyms, syment, strtab, strsz);
+            loadSymbolTable(symtab, syment * nsyms, syment, strtab);
         }
 
         const char* base = this->base();
@@ -671,10 +569,7 @@ void ElfParser::parseDynamicSection() {
                 ElfRelocation* r = (ElfRelocation*)(jmprel + offs);
                 ElfSymbol* sym = (ElfSymbol*)(symtab + ELF_R_SYM(r->r_info) * syment);
                 if (sym->st_name != 0) {
-                    const char* sym_name = strAt(strtab, strsz, sym->st_name);
-                    if (sym_name != NULL) {
-                        _cc->addImport((void**)(base + r->r_offset), sym_name);
-                    }
+                    _cc->addImport((void**)(base + r->r_offset), strtab + sym->st_name);
                 }
             }
         }
@@ -688,10 +583,7 @@ void ElfParser::parseDynamicSection() {
                 if (ELF_R_TYPE(r->r_info) == R_GLOB_DAT || ELF_R_TYPE(r->r_info) == R_ABS64) {
                     ElfSymbol* sym = (ElfSymbol*)(symtab + ELF_R_SYM(r->r_info) * syment);
                     if (sym->st_name != 0) {
-                        const char* sym_name = strAt(strtab, strsz, sym->st_name);
-                        if (sym_name != NULL) {
-                            _cc->addImport((void**)(base + r->r_offset), sym_name);
-                        }
+                        _cc->addImport((void**)(base + r->r_offset), strtab + sym->st_name);
                     }
                 }
             }
@@ -702,27 +594,33 @@ void ElfParser::parseDynamicSection() {
 void ElfParser::parseDwarfInfo() {
     if (!DWARF_SUPPORTED) return;
 
+    // Try SFrame first (simpler format, faster parsing, no opcode interpretation).
+    ElfProgramHeader* sframe_phdr = findProgramHeader(PT_GNU_SFRAME);
+    if (sframe_phdr != NULL && sframe_phdr->p_vaddr != 0) {
+        const char* section_base = at(sframe_phdr);
+        uintptr_t section_offset_full = static_cast<uintptr_t>(section_base - _base);
+        u32 section_offset = static_cast<u32>(section_offset_full);
+        SFrameParser sframe(_cc->name(), section_base,
+                            static_cast<size_t>(sframe_phdr->p_filesz), section_offset);
+        if (sframe.parse()) {
+            _cc->setDwarfTable(sframe.table(), sframe.count(),
+                               sframe.detectedDefaultFrame());
+            return;
+        }
+        // SFrame parse failed; fall through to DWARF
+    }
+
+    // Existing DWARF path (unchanged).
     ElfProgramHeader* eh_frame_hdr = findProgramHeader(PT_GNU_EH_FRAME);
     if (eh_frame_hdr != NULL) {
         if (eh_frame_hdr->p_vaddr != 0) {
             // Parse per-PC frame descriptions and detect per-library default frame layout.
             // On aarch64 this distinguishes GCC (LINKED_FRAME_SIZE=0) from clang
             // (LINKED_FRAME_CLANG_SIZE=16) conventions for each shared library.
-            // Compute image_end from the highest end address of all LOAD segments so
-            // the DWARF parser can validate FDE pointers against mapped memory.
-            const char* image_end = _base;
-            for (int i = 0; i < _header->e_phnum; i++) {
-                ElfProgramHeader* ph = phdrAt(i);
-                if (ph != NULL && ph->p_type == PT_LOAD) {
-                    const char* seg_end = at(ph) + ph->p_memsz;
-                    if (seg_end > image_end) image_end = seg_end;
-                }
-            }
-            DwarfParser dwarf(_cc->name(), _base, at(eh_frame_hdr), eh_frame_hdr->p_memsz,
-                              DwarfParser::EhFrameHdrTag{}, image_end);
+            DwarfParser dwarf(_cc->name(), _base, at(eh_frame_hdr));
             _cc->setDwarfTable(dwarf.table(), dwarf.count(), dwarf.detectedDefaultFrame());
         } else if (strcmp(_cc->name(), "[vdso]") == 0) {
-            FrameDesc* table = (FrameDesc*)malloc(sizeof(FrameDesc));
+            FrameDesc* table = static_cast<FrameDesc*>(malloc(sizeof(FrameDesc)));
             *table = FrameDesc::empty_frame;
             _cc->setDwarfTable(table, 1);
         }
@@ -748,16 +646,10 @@ uint32_t ElfParser::getSymbolCount(uint32_t* gnu_hash) {
 void ElfParser::loadSymbols(bool use_debug) {
     ElfSection* symtab = findSection(SHT_SYMTAB, ".symtab");
     if (symtab != NULL) {
-        // Parse debug symbols from the original .so. The symbol table and its
-        // linked string table are file-offset-relative, so every range is
-        // validated against the mapped image before it is read.
-        ElfSection* strtab = sectionAt(symtab->sh_link);
-        const char* symbols = contentAt(symtab, symtab->sh_size);
-        const char* strings = strtab != NULL ? contentAt(strtab, strtab->sh_size) : NULL;
-        if (symbols != NULL && strings != NULL) {
-            loadSymbolTable(symbols, symtab->sh_size, symtab->sh_entsize, strings, strtab->sh_size);
-            _cc->setDebugSymbols(true);
-        }
+        // Parse debug symbols from the original .so
+        ElfSection* strtab = section(symtab->sh_link);
+        loadSymbolTable(at(symtab), symtab->sh_size, symtab->sh_entsize, at(strtab));
+        _cc->setDebugSymbols(true);
     } else if (use_debug) {
         // Try to load symbols from an external debuginfo library
         loadSymbolsUsingBuildId() || loadSymbolsUsingDebugLink();
@@ -844,23 +736,12 @@ bool ElfParser::loadSymbolsUsingBuildId() {
         return false;
     }
 
-    // The whole note section must be mapped before reading the note header.
-    const char* note_base = contentAt(section, section->sh_size);
-    if (note_base == NULL || section->sh_size < sizeof(ElfNote)) {
-        return false;
-    }
-    ElfNote* note = (ElfNote*)note_base;
+    ElfNote* note = (ElfNote*)at(section);
     if (note->n_namesz != 4 || note->n_descsz < 2 || note->n_descsz > 64) {
         return false;
     }
 
-    // The descriptor (build-id bytes) follows the header and a 4-byte aligned
-    // "GNU\0" name; ensure it lies inside the note section.
-    size_t desc_off = sizeof(ElfNote) + 4;
-    if (desc_off + note->n_descsz > section->sh_size) {
-        return false;
-    }
-    const char* build_id = note_base + desc_off;
+    const char* build_id = (const char*)note + sizeof(*note) + 4;
     int build_id_len = note->n_descsz;
 
     return loadSymbolsFromDebug(build_id, build_id_len)
@@ -874,13 +755,6 @@ bool ElfParser::loadSymbolsUsingDebugLink() {
         return false;
     }
 
-    // The debuglink is a NUL-terminated filename at the start of the section;
-    // validate it is mapped and terminated before it feeds strcmp()/snprintf().
-    const char* debuglink = contentAt(section, section->sh_size);
-    if (debuglink == NULL || memchr(debuglink, '\0', section->sh_size) == NULL) {
-        return false;
-    }
-
     const char* basename = strrchr(_file_name, '/');
     if (basename == NULL) {
         return false;
@@ -891,6 +765,7 @@ bool ElfParser::loadSymbolsUsingDebugLink() {
         return false;
     }
 
+    const char* debuglink = at(section);
     char path[PATH_MAX];
     bool result = false;
 
@@ -914,29 +789,13 @@ bool ElfParser::loadSymbolsUsingDebugLink() {
     return result;
 }
 
-void ElfParser::loadSymbolTable(const char* symbols, size_t total_size, size_t ent_size, const char* strings, size_t strings_size) {
-    // A stride smaller than one symbol entry would never advance past (or would
-    // re-read) an entry; reject it to avoid an infinite loop / over-read.
-    if (ent_size < sizeof(ElfSymbol)) {
-        return;
-    }
+void ElfParser::loadSymbolTable(const char* symbols, size_t total_size, size_t ent_size, const char* strings) {
     const char* base = this->base();
-    // Iterate by a size_t offset rather than incrementing the pointer: a huge
-    // attacker-controlled ent_size would otherwise overflow `symbols + ent_size`
-    // to a small pointer that still compares <= end, walking off the image. The
-    // `ent_size <= total_size - off` form keeps off <= total_size with no overflow.
-    for (size_t off = 0; ent_size <= total_size - off; off += ent_size) {
-        ElfSymbol* sym = (ElfSymbol*)(symbols + off);
+    for (const char* symbols_end = symbols + total_size; symbols < symbols_end; symbols += ent_size) {
+        ElfSymbol* sym = (ElfSymbol*)symbols;
         if (sym->st_name != 0 && sym->st_value != 0) {
-            // Resolve the name through the bounded string table; a bad st_name
-            // offset (or unterminated string) drops the symbol instead of reading
-            // out of bounds.
-            const char* sym_name = strAt(strings, strings_size, sym->st_name);
-            if (sym_name == NULL) {
-                continue;
-            }
             // Skip special AArch64 mapping symbols: $x and $d
-            if (sym->st_size != 0 || sym->st_info != 0 || sym_name[0] != '$') {
+            if (sym->st_size != 0 || sym->st_info != 0 || strings[sym->st_name] != '$') {
                 const char* addr;
                 if (base != NULL) {
                     // Check for overflow when adding sym->st_value to base
@@ -958,65 +817,36 @@ void ElfParser::loadSymbolTable(const char* symbols, size_t total_size, size_t e
                 } else {
                     addr = (const char*)sym->st_value;
                 }
-                _cc->add(addr, (int)sym->st_size, sym_name);
+                _cc->add(addr, (int)sym->st_size, strings + sym->st_name);
             }
         }
     }
 }
 
 void ElfParser::addRelocationSymbols(ElfSection* reltab, const char* plt) {
-    // Resolve and bounds-check the linked symbol and string tables. Any missing
-    // or out-of-image section aborts relocation naming rather than reading wild
-    // pointers built from attacker-controlled sh_link / r_info / sh_entsize.
-    ElfSection* symtab = sectionAt(reltab->sh_link);
-    ElfSection* strtab = symtab != NULL ? sectionAt(symtab->sh_link) : NULL;
-    if (symtab == NULL || strtab == NULL) {
-        return;
-    }
-    size_t sym_region = symtab->sh_size;
-    size_t strings_size = strtab->sh_size;
-    size_t sym_ent = symtab->sh_entsize;
-    size_t rel_ent = reltab->sh_entsize;
-    const char* symbols = contentAt(symtab, sym_region);
-    const char* strings = contentAt(strtab, strings_size);
-    size_t reltab_size = reltab->sh_size;
-    const char* relocations = contentAt(reltab, reltab_size);
-    if (symbols == NULL || strings == NULL || relocations == NULL
-            || rel_ent < sizeof(ElfRelocation)
-            || sym_ent < sizeof(ElfSymbol)
-            || sym_region < sizeof(ElfSymbol)) {
-        return;
-    }
+    ElfSection* symtab = section(reltab->sh_link);
+    const char* symbols = at(symtab);
 
-    // Largest symbol index whose full ElfSymbol still fits in the table. Written
-    // as a division so the index * sym_ent product can never overflow.
-    size_t max_sym_index = (sym_region - sizeof(ElfSymbol)) / sym_ent;
+    ElfSection* strtab = section(symtab->sh_link);
+    const char* strings = at(strtab);
 
-    // Offset-based iteration (see loadSymbolTable) so a huge rel_ent cannot
-    // overflow the relocation pointer past the section end.
-    for (size_t off = 0; rel_ent <= reltab_size - off; off += rel_ent, plt += PLT_ENTRY_SIZE) {
-        ElfRelocation* r = (ElfRelocation*)(relocations + off);
-        if (ELF_R_SYM(r->r_info) > max_sym_index) {
-            continue;
-        }
-        ElfSymbol* sym = (ElfSymbol*)(symbols + (size_t)ELF_R_SYM(r->r_info) * sym_ent);
+    const char* relocations = at(reltab);
+    const char* relocations_end = relocations + reltab->sh_size;
+    for (; relocations < relocations_end; relocations += reltab->sh_entsize) {
+        ElfRelocation* r = (ElfRelocation*)relocations;
+        ElfSymbol* sym = (ElfSymbol*)(symbols + ELF_R_SYM(r->r_info) * symtab->sh_entsize);
 
         char name[256];
         if (sym->st_name == 0) {
             strcpy(name, "@plt");
         } else {
-            const char* sym_name = strAt(strings, strings_size, sym->st_name);
-            if (sym_name == NULL) {
-                continue;  // plt advances via the for-increment
-            }
-            // sym_name is NUL-terminated within the string table, so sym_name[1]
-            // is safe to read (it is at worst the terminator).
-            char sep = sym_name[0] == '_' && sym_name[1] == 'Z' ? '.' : '@';
-            snprintf(name, sizeof(name), "%s%cplt", sym_name, sep);
+            const char* sym_name = strings + sym->st_name;
+            snprintf(name, sizeof(name), "%s%cplt", sym_name, sym_name[0] == '_' && sym_name[1] == 'Z' ? '.' : '@');
             name[sizeof(name) - 1] = 0;
         }
 
         _cc->add(plt, PLT_ENTRY_SIZE, name);
+        plt += PLT_ENTRY_SIZE;
     }
 }
 
@@ -1165,7 +995,6 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
         } else if (lib.image_base == NULL) {
             // Unlikely case when image base has not been found: not safe to access program headers.
             // Be careful: executable file is not always ELF, e.g. classes.jsa
-            TEST_LOG("parseLibraries: image_base==NULL for %s, skipping program headers", lib.file);
             ElfParser::parseFile(cc, lib.map_start, lib.file, true);
         } else {
             // Parse debug symbols first
@@ -1174,8 +1003,6 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
             UnloadProtection handle(cc);
             if (handle.isValid()) {
                 ElfParser::parseProgramHeaders(cc, lib.image_base, lib.map_end, OS::isMusl());
-            } else {
-                TEST_LOG("parseLibraries: UnloadProtection invalid for %s, skipping program headers", lib.file);
             }
         }
 
@@ -1331,11 +1158,8 @@ char* SymbolsLinux::extractBuildIdFromMemory(const void* elf_base, size_t elf_si
         return nullptr;
     }
 
-    // Verify program header table is within file bounds. Written as subtractions
-    // so a huge e_phoff cannot wrap the addition and slip past the check, which
-    // would leave `phdr` pointing outside the mapped image.
-    if (ehdr->e_phoff > elf_size ||
-        ehdr->e_phnum * sizeof(Elf64_Phdr) > elf_size - ehdr->e_phoff) {
+    // Verify program header table is within file bounds
+    if (ehdr->e_phoff + ehdr->e_phnum * sizeof(Elf64_Phdr) > elf_size) {
         return nullptr;
     }
 
@@ -1350,11 +1174,8 @@ char* SymbolsLinux::extractBuildIdFromMemory(const void* elf_base, size_t elf_si
     // Search for PT_NOTE segments
     for (int i = 0; i < ehdr->e_phnum; i++) {
         if (phdr[i].p_type == PT_NOTE && phdr[i].p_filesz > 0) {
-            // Ensure note segment is within file bounds. Subtraction form avoids
-            // a u64 overflow in p_offset + p_filesz that would otherwise yield a
-            // wild note_data pointer passed to findBuildIdInNotes().
-            if (phdr[i].p_offset > elf_size ||
-                phdr[i].p_filesz > elf_size - phdr[i].p_offset) {
+            // Ensure note segment is within file bounds
+            if (phdr[i].p_offset + phdr[i].p_filesz > elf_size) {
                 continue;
             }
 
@@ -1390,19 +1211,11 @@ const uint8_t* SymbolsLinux::findBuildIdInNotes(const void* note_data, size_t no
             break;
         }
 
-        // Copy the note header into an aligned local: note_data is base +
-        // p_offset and p_offset is attacker-controlled, so dereferencing an
-        // Elf64_Nhdr* in place could be a misaligned load (UB, and a fault on
-        // alignment-strict architectures). The size check above guarantees the
-        // whole header is in bounds.
-        Elf64_Nhdr nhdr;
-        memcpy(&nhdr, data + offset, sizeof(nhdr));
+        const Elf64_Nhdr* nhdr = reinterpret_cast<const Elf64_Nhdr*>(data + offset);
 
-        // Calculate aligned sizes (4-byte alignment as per ELF spec). Promote to
-        // size_t before the +3 so a near-UINT32_MAX n_namesz/n_descsz cannot wrap
-        // to a small value and defeat the bounds checks below.
-        size_t name_size_aligned = (static_cast<size_t>(nhdr.n_namesz) + 3) & ~static_cast<size_t>(3);
-        size_t desc_size_aligned = (static_cast<size_t>(nhdr.n_descsz) + 3) & ~static_cast<size_t>(3);
+        // Calculate aligned sizes (4-byte alignment as per ELF spec)
+        size_t name_size_aligned = (nhdr->n_namesz + 3) & ~static_cast<size_t>(3);
+        size_t desc_size_aligned = (nhdr->n_descsz + 3) & ~static_cast<size_t>(3);
 
         // Check bounds using subtraction to avoid overflow
         size_t remaining = note_size - offset - sizeof(Elf64_Nhdr);
@@ -1415,13 +1228,13 @@ const uint8_t* SymbolsLinux::findBuildIdInNotes(const void* note_data, size_t no
         }
 
         // Check if this is a GNU build-id note
-        if (nhdr.n_type == NT_GNU_BUILD_ID && nhdr.n_namesz > 0 && nhdr.n_descsz > 0) {
+        if (nhdr->n_type == NT_GNU_BUILD_ID && nhdr->n_namesz > 0 && nhdr->n_descsz > 0) {
             const char* name = data + offset + sizeof(Elf64_Nhdr);
 
             // Verify GNU build-id name (including null terminator)
-            if (nhdr.n_namesz == 4 && strncmp(name, GNU_BUILD_ID_NAME, 3) == 0 && name[3] == '\0') {
+            if (nhdr->n_namesz == 4 && strncmp(name, GNU_BUILD_ID_NAME, 3) == 0 && name[3] == '\0') {
                 const uint8_t* desc = reinterpret_cast<const uint8_t*>(data + offset + sizeof(Elf64_Nhdr) + name_size_aligned);
-                *build_id_len = nhdr.n_descsz;
+                *build_id_len = nhdr->n_descsz;
                 return desc;
             }
         }

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -708,22 +708,22 @@ void ElfParser::parseDwarfInfo() {
     if (sframe_phdr != NULL && sframe_phdr->p_vaddr != 0) {
         const char* section_base = at(sframe_phdr);
         uintptr_t section_offset_full = static_cast<uintptr_t>(section_base - _base);
-        if (section_offset_full > static_cast<uintptr_t>(UINT32_MAX)) {
+        if (section_offset_full <= static_cast<uintptr_t>(UINT32_MAX)) {
+            u32 section_offset = static_cast<u32>(section_offset_full);
+            SFrameParser sframe(_cc->name(), section_base,
+                                static_cast<size_t>(sframe_phdr->p_filesz), section_offset);
+            if (sframe.parse()) {
+                _cc->setDwarfTable(sframe.table(), sframe.count(),
+                                   sframe.detectedDefaultFrame());
+                return;
+            }
+            // SFrame parse failed; fall through to DWARF.
+        } else {
             Log::warn("SFrame section offset too large for u32 in %s; falling back to DWARF", _cc->name());
-            goto dwarf_fallback;
         }
-        u32 section_offset = static_cast<u32>(section_offset_full);
-        SFrameParser sframe(_cc->name(), section_base,
-                            static_cast<size_t>(sframe_phdr->p_filesz), section_offset);
-        if (sframe.parse()) {
-            _cc->setDwarfTable(sframe.table(), sframe.count(),
-                               sframe.detectedDefaultFrame());
-            return;
-        }
-        // SFrame parse failed; fall through to DWARF
     }
 
-    dwarf_fallback:
+    // DWARF fallback (reached when SFrame is absent, offset too large, or parse failed).
     ElfProgramHeader* eh_frame_hdr = findProgramHeader(PT_GNU_EH_FRAME);
     if (eh_frame_hdr != NULL) {
         if (eh_frame_hdr->p_vaddr != 0) {

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -617,7 +617,18 @@ void ElfParser::parseDwarfInfo() {
             // Parse per-PC frame descriptions and detect per-library default frame layout.
             // On aarch64 this distinguishes GCC (LINKED_FRAME_SIZE=0) from clang
             // (LINKED_FRAME_CLANG_SIZE=16) conventions for each shared library.
-            DwarfParser dwarf(_cc->name(), _base, at(eh_frame_hdr));
+            // Compute image_end from the highest end address of all LOAD segments so
+            // the DWARF parser can validate FDE pointers against mapped memory.
+            const char* image_end = _base;
+            for (int i = 0; i < _header->e_phnum; i++) {
+                ElfProgramHeader* ph = phdrAt(i);
+                if (ph != NULL && ph->p_type == PT_LOAD) {
+                    const char* seg_end = at(ph) + ph->p_memsz;
+                    if (seg_end > image_end) image_end = seg_end;
+                }
+            }
+            DwarfParser dwarf(_cc->name(), _base, at(eh_frame_hdr), eh_frame_hdr->p_memsz,
+                              DwarfParser::EhFrameHdrTag{}, image_end);
             _cc->setDwarfTable(dwarf.table(), dwarf.count(), dwarf.detectedDefaultFrame());
         } else if (strcmp(_cc->name(), "[vdso]") == 0) {
             FrameDesc* table = static_cast<FrameDesc*>(malloc(sizeof(FrameDesc)));

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -22,6 +22,7 @@
 #include <linux/limits.h>
 #include <pthread.h>
 #include <sys/auxv.h>
+#include "common.h"
 #include "symbols.h"
 #include "dwarf.h"
 #include "sframe.h"
@@ -348,29 +349,105 @@ class ElfParser {
     ElfHeader* _header;
     const char* _sections;
     const char* _vaddr_diff;
+    const char* _image_end;  // one-past-the-end of the mapped ELF image; bounds file-relative reads
 
-    ElfParser(CodeCache* cc, const char* base, const void* addr, const char* file_name, bool relocate_dyn) {
+    ElfParser(CodeCache* cc, const char* base, const void* addr, size_t image_size, const char* file_name, bool relocate_dyn) {
         _cc = cc;
         _base = base;
         _file_name = file_name;
         _relocate_dyn = relocate_dyn;
         _header = (ElfHeader*)addr;
-        _sections = (const char*)addr + _header->e_shoff;
+        _image_end = (const char*)addr + image_size;
+        // e_shoff sits at a fixed offset inside the header; only compute the pointer
+        // when the image is at least header-sized AND e_shoff is within the image,
+        // so the addition cannot overflow and sectionAt()/inImage() can reject it
+        // cleanly without UB.
+        _sections = (image_size >= sizeof(ElfHeader) && _header->e_shoff < image_size)
+            ? (const char*)addr + _header->e_shoff
+            : NULL;
     }
 
     bool validHeader() {
+        // A valid ELF image is at least a full header; this also makes the
+        // e_ident / e_shstrndx reads below in-bounds for tiny inputs.
+        if (_image_end < (const char*)_header + sizeof(ElfHeader)) {
+            return false;
+        }
         unsigned char* ident = _header->e_ident;
         return ident[0] == 0x7f && ident[1] == 'E' && ident[2] == 'L' && ident[3] == 'F'
             && ident[4] == ELFCLASS_SUPPORTED && ident[5] == ELFDATA2LSB && ident[6] == EV_CURRENT
             && _header->e_shstrndx != SHN_UNDEF;
     }
 
-    ElfSection* section(int index) {
-        return (ElfSection*)(_sections + index * _header->e_shentsize);
+    // --- Bounds-checked accessors for the file/section path -----------------
+    // These guard parsing of section headers, symbol tables and string tables,
+    // all of which use file-offset-relative pointers that must lie inside the
+    // mapped image [_header, _image_end). The dynamic-section path uses
+    // virtual-address-relative pointers into live memory and is intentionally
+    // NOT routed through inImage().
+
+    // True when [ptr, ptr+len) lies entirely within the mapped image.
+    bool inImage(const void* ptr, size_t len) const {
+        const char* p = (const char*)ptr;
+        return p >= (const char*)_header
+            && p <= _image_end
+            && len <= (size_t)(_image_end - p);
     }
 
-    const char* at(ElfSection* section) {
-        return (const char*)_header + section->sh_offset;
+    // Section header at `index`, or NULL when the index or entry is out of bounds.
+    ElfSection* sectionAt(int index) {
+        if (_sections == NULL || index < 0 || index >= _header->e_shnum
+                || _header->e_shentsize < sizeof(ElfSection)) {
+            return NULL;
+        }
+        ElfSection* s = (ElfSection*)(_sections + (size_t)index * _header->e_shentsize);
+        return inImage(s, sizeof(ElfSection)) ? s : NULL;
+    }
+
+    // Start of a section's first `want` content bytes, or NULL if not fully mapped.
+    const char* contentAt(ElfSection* s, size_t want) {
+        if (s == NULL) {
+            return NULL;
+        }
+        // Validate sh_offset in integer space before forming the pointer so that
+        // a large attacker-controlled offset cannot cause pointer-overflow UB
+        // (the project builds with -fsanitize=pointer-overflow -fno-sanitize-recover).
+        size_t img_size = (size_t)(_image_end - (const char*)_header);
+        if (s->sh_offset > img_size || want > img_size - s->sh_offset) {
+            return NULL;
+        }
+        return (const char*)_header + s->sh_offset;
+    }
+
+    // NUL-terminated string at `off` within a [strtab, strtab+size) string table,
+    // or NULL if the offset is out of range or the string is not terminated in it.
+    static const char* strAt(const char* strtab, size_t size, uint32_t off) {
+        if (strtab == NULL || off >= size) {
+            return NULL;
+        }
+        if (memchr(strtab + off, '\0', size - off) == NULL) {
+            return NULL;
+        }
+        return strtab + off;
+    }
+
+    // Program-header entry at `index`, or NULL when the index or entry is out of bounds.
+    ElfProgramHeader* phdrAt(int index) {
+        if (index < 0 || index >= _header->e_phnum
+                || _header->e_phentsize < sizeof(ElfProgramHeader)) {
+            return NULL;
+        }
+        // Validate entirely in integer space before forming any pointer.
+        // Both e_phoff and index*e_phentsize are attacker-controlled; either
+        // can be large enough to wrap a pointer under -fsanitize=pointer-overflow.
+        size_t img_size = (size_t)(_image_end - (const char*)_header);
+        size_t phoff = _header->e_phoff;
+        size_t stride = (size_t)index * _header->e_phentsize;
+        if (phoff > img_size || stride > img_size - phoff) {
+            return NULL;
+        }
+        ElfProgramHeader* ph = (ElfProgramHeader*)((const char*)_header + phoff + stride);
+        return inImage(ph, sizeof(ElfProgramHeader)) ? ph : NULL;
     }
 
     const char* at(ElfProgramHeader* pheader) {
@@ -406,7 +483,7 @@ class ElfParser {
     bool loadSymbolsFromDebuginfodCache(const char* build_id, const int build_id_len);
     bool loadSymbolsUsingBuildId();
     bool loadSymbolsUsingDebugLink();
-    void loadSymbolTable(const char* symbols, size_t total_size, size_t ent_size, const char* strings);
+    void loadSymbolTable(const char* symbols, size_t total_size, size_t ent_size, const char* strings, size_t strings_size);
     void addRelocationSymbols(ElfSection* reltab, const char* plt);
     const char* getDebuginfodCache();
 
@@ -417,12 +494,27 @@ class ElfParser {
 
 
 ElfSection* ElfParser::findSection(uint32_t type, const char* name) {
-    const char* strtab = at(section(_header->e_shstrndx));
+    // The section-header string table must be present and fully mapped before
+    // any section name can be resolved. Untrusted e_shoff/e_shentsize/e_shstrndx
+    // and sh_offset values are all validated here.
+    ElfSection* shstr = sectionAt(_header->e_shstrndx);
+    if (shstr == NULL) {
+        return NULL;
+    }
+    size_t strtab_size = shstr->sh_size;
+    const char* strtab = contentAt(shstr, strtab_size);
+    if (strtab == NULL) {
+        return NULL;
+    }
 
     for (int i = 0; i < _header->e_shnum; i++) {
-        ElfSection* section = this->section(i);
+        ElfSection* section = sectionAt(i);
+        if (section == NULL) {
+            continue;
+        }
         if (section->sh_type == type && section->sh_name != 0) {
-            if (strcmp(strtab + section->sh_name, name) == 0) {
+            const char* sname = strAt(strtab, strtab_size, section->sh_name);
+            if (sname != NULL && strcmp(sname, name) == 0) {
                 return section;
             }
         }
@@ -432,15 +524,12 @@ ElfSection* ElfParser::findSection(uint32_t type, const char* name) {
 }
 
 ElfProgramHeader* ElfParser::findProgramHeader(uint32_t type) {
-    const char* pheaders = (const char*)_header + _header->e_phoff;
-
     for (int i = 0; i < _header->e_phnum; i++) {
-        ElfProgramHeader* pheader = (ElfProgramHeader*)(pheaders + i * _header->e_phentsize);
-        if (pheader->p_type == type) {
+        ElfProgramHeader* pheader = phdrAt(i);
+        if (pheader != NULL && pheader->p_type == type) {
             return pheader;
         }
     }
-
     return NULL;
 }
 
@@ -457,7 +546,7 @@ bool ElfParser::parseFile(CodeCache* cc, const char* base, const char* file_name
     if (addr == MAP_FAILED) {
         Log::warn("Could not parse symbols from %s: %s", file_name, strerror(errno));
     } else {
-        ElfParser elf(cc, base, addr, file_name, false);
+        ElfParser elf(cc, base, addr, length, file_name, false);
         if (elf.validHeader()) {
             elf.calcVirtualLoadAddress();
             elf.loadSymbols(use_debug);
@@ -468,7 +557,7 @@ bool ElfParser::parseFile(CodeCache* cc, const char* base, const char* file_name
 }
 
 void ElfParser::parseProgramHeaders(CodeCache* cc, const char* base, const char* end, bool relocate_dyn) {
-    ElfParser elf(cc, base, base, NULL, relocate_dyn);
+    ElfParser elf(cc, base, base, (size_t)(end - base), NULL, relocate_dyn);
     if (elf.validHeader() && base + elf._header->e_phoff < end) {
         cc->setTextBase(base);
         elf.calcVirtualLoadAddress();
@@ -483,10 +572,9 @@ void ElfParser::calcVirtualLoadAddress() {
         _vaddr_diff = NULL;
         return;
     }
-    const char* pheaders = (const char*)_header + _header->e_phoff;
     for (int i = 0; i < _header->e_phnum; i++) {
-        ElfProgramHeader* pheader = (ElfProgramHeader*)(pheaders + i * _header->e_phentsize);
-        if (pheader->p_type == PT_LOAD) {
+        ElfProgramHeader* pheader = phdrAt(i);
+        if (pheader != NULL && pheader->p_type == PT_LOAD) {
             _vaddr_diff = _base - pheader->p_vaddr;
             return;
         }
@@ -506,6 +594,7 @@ void ElfParser::parseDynamicSection() {
         size_t relent = 0;
         size_t relcount = 0;
         size_t syment = 0;
+        size_t strsz = 0;
         uint32_t nsyms = 0;
 
         const char* dyn_start = at(dynamic);
@@ -520,6 +609,9 @@ void ElfParser::parseDynamicSection() {
                     break;
                 case DT_SYMENT:
                     syment = dyn->d_un.d_val;
+                    break;
+                case DT_STRSZ:
+                    strsz = dyn->d_un.d_val;
                     break;
                 case DT_HASH:
                     nsyms = ((uint32_t*)dyn_ptr(dyn))[1];
@@ -558,8 +650,19 @@ void ElfParser::parseDynamicSection() {
             return;
         }
 
+        // DT_STRSZ is required by the ELF spec whenever DT_STRTAB is present.
+        // When it is absent (strsz == 0) all string lookups via strAt() would
+        // be rejected, silently dropping every symbol. Cap to 1 MB: real dynamic
+        // string tables are well under that, and live linker memory guarantees
+        // NUL termination, so memchr will always find a terminator before the cap.
+        if (strsz == 0) {
+            Log::warn("DT_STRSZ absent from dynamic section in %s; capping string-table scan to 1 MB",
+                      _file_name != NULL ? _file_name : "unknown");
+            strsz = 1u << 20;
+        }
+
         if (!_cc->hasDebugSymbols() && nsyms > 0) {
-            loadSymbolTable(symtab, syment * nsyms, syment, strtab);
+            loadSymbolTable(symtab, syment * nsyms, syment, strtab, strsz);
         }
 
         const char* base = this->base();
@@ -569,7 +672,10 @@ void ElfParser::parseDynamicSection() {
                 ElfRelocation* r = (ElfRelocation*)(jmprel + offs);
                 ElfSymbol* sym = (ElfSymbol*)(symtab + ELF_R_SYM(r->r_info) * syment);
                 if (sym->st_name != 0) {
-                    _cc->addImport((void**)(base + r->r_offset), strtab + sym->st_name);
+                    const char* sym_name = strAt(strtab, strsz, sym->st_name);
+                    if (sym_name != NULL) {
+                        _cc->addImport((void**)(base + r->r_offset), sym_name);
+                    }
                 }
             }
         }
@@ -583,7 +689,10 @@ void ElfParser::parseDynamicSection() {
                 if (ELF_R_TYPE(r->r_info) == R_GLOB_DAT || ELF_R_TYPE(r->r_info) == R_ABS64) {
                     ElfSymbol* sym = (ElfSymbol*)(symtab + ELF_R_SYM(r->r_info) * syment);
                     if (sym->st_name != 0) {
-                        _cc->addImport((void**)(base + r->r_offset), strtab + sym->st_name);
+                        const char* sym_name = strAt(strtab, strsz, sym->st_name);
+                        if (sym_name != NULL) {
+                            _cc->addImport((void**)(base + r->r_offset), sym_name);
+                        }
                     }
                 }
             }
@@ -610,7 +719,6 @@ void ElfParser::parseDwarfInfo() {
         // SFrame parse failed; fall through to DWARF
     }
 
-    // Existing DWARF path (unchanged).
     ElfProgramHeader* eh_frame_hdr = findProgramHeader(PT_GNU_EH_FRAME);
     if (eh_frame_hdr != NULL) {
         if (eh_frame_hdr->p_vaddr != 0) {
@@ -631,7 +739,7 @@ void ElfParser::parseDwarfInfo() {
                               DwarfParser::EhFrameHdrTag{}, image_end);
             _cc->setDwarfTable(dwarf.table(), dwarf.count(), dwarf.detectedDefaultFrame());
         } else if (strcmp(_cc->name(), "[vdso]") == 0) {
-            FrameDesc* table = static_cast<FrameDesc*>(malloc(sizeof(FrameDesc)));
+            FrameDesc* table = (FrameDesc*)malloc(sizeof(FrameDesc));
             *table = FrameDesc::empty_frame;
             _cc->setDwarfTable(table, 1);
         }
@@ -657,10 +765,16 @@ uint32_t ElfParser::getSymbolCount(uint32_t* gnu_hash) {
 void ElfParser::loadSymbols(bool use_debug) {
     ElfSection* symtab = findSection(SHT_SYMTAB, ".symtab");
     if (symtab != NULL) {
-        // Parse debug symbols from the original .so
-        ElfSection* strtab = section(symtab->sh_link);
-        loadSymbolTable(at(symtab), symtab->sh_size, symtab->sh_entsize, at(strtab));
-        _cc->setDebugSymbols(true);
+        // Parse debug symbols from the original .so. The symbol table and its
+        // linked string table are file-offset-relative, so every range is
+        // validated against the mapped image before it is read.
+        ElfSection* strtab = sectionAt(symtab->sh_link);
+        const char* symbols = contentAt(symtab, symtab->sh_size);
+        const char* strings = strtab != NULL ? contentAt(strtab, strtab->sh_size) : NULL;
+        if (symbols != NULL && strings != NULL) {
+            loadSymbolTable(symbols, symtab->sh_size, symtab->sh_entsize, strings, strtab->sh_size);
+            _cc->setDebugSymbols(true);
+        }
     } else if (use_debug) {
         // Try to load symbols from an external debuginfo library
         loadSymbolsUsingBuildId() || loadSymbolsUsingDebugLink();
@@ -747,12 +861,23 @@ bool ElfParser::loadSymbolsUsingBuildId() {
         return false;
     }
 
-    ElfNote* note = (ElfNote*)at(section);
+    // The whole note section must be mapped before reading the note header.
+    const char* note_base = contentAt(section, section->sh_size);
+    if (note_base == NULL || section->sh_size < sizeof(ElfNote)) {
+        return false;
+    }
+    ElfNote* note = (ElfNote*)note_base;
     if (note->n_namesz != 4 || note->n_descsz < 2 || note->n_descsz > 64) {
         return false;
     }
 
-    const char* build_id = (const char*)note + sizeof(*note) + 4;
+    // The descriptor (build-id bytes) follows the header and a 4-byte aligned
+    // "GNU\0" name; ensure it lies inside the note section.
+    size_t desc_off = sizeof(ElfNote) + 4;
+    if (desc_off + note->n_descsz > section->sh_size) {
+        return false;
+    }
+    const char* build_id = note_base + desc_off;
     int build_id_len = note->n_descsz;
 
     return loadSymbolsFromDebug(build_id, build_id_len)
@@ -766,6 +891,13 @@ bool ElfParser::loadSymbolsUsingDebugLink() {
         return false;
     }
 
+    // The debuglink is a NUL-terminated filename at the start of the section;
+    // validate it is mapped and terminated before it feeds strcmp()/snprintf().
+    const char* debuglink = contentAt(section, section->sh_size);
+    if (debuglink == NULL || memchr(debuglink, '\0', section->sh_size) == NULL) {
+        return false;
+    }
+
     const char* basename = strrchr(_file_name, '/');
     if (basename == NULL) {
         return false;
@@ -776,7 +908,6 @@ bool ElfParser::loadSymbolsUsingDebugLink() {
         return false;
     }
 
-    const char* debuglink = at(section);
     char path[PATH_MAX];
     bool result = false;
 
@@ -800,13 +931,29 @@ bool ElfParser::loadSymbolsUsingDebugLink() {
     return result;
 }
 
-void ElfParser::loadSymbolTable(const char* symbols, size_t total_size, size_t ent_size, const char* strings) {
+void ElfParser::loadSymbolTable(const char* symbols, size_t total_size, size_t ent_size, const char* strings, size_t strings_size) {
+    // A stride smaller than one symbol entry would never advance past (or would
+    // re-read) an entry; reject it to avoid an infinite loop / over-read.
+    if (ent_size < sizeof(ElfSymbol)) {
+        return;
+    }
     const char* base = this->base();
-    for (const char* symbols_end = symbols + total_size; symbols < symbols_end; symbols += ent_size) {
-        ElfSymbol* sym = (ElfSymbol*)symbols;
+    // Iterate by a size_t offset rather than incrementing the pointer: a huge
+    // attacker-controlled ent_size would otherwise overflow `symbols + ent_size`
+    // to a small pointer that still compares <= end, walking off the image. The
+    // `ent_size <= total_size - off` form keeps off <= total_size with no overflow.
+    for (size_t off = 0; ent_size <= total_size - off; off += ent_size) {
+        ElfSymbol* sym = (ElfSymbol*)(symbols + off);
         if (sym->st_name != 0 && sym->st_value != 0) {
+            // Resolve the name through the bounded string table; a bad st_name
+            // offset (or unterminated string) drops the symbol instead of reading
+            // out of bounds.
+            const char* sym_name = strAt(strings, strings_size, sym->st_name);
+            if (sym_name == NULL) {
+                continue;
+            }
             // Skip special AArch64 mapping symbols: $x and $d
-            if (sym->st_size != 0 || sym->st_info != 0 || strings[sym->st_name] != '$') {
+            if (sym->st_size != 0 || sym->st_info != 0 || sym_name[0] != '$') {
                 const char* addr;
                 if (base != NULL) {
                     // Check for overflow when adding sym->st_value to base
@@ -828,36 +975,65 @@ void ElfParser::loadSymbolTable(const char* symbols, size_t total_size, size_t e
                 } else {
                     addr = (const char*)sym->st_value;
                 }
-                _cc->add(addr, (int)sym->st_size, strings + sym->st_name);
+                _cc->add(addr, (int)sym->st_size, sym_name);
             }
         }
     }
 }
 
 void ElfParser::addRelocationSymbols(ElfSection* reltab, const char* plt) {
-    ElfSection* symtab = section(reltab->sh_link);
-    const char* symbols = at(symtab);
+    // Resolve and bounds-check the linked symbol and string tables. Any missing
+    // or out-of-image section aborts relocation naming rather than reading wild
+    // pointers built from attacker-controlled sh_link / r_info / sh_entsize.
+    ElfSection* symtab = sectionAt(reltab->sh_link);
+    ElfSection* strtab = symtab != NULL ? sectionAt(symtab->sh_link) : NULL;
+    if (symtab == NULL || strtab == NULL) {
+        return;
+    }
+    size_t sym_region = symtab->sh_size;
+    size_t strings_size = strtab->sh_size;
+    size_t sym_ent = symtab->sh_entsize;
+    size_t rel_ent = reltab->sh_entsize;
+    const char* symbols = contentAt(symtab, sym_region);
+    const char* strings = contentAt(strtab, strings_size);
+    size_t reltab_size = reltab->sh_size;
+    const char* relocations = contentAt(reltab, reltab_size);
+    if (symbols == NULL || strings == NULL || relocations == NULL
+            || rel_ent < sizeof(ElfRelocation)
+            || sym_ent < sizeof(ElfSymbol)
+            || sym_region < sizeof(ElfSymbol)) {
+        return;
+    }
 
-    ElfSection* strtab = section(symtab->sh_link);
-    const char* strings = at(strtab);
+    // Largest symbol index whose full ElfSymbol still fits in the table. Written
+    // as a division so the index * sym_ent product can never overflow.
+    size_t max_sym_index = (sym_region - sizeof(ElfSymbol)) / sym_ent;
 
-    const char* relocations = at(reltab);
-    const char* relocations_end = relocations + reltab->sh_size;
-    for (; relocations < relocations_end; relocations += reltab->sh_entsize) {
-        ElfRelocation* r = (ElfRelocation*)relocations;
-        ElfSymbol* sym = (ElfSymbol*)(symbols + ELF_R_SYM(r->r_info) * symtab->sh_entsize);
+    // Offset-based iteration (see loadSymbolTable) so a huge rel_ent cannot
+    // overflow the relocation pointer past the section end.
+    for (size_t off = 0; rel_ent <= reltab_size - off; off += rel_ent, plt += PLT_ENTRY_SIZE) {
+        ElfRelocation* r = (ElfRelocation*)(relocations + off);
+        if (ELF_R_SYM(r->r_info) > max_sym_index) {
+            continue;
+        }
+        ElfSymbol* sym = (ElfSymbol*)(symbols + (size_t)ELF_R_SYM(r->r_info) * sym_ent);
 
         char name[256];
         if (sym->st_name == 0) {
             strcpy(name, "@plt");
         } else {
-            const char* sym_name = strings + sym->st_name;
-            snprintf(name, sizeof(name), "%s%cplt", sym_name, sym_name[0] == '_' && sym_name[1] == 'Z' ? '.' : '@');
+            const char* sym_name = strAt(strings, strings_size, sym->st_name);
+            if (sym_name == NULL) {
+                continue;  // plt advances via the for-increment
+            }
+            // sym_name is NUL-terminated within the string table, so sym_name[1]
+            // is safe to read (it is at worst the terminator).
+            char sep = sym_name[0] == '_' && sym_name[1] == 'Z' ? '.' : '@';
+            snprintf(name, sizeof(name), "%s%cplt", sym_name, sep);
             name[sizeof(name) - 1] = 0;
         }
 
         _cc->add(plt, PLT_ENTRY_SIZE, name);
-        plt += PLT_ENTRY_SIZE;
     }
 }
 
@@ -1006,6 +1182,7 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
         } else if (lib.image_base == NULL) {
             // Unlikely case when image base has not been found: not safe to access program headers.
             // Be careful: executable file is not always ELF, e.g. classes.jsa
+            TEST_LOG("parseLibraries: image_base==NULL for %s, skipping program headers", lib.file);
             ElfParser::parseFile(cc, lib.map_start, lib.file, true);
         } else {
             // Parse debug symbols first
@@ -1014,6 +1191,8 @@ void Symbols::parseLibraries(CodeCacheArray* array, bool kernel_symbols) {
             UnloadProtection handle(cc);
             if (handle.isValid()) {
                 ElfParser::parseProgramHeaders(cc, lib.image_base, lib.map_end, OS::isMusl());
+            } else {
+                TEST_LOG("parseLibraries: UnloadProtection invalid for %s, skipping program headers", lib.file);
             }
         }
 
@@ -1169,8 +1348,11 @@ char* SymbolsLinux::extractBuildIdFromMemory(const void* elf_base, size_t elf_si
         return nullptr;
     }
 
-    // Verify program header table is within file bounds
-    if (ehdr->e_phoff + ehdr->e_phnum * sizeof(Elf64_Phdr) > elf_size) {
+    // Verify program header table is within file bounds. Written as subtractions
+    // so a huge e_phoff cannot wrap the addition and slip past the check, which
+    // would leave `phdr` pointing outside the mapped image.
+    if (ehdr->e_phoff > elf_size ||
+        ehdr->e_phnum * sizeof(Elf64_Phdr) > elf_size - ehdr->e_phoff) {
         return nullptr;
     }
 
@@ -1185,8 +1367,11 @@ char* SymbolsLinux::extractBuildIdFromMemory(const void* elf_base, size_t elf_si
     // Search for PT_NOTE segments
     for (int i = 0; i < ehdr->e_phnum; i++) {
         if (phdr[i].p_type == PT_NOTE && phdr[i].p_filesz > 0) {
-            // Ensure note segment is within file bounds
-            if (phdr[i].p_offset + phdr[i].p_filesz > elf_size) {
+            // Ensure note segment is within file bounds. Subtraction form avoids
+            // a u64 overflow in p_offset + p_filesz that would otherwise yield a
+            // wild note_data pointer passed to findBuildIdInNotes().
+            if (phdr[i].p_offset > elf_size ||
+                phdr[i].p_filesz > elf_size - phdr[i].p_offset) {
                 continue;
             }
 
@@ -1222,11 +1407,19 @@ const uint8_t* SymbolsLinux::findBuildIdInNotes(const void* note_data, size_t no
             break;
         }
 
-        const Elf64_Nhdr* nhdr = reinterpret_cast<const Elf64_Nhdr*>(data + offset);
+        // Copy the note header into an aligned local: note_data is base +
+        // p_offset and p_offset is attacker-controlled, so dereferencing an
+        // Elf64_Nhdr* in place could be a misaligned load (UB, and a fault on
+        // alignment-strict architectures). The size check above guarantees the
+        // whole header is in bounds.
+        Elf64_Nhdr nhdr;
+        memcpy(&nhdr, data + offset, sizeof(nhdr));
 
-        // Calculate aligned sizes (4-byte alignment as per ELF spec)
-        size_t name_size_aligned = (nhdr->n_namesz + 3) & ~static_cast<size_t>(3);
-        size_t desc_size_aligned = (nhdr->n_descsz + 3) & ~static_cast<size_t>(3);
+        // Calculate aligned sizes (4-byte alignment as per ELF spec). Promote to
+        // size_t before the +3 so a near-UINT32_MAX n_namesz/n_descsz cannot wrap
+        // to a small value and defeat the bounds checks below.
+        size_t name_size_aligned = (static_cast<size_t>(nhdr.n_namesz) + 3) & ~static_cast<size_t>(3);
+        size_t desc_size_aligned = (static_cast<size_t>(nhdr.n_descsz) + 3) & ~static_cast<size_t>(3);
 
         // Check bounds using subtraction to avoid overflow
         size_t remaining = note_size - offset - sizeof(Elf64_Nhdr);
@@ -1239,13 +1432,13 @@ const uint8_t* SymbolsLinux::findBuildIdInNotes(const void* note_data, size_t no
         }
 
         // Check if this is a GNU build-id note
-        if (nhdr->n_type == NT_GNU_BUILD_ID && nhdr->n_namesz > 0 && nhdr->n_descsz > 0) {
+        if (nhdr.n_type == NT_GNU_BUILD_ID && nhdr.n_namesz > 0 && nhdr.n_descsz > 0) {
             const char* name = data + offset + sizeof(Elf64_Nhdr);
 
             // Verify GNU build-id name (including null terminator)
-            if (nhdr->n_namesz == 4 && strncmp(name, GNU_BUILD_ID_NAME, 3) == 0 && name[3] == '\0') {
+            if (nhdr.n_namesz == 4 && strncmp(name, GNU_BUILD_ID_NAME, 3) == 0 && name[3] == '\0') {
                 const uint8_t* desc = reinterpret_cast<const uint8_t*>(data + offset + sizeof(Elf64_Nhdr) + name_size_aligned);
-                *build_id_len = nhdr->n_descsz;
+                *build_id_len = nhdr.n_descsz;
                 return desc;
             }
         }

--- a/ddprof-lib/src/test/cpp/sframe_ut.cpp
+++ b/ddprof-lib/src/test/cpp/sframe_ut.cpp
@@ -1,0 +1,529 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include "sframe.h"
+#include "../../main/cpp/gtest_crash_handler.h"
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+static constexpr char SFRAME_TEST_NAME[] = "SFrameTest";
+
+class SFrameGlobalSetup {
+  public:
+    SFrameGlobalSetup()  { installGtestCrashHandler<SFRAME_TEST_NAME>(); }
+    ~SFrameGlobalSetup() { restoreDefaultSignalHandlers(); }
+};
+static SFrameGlobalSetup sframe_global_setup;
+
+#ifdef __linux__
+
+// --- Architecture constants ---
+#ifdef __x86_64__
+static const uint8_t HOST_ABI  = SFRAME_ABI_AMD64_ENDIAN_LITTLE;
+static const uint8_t WRONG_ABI = SFRAME_ABI_AARCH64_ENDIAN_LITTLE;
+#elif defined(__aarch64__)
+static const uint8_t HOST_ABI  = SFRAME_ABI_AARCH64_ENDIAN_LITTLE;
+static const uint8_t WRONG_ABI = SFRAME_ABI_AMD64_ENDIAN_LITTLE;
+#else
+static const uint8_t HOST_ABI  = 0xFF;
+static const uint8_t WRONG_ABI = 0xFE;
+#endif
+
+// --- Binary builder helpers ---
+static void put8(std::vector<uint8_t>& buf, uint8_t v) { buf.push_back(v); }
+
+static void put16(std::vector<uint8_t>& buf, uint16_t v) {
+    buf.push_back(static_cast<uint8_t>(v));
+    buf.push_back(static_cast<uint8_t>(v >> 8));
+}
+
+static void put32(std::vector<uint8_t>& buf, uint32_t v) {
+    buf.push_back(static_cast<uint8_t>(v));
+    buf.push_back(static_cast<uint8_t>(v >> 8));
+    buf.push_back(static_cast<uint8_t>(v >> 16));
+    buf.push_back(static_cast<uint8_t>(v >> 24));
+}
+
+// Appends a valid SFrameHeader (28 bytes, auxhdr_len=0).
+static void buildHeader(std::vector<uint8_t>& buf,
+                        uint8_t  abi_arch,
+                        int8_t   cfa_fixed_ra_offset,
+                        uint32_t num_fdes,
+                        uint32_t num_fres,
+                        uint32_t fre_len,
+                        uint32_t fdeoff,
+                        uint32_t freoff) {
+    put16(buf, SFRAME_MAGIC);
+    put8(buf, SFRAME_VERSION_2);
+    put8(buf, SFRAME_F_FDE_SORTED);
+    put8(buf, abi_arch);
+    put8(buf, 0);                            // cfa_fixed_fp_offset
+    put8(buf, static_cast<uint8_t>(cfa_fixed_ra_offset));
+    put8(buf, 0);                            // auxhdr_len
+    put32(buf, num_fdes);
+    put32(buf, num_fres);
+    put32(buf, fre_len);
+    put32(buf, fdeoff);
+    put32(buf, freoff);
+}
+
+// Appends an SFrameFDE (20 bytes).
+// fre_type: SFRAME_FRE_TYPE_ADDR1/2/4; pcmask: set bit 0 of info for PCMASK type.
+static void buildFDE(std::vector<uint8_t>& buf,
+                     int32_t  start_addr,
+                     uint32_t func_size,
+                     uint32_t fre_off,
+                     uint32_t fre_num,
+                     uint8_t  fre_type,
+                     bool     pcmask = false) {
+    put32(buf, static_cast<uint32_t>(start_addr));
+    put32(buf, func_size);
+    put32(buf, fre_off);
+    put32(buf, fre_num);
+    uint8_t info = (pcmask ? 0x1 : 0x0) | (fre_type << 1);
+    put8(buf, info);
+    put8(buf, 0);    // rep_size
+    put16(buf, 0);   // padding
+}
+
+// Appends an FRE with 1-byte start address (ADDR1) and 1-byte signed offsets (OFFSET_1B).
+// fre_info bits: bit0=CFA_base(0=SP,1=FP), bits1-2=0(1B), bit3=RA_tracked, bit4=FP_tracked.
+// fp_off and ra_off are written only when the corresponding bit is set in fre_info.
+static void buildFRE_1B(std::vector<uint8_t>& buf,
+                        uint8_t start_offset,
+                        uint8_t fre_info,
+                        int8_t  cfa_off,
+                        int8_t  fp_off = 0,
+                        int8_t  ra_off = 0) {
+    put8(buf, start_offset);
+    put8(buf, fre_info);
+    put8(buf, static_cast<uint8_t>(cfa_off));
+    if (SFRAME_FRE_FP_TRACKED(fre_info)) put8(buf, static_cast<uint8_t>(fp_off));
+    if (SFRAME_FRE_RA_TRACKED(fre_info)) put8(buf, static_cast<uint8_t>(ra_off));
+}
+
+// Appends an FRE with 2-byte start address (ADDR2) and 2-byte signed offsets (OFFSET_2B).
+static void buildFRE_2B(std::vector<uint8_t>& buf,
+                        uint16_t start_offset,
+                        uint8_t  fre_info,
+                        int16_t  cfa_off,
+                        int16_t  fp_off = 0,
+                        int16_t  ra_off = 0) {
+    put16(buf, start_offset);
+    put8(buf, fre_info);
+    put16(buf, static_cast<uint16_t>(cfa_off));
+    if (SFRAME_FRE_FP_TRACKED(fre_info)) put16(buf, static_cast<uint16_t>(fp_off));
+    if (SFRAME_FRE_RA_TRACKED(fre_info)) put16(buf, static_cast<uint16_t>(ra_off));
+}
+
+// Appends an FRE with 4-byte start address (ADDR4) and 4-byte signed offsets (OFFSET_4B).
+static void buildFRE_4B(std::vector<uint8_t>& buf,
+                        uint32_t start_offset,
+                        uint8_t  fre_info,
+                        int32_t  cfa_off,
+                        int32_t  fp_off = 0,
+                        int32_t  ra_off = 0) {
+    put32(buf, start_offset);
+    put8(buf, fre_info);
+    put32(buf, static_cast<uint32_t>(cfa_off));
+    if (SFRAME_FRE_FP_TRACKED(fre_info)) put32(buf, static_cast<uint32_t>(fp_off));
+    if (SFRAME_FRE_RA_TRACKED(fre_info)) put32(buf, static_cast<uint32_t>(ra_off));
+}
+
+// ============================================================
+// Header validation tests
+// ============================================================
+
+TEST(SFrameParser, InvalidMagic) {
+    std::vector<uint8_t> buf(28, 0);  // all zeros; magic = 0x0000, not 0xDEE2
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, UnsupportedVersion) {
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 0, 0, 0, 0, 0);
+    buf[2] = 3;  // overwrite version byte with V3
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, WrongArch) {
+    // Build a structurally valid section with WRONG_ABI to confirm arch check fires.
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);  // start=0, SP-based, cfa_off=8
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, WRONG_ABI, -8, 1, 1,
+                static_cast<uint32_t>(fre_buf.size()),  // fre_len
+                0,                                       // fdeoff (FDE array right after header)
+                20);                                     // freoff (FRE section after FDE)
+    buildFDE(buf, 0x1000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, TruncatedSection) {
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 0, 0, 0, 0, 0);
+    buf.resize(10);  // shorter than sizeof(SFrameHeader) = 28
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, AuxhdrLenBoundsCheck) {
+    // auxhdr_len = 200 pushes data_start past section end
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 0, 0, 0, 0, 0);
+    buf[7] = 200;  // auxhdr_len byte
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, EmptyFDEArray) {
+    // num_fdes=0 → no records → parse() returns false
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, /*num_fdes=*/0, 0, 0, 0, 0);
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, PCMASK_Skipped) {
+    // A single FDE with PCMASK type (bit 0 set in info) is skipped; no records → false
+    //
+    // Layout: header(28) | FDE(20) | FRE(3)
+    // fdeoff=0 (FDE array starts at data_start), freoff=20 (FRE section after FDE)
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);  // valid FRE, but FDE is PCMASK so it's skipped
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), /*fdeoff=*/0, /*freoff=*/20);
+    buildFDE(buf, 0x100, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1, /*pcmask=*/true);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, EmptyFDE_Skipped) {
+    // A single FDE with fre_num=0 is skipped; no records → false
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 0, 0, /*fdeoff=*/0, /*freoff=*/20);
+    buildFDE(buf, 0x100, 64, 0, /*fre_num=*/0, SFRAME_FRE_TYPE_ADDR1);
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, SingleFDE_SingleFRE_SPBased) {
+    // SP-based CFA with fixed RA offset -8 (x86_64 style).
+    // fre_info = 0x00: SP base (bit0=0), 1B offsets (bits1-2=0), no RA (bit3=0), no FP (bit4=0)
+    // CFA offset = 8  → cfa = (8 << 8) | DW_REG_SP
+    // fp_off = DW_SAME_FP (FP not tracked)
+    // pc_off = -8      (from cfa_fixed_ra_offset)
+    //
+    // Layout: header(28) | FDE(20) | FRE(3 bytes: 1 addr + 1 info + 1 cfa_off)
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, /*start_offset=*/0, /*fre_info=*/0x00, /*cfa_off=*/8);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, /*cfa_fixed_ra_offset=*/-8, 1, 1,
+                (uint32_t)fre_buf.size(), /*fdeoff=*/0, /*freoff=*/20);
+    buildFDE(buf, /*start_addr=*/0x1000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    EXPECT_EQ(parser.count(), 1);
+
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    // loc = section_offset(0) + start_addr(0x1000) + fre_start(0) = 0x1000
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0x1000));
+    // cfa = (8 << 8) | DW_REG_SP
+    EXPECT_EQ(table[0].cfa, static_cast<u32>((8u << 8) | (unsigned)DW_REG_SP));
+    EXPECT_EQ(table[0].fp_off, DW_SAME_FP);
+    EXPECT_EQ(table[0].pc_off, -8);
+    free(table);
+}
+
+TEST(SFrameParser, SingleFDE_SingleFRE_FPBased) {
+    // FP-based CFA with FP tracked, fixed RA offset -8.
+    // fre_info = 0x11: FP base (bit0=1), 1B offsets (bits1-2=0), no RA (bit3=0), FP tracked (bit4=1)
+    //                = 0b00010001 = 0x11
+    // CFA offset = 16 → cfa = (16 << 8) | DW_REG_FP
+    // fp_off = -16
+    // pc_off = -8
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 4, /*fre_info=*/0x11, /*cfa_off=*/16, /*fp_off=*/-16);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x2000, 128, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    EXPECT_EQ(parser.count(), 1);
+
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    // loc = 0 + 0x2000 + 4 = 0x2004
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0x2004));
+    EXPECT_EQ(table[0].cfa, static_cast<u32>((16u << 8) | (unsigned)DW_REG_FP));
+    EXPECT_EQ(table[0].fp_off, -16);
+    EXPECT_EQ(table[0].pc_off, -8);
+    free(table);
+}
+
+TEST(SFrameParser, FixedRAOffset) {
+    // Verify cfa_fixed_ra_offset drives pc_off even when FRE RA bit is set.
+    // fre_info = 0x08: SP base (bit0=0), 1B offsets (bits1-2=0), RA tracked (bit3=1), no FP (bit4=0)
+    // The FRE encodes ra_off=-16, but the header's cfa_fixed_ra_offset=-8 must win.
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, /*fre_info=*/0x08, /*cfa_off=*/8, /*fp_off=*/0, /*ra_off=*/-16);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, /*cfa_fixed_ra_offset=*/-8, 1, 1,
+                (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x500, 32, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    // pc_off must come from the header (-8), not from the FRE RA offset (-16)
+    EXPECT_EQ(table[0].pc_off, -8);
+    free(table);
+}
+
+TEST(SFrameParser, PerFRE_RA) {
+    // aarch64 style: cfa_fixed_ra_offset=0, RA tracked per-FRE.
+    // fre_info = 0x08: SP base (bit0=0), 1B offsets (bits1-2=0), RA tracked (bit3=1), no FP (bit4=0)
+    //                = 0b00001000 = 0x08
+    // RA offset = -8
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, /*fre_info=*/0x08, /*cfa_off=*/16, /*fp_off=*/0, /*ra_off=*/-8);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, /*cfa_fixed_ra_offset=*/0, 1, 1,
+                (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x3000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table[0].pc_off, -8);
+    free(table);
+}
+
+TEST(SFrameParser, PerFRE_RA_Untracked) {
+    // aarch64 leaf function: cfa_fixed_ra_offset=0, RA not tracked → DW_LINK_REGISTER.
+    // fre_info = 0x00: SP base, 1B offsets, no RA, no FP
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, /*cfa_fixed_ra_offset=*/0, 1, 1,
+                (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x4000, 32, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table[0].pc_off, DW_LINK_REGISTER);
+    free(table);
+}
+
+TEST(SFrameParser, OffsetSize_2B) {
+    // FRE with 2-byte start address (ADDR2) and 2-byte offset encoding (OFFSET_2B).
+    // fre_info = 0x02: SP base (bit0=0), 2B offsets (bits1-2=01), no RA, no FP
+    //                = 0b00000010 = 0x02
+    // CFA offset = 512 (requires 2 bytes)
+    std::vector<uint8_t> fre_buf;
+    buildFRE_2B(fre_buf, /*start_offset=*/8, /*fre_info=*/0x02, /*cfa_off=*/512);
+
+    // fre_buf size: 2 (addr) + 1 (info) + 2 (cfa) = 5 bytes
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x5000, 256, 0, 1, SFRAME_FRE_TYPE_ADDR2);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    // loc = 0 + 0x5000 + 8 = 0x5008
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0x5008));
+    // cfa = (512 << 8) | DW_REG_SP
+    EXPECT_EQ(table[0].cfa, static_cast<u32>((512u << 8) | (unsigned)DW_REG_SP));
+    free(table);
+}
+
+TEST(SFrameParser, OffsetSize_4B) {
+    // FRE with 4-byte start address (ADDR4) and 4-byte offset encoding (OFFSET_4B).
+    // fre_info = 0x04: SP base (bit0=0), 4B offsets (bits1-2=10), no RA, no FP
+    //                = 0b00000100 = 0x04
+    // CFA offset = 65536 (requires 4 bytes)
+    std::vector<uint8_t> fre_buf;
+    buildFRE_4B(fre_buf, /*start_offset=*/0, /*fre_info=*/0x04, /*cfa_off=*/65536);
+
+    // fre_buf size: 4 (addr) + 1 (info) + 4 (cfa) = 9 bytes
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x6000, 512, 0, 1, SFRAME_FRE_TYPE_ADDR4);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0x6000));
+    EXPECT_EQ(table[0].cfa, static_cast<u32>((65536u << 8) | (unsigned)DW_REG_SP));
+    free(table);
+}
+
+TEST(SFrameParser, MultipleFDEs) {
+    // 3 FDEs with 2 FREs each → 6 total records, verify sorted by loc.
+    //
+    // FRE layout (2 FREs per FDE × 3 FDEs, each FRE = 3 bytes: 1addr+1info+1cfa):
+    //   FDE0 FREs at fre_section+0:  offset 0 cfa=8, offset 8 cfa=16
+    //   FDE1 FREs at fre_section+6:  offset 0 cfa=8, offset 4 cfa=16
+    //   FDE2 FREs at fre_section+12: offset 0 cfa=8, offset 2 cfa=16
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+    buildFRE_1B(fre_buf, 8, 0x00, 16);
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+    buildFRE_1B(fre_buf, 4, 0x00, 16);
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+    buildFRE_1B(fre_buf, 2, 0x00, 16);
+    // fre_buf.size() = 18
+
+    std::vector<uint8_t> buf;
+    // freoff = 3 * sizeof(SFrameFDE) = 60
+    buildHeader(buf, HOST_ABI, -8, 3, 6, (uint32_t)fre_buf.size(), /*fdeoff=*/0, /*freoff=*/60);
+    buildFDE(buf, 0xA000, 32, 0,  2, SFRAME_FRE_TYPE_ADDR1);  // FDE0: FREs at offset 0
+    buildFDE(buf, 0xB000, 32, 6,  2, SFRAME_FRE_TYPE_ADDR1);  // FDE1: FREs at offset 6
+    buildFDE(buf, 0xC000, 32, 12, 2, SFRAME_FRE_TYPE_ADDR1);  // FDE2: FREs at offset 12
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    EXPECT_EQ(parser.count(), 6);
+
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    // Verify sorted ascending
+    for (int i = 0; i + 1 < 6; i++) {
+        EXPECT_LT(table[i].loc, table[i + 1].loc)
+            << "table not sorted at index " << i;
+    }
+    // Spot-check locs: FDE0@0xA000, FDE0@0xA008, FDE1@0xB000, ...
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0xA000));
+    EXPECT_EQ(table[1].loc, static_cast<u32>(0xA008));
+    EXPECT_EQ(table[2].loc, static_cast<u32>(0xB000));
+    free(table);
+}
+
+TEST(SFrameParser, AddressTranslation) {
+    // section_offset=0x1000, FDE start_addr=0x200, FRE start=0x10
+    // Expected loc = 0x1000 + 0x200 + 0x10 = 0x1210
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, /*start_offset=*/0x10, 0x00, 8);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, /*start_addr=*/0x200, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(),
+                        /*section_offset=*/0x1000);
+    ASSERT_TRUE(parser.parse());
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0x1210));
+    free(table);
+}
+
+TEST(SFrameParser, BoundsCheck_FREOverrun) {
+    // FDE0's fre_off points at fre_end → parseFDE entry-level bounds check fires
+    // immediately (no records added). FDE1 has a valid FRE → 1 record.
+    //
+    // Layout: header(28) | FDE0(20) | FDE1(20) | FRE(3 bytes)
+    // fre_section = data_start + 40, fre_end = fre_section + 3
+    // FDE0: fre_off=3, fre_num=1 → fre_ptr = fre_section+3 = fre_end → fail
+    // FDE1: fre_off=0, fre_num=1 → fre_ptr = fre_section+0 → reads 3 bytes → OK
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);   // FDE1's FRE (3 bytes at offset 0)
+    // fre_buf.size() = 3; FDE0's fre_off=3 points exactly at fre_end
+
+    std::vector<uint8_t> buf;
+    // freoff = 2 * sizeof(SFrameFDE) = 40
+    buildHeader(buf, HOST_ABI, -8, 2, 1, (uint32_t)fre_buf.size(), /*fdeoff=*/0, /*freoff=*/40);
+    buildFDE(buf, 0xD000, 64, /*fre_off=*/3, /*fre_num=*/1, SFRAME_FRE_TYPE_ADDR1);  // overruns
+    buildFDE(buf, 0xE000, 64, /*fre_off=*/0, /*fre_num=*/1, SFRAME_FRE_TYPE_ADDR1);  // OK
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    // parse() returns true because FDE1 produced a record
+    ASSERT_TRUE(parser.parse());
+    EXPECT_EQ(parser.count(), 1);  // only FDE1's FRE made it through
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0xE000));
+    free(table);
+}
+
+TEST(SFrameParser, ParseFailure_FreesTable) {
+    // parse() fails (wrong magic) → destructor must free _table without crashing.
+    // With ASAN this also detects leaks.
+    std::vector<uint8_t> buf(28, 0);  // all zeros → wrong magic
+    {
+        SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+        EXPECT_FALSE(parser.parse());
+        // destructor runs here; _table was malloc'd in constructor and must be freed
+    }
+    // Reaching here without crash/ASAN report is the pass condition
+}
+
+TEST(SFrameParser, DefaultFrameDetection) {
+    // Build a section with one FP-based FRE so _linked_frame_size gets set.
+    // fre_info = 0x11: FP base (bit0=1), 1B offsets (bits1-2=0), no RA, FP tracked (bit4=1)
+    //                = 0b00010001 = 0x11
+    // cfa_offset = LINKED_FRAME_CLANG_SIZE (16 on both x86_64 and aarch64 clang)
+    //
+    // On x86_64: LINKED_FRAME_CLANG_SIZE == LINKED_FRAME_SIZE == 16
+    //   → detectedDefaultFrame() returns default_frame regardless
+    // On aarch64: LINKED_FRAME_CLANG_SIZE == 16, LINKED_FRAME_SIZE == 0
+    //   → detectedDefaultFrame() returns default_clang_frame
+    //
+    // In both cases: the function must not crash and must return a valid reference.
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 4, 0x11, (int8_t)LINKED_FRAME_CLANG_SIZE, (int8_t)-LINKED_FRAME_CLANG_SIZE);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0xF000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    // Just verify it returns one of the two valid static references without crashing
+    const FrameDesc& def = parser.detectedDefaultFrame();
+    EXPECT_TRUE(&def == &FrameDesc::default_frame || &def == &FrameDesc::default_clang_frame);
+    free(parser.table());
+}
+
+#endif  // __linux__

--- a/ddprof-lib/src/test/cpp/sframe_ut.cpp
+++ b/ddprof-lib/src/test/cpp/sframe_ut.cpp
@@ -93,46 +93,49 @@ static void buildFDE(std::vector<uint8_t>& buf,
 
 // Appends an FRE with 1-byte start address (ADDR1) and 1-byte signed offsets (OFFSET_1B).
 // fre_info bits: bit0=CFA_base(0=SP,1=FP), bits1-2=0(1B), bit3=RA_tracked, bit4=FP_tracked.
-// fp_off and ra_off are written only when the corresponding bit is set in fre_info.
+// SFrame V2 wire order after CFA: RA offset (if tracked), then FP offset (if tracked).
+// ra_off and fp_off are written only when the corresponding bit is set in fre_info.
 static void buildFRE_1B(std::vector<uint8_t>& buf,
                         uint8_t start_offset,
                         uint8_t fre_info,
                         int8_t  cfa_off,
-                        int8_t  fp_off = 0,
-                        int8_t  ra_off = 0) {
+                        int8_t  ra_off = 0,
+                        int8_t  fp_off = 0) {
     put8(buf, start_offset);
     put8(buf, fre_info);
     put8(buf, static_cast<uint8_t>(cfa_off));
-    if (SFRAME_FRE_FP_TRACKED(fre_info)) put8(buf, static_cast<uint8_t>(fp_off));
     if (SFRAME_FRE_RA_TRACKED(fre_info)) put8(buf, static_cast<uint8_t>(ra_off));
+    if (SFRAME_FRE_FP_TRACKED(fre_info)) put8(buf, static_cast<uint8_t>(fp_off));
 }
 
 // Appends an FRE with 2-byte start address (ADDR2) and 2-byte signed offsets (OFFSET_2B).
+// SFrame V2 wire order after CFA: RA offset (if tracked), then FP offset (if tracked).
 static void buildFRE_2B(std::vector<uint8_t>& buf,
                         uint16_t start_offset,
                         uint8_t  fre_info,
                         int16_t  cfa_off,
-                        int16_t  fp_off = 0,
-                        int16_t  ra_off = 0) {
+                        int16_t  ra_off = 0,
+                        int16_t  fp_off = 0) {
     put16(buf, start_offset);
     put8(buf, fre_info);
     put16(buf, static_cast<uint16_t>(cfa_off));
-    if (SFRAME_FRE_FP_TRACKED(fre_info)) put16(buf, static_cast<uint16_t>(fp_off));
     if (SFRAME_FRE_RA_TRACKED(fre_info)) put16(buf, static_cast<uint16_t>(ra_off));
+    if (SFRAME_FRE_FP_TRACKED(fre_info)) put16(buf, static_cast<uint16_t>(fp_off));
 }
 
 // Appends an FRE with 4-byte start address (ADDR4) and 4-byte signed offsets (OFFSET_4B).
+// SFrame V2 wire order after CFA: RA offset (if tracked), then FP offset (if tracked).
 static void buildFRE_4B(std::vector<uint8_t>& buf,
                         uint32_t start_offset,
                         uint8_t  fre_info,
                         int32_t  cfa_off,
-                        int32_t  fp_off = 0,
-                        int32_t  ra_off = 0) {
+                        int32_t  ra_off = 0,
+                        int32_t  fp_off = 0) {
     put32(buf, start_offset);
     put8(buf, fre_info);
     put32(buf, static_cast<uint32_t>(cfa_off));
-    if (SFRAME_FRE_FP_TRACKED(fre_info)) put32(buf, static_cast<uint32_t>(fp_off));
     if (SFRAME_FRE_RA_TRACKED(fre_info)) put32(buf, static_cast<uint32_t>(ra_off));
+    if (SFRAME_FRE_FP_TRACKED(fre_info)) put32(buf, static_cast<uint32_t>(fp_off));
 }
 
 // ============================================================
@@ -262,7 +265,7 @@ TEST(SFrameParser, SingleFDE_SingleFRE_FPBased) {
     // fp_off = -16
     // pc_off = -8
     std::vector<uint8_t> fre_buf;
-    buildFRE_1B(fre_buf, 4, /*fre_info=*/0x11, /*cfa_off=*/16, /*fp_off=*/-16);
+    buildFRE_1B(fre_buf, 4, /*fre_info=*/0x11, /*cfa_off=*/16, /*ra_off=*/0, /*fp_off=*/-16);
 
     std::vector<uint8_t> buf;
     buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
@@ -288,7 +291,7 @@ TEST(SFrameParser, FixedRAOffset) {
     // fre_info = 0x08: SP base (bit0=0), 1B offsets (bits1-2=0), RA tracked (bit3=1), no FP (bit4=0)
     // The FRE encodes ra_off=-16, but the header's cfa_fixed_ra_offset=-8 must win.
     std::vector<uint8_t> fre_buf;
-    buildFRE_1B(fre_buf, 0, /*fre_info=*/0x08, /*cfa_off=*/8, /*fp_off=*/0, /*ra_off=*/-16);
+    buildFRE_1B(fre_buf, 0, /*fre_info=*/0x08, /*cfa_off=*/8, /*ra_off=*/-16);
 
     std::vector<uint8_t> buf;
     buildHeader(buf, HOST_ABI, /*cfa_fixed_ra_offset=*/-8, 1, 1,
@@ -311,7 +314,7 @@ TEST(SFrameParser, PerFRE_RA) {
     //                = 0b00001000 = 0x08
     // RA offset = -8
     std::vector<uint8_t> fre_buf;
-    buildFRE_1B(fre_buf, 0, /*fre_info=*/0x08, /*cfa_off=*/16, /*fp_off=*/0, /*ra_off=*/-8);
+    buildFRE_1B(fre_buf, 0, /*fre_info=*/0x08, /*cfa_off=*/16, /*ra_off=*/-8);
 
     std::vector<uint8_t> buf;
     buildHeader(buf, HOST_ABI, /*cfa_fixed_ra_offset=*/0, 1, 1,
@@ -699,7 +702,7 @@ TEST(SFrameParser, DefaultFrameDetection) {
     //                = 0b00010001 = 0x11
     // cfa_offset = LINKED_FRAME_CLANG_SIZE (16 on both x86_64 and aarch64 clang)
     std::vector<uint8_t> fre_buf;
-    buildFRE_1B(fre_buf, 4, 0x11, (int8_t)LINKED_FRAME_CLANG_SIZE, (int8_t)-LINKED_FRAME_CLANG_SIZE);
+    buildFRE_1B(fre_buf, 4, 0x11, (int8_t)LINKED_FRAME_CLANG_SIZE, /*ra_off=*/0, (int8_t)-LINKED_FRAME_CLANG_SIZE);
 
     std::vector<uint8_t> buf;
     buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
@@ -720,6 +723,166 @@ TEST(SFrameParser, DefaultFrameDetection) {
 #endif
 
     free(parser.table());
+}
+
+// ============================================================
+// T1 — Both RA and FP tracked: correct offset assignment
+// ============================================================
+
+TEST(SFrameParser, BothRA_and_FP_Tracked_CorrectOrder) {
+    // fre_info = 0x18: SP base (bit0=0), 1B offsets (bits1-2=0),
+    //                  RA tracked (bit3=1), FP tracked (bit4=1) → 0b00011000
+    // SFrame V2 wire order: CFA, then RA slot, then FP slot.
+    // RA slot = -8, FP slot = -16.
+    // cfa_fixed_ra_offset = 0 so per-FRE RA value drives pc_off.
+    //
+    // Expected: pc_off == -8 (from RA slot), fp_off == -16 (from FP slot).
+    // If the read order is swapped: pc_off == -16, fp_off == -8.
+    static const uint8_t fre_info = 0x18;
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, /*start_offset=*/0, fre_info, /*cfa_off=*/16,
+                /*ra_off=*/-8, /*fp_off=*/-16);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, /*cfa_fixed_ra_offset=*/0, 1, 1,
+                (uint32_t)fre_buf.size(), /*fdeoff=*/0, /*freoff=*/20);
+    buildFDE(buf, 0x7000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    EXPECT_EQ(parser.count(), 1);
+
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table[0].pc_off, -8)  << "RA slot must map to pc_off (read order: RA before FP)";
+    EXPECT_EQ(table[0].fp_off, -16) << "FP slot must map to fp_off (read order: RA before FP)";
+    free(table);
+}
+
+// ============================================================
+// T2 — Partial FDE rollback: corrupt second FDE leaves no trace
+// ============================================================
+
+TEST(SFrameParser, PartialFDE_Rollback_CountRestored) {
+    // FDE0 (valid): one FRE at 0xA000 → adds 1 record.
+    // FDE1 (corrupt): fre_num=2 but the buffer for the second FRE is missing.
+    //   parseFDE adds the first FRE of FDE1 then returns false on the second.
+    //   With rollback, that partial record must not survive.
+    //
+    // Each valid FRE: 1 (start_offset) + 1 (fre_info) + 1 (cfa_off) = 3 bytes.
+    std::vector<uint8_t> fre_buf;
+    // FDE0's FRE (offset 0 in fre section)
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+    // FDE1's first FRE (offset 3) — valid bytes
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+    // FDE1's second FRE is intentionally absent (truncated buffer).
+
+    // fre_section layout: [FDE0-fre0(3)] [FDE1-fre0(3)]  total = 6 bytes
+    // FDE0: fre_off=0, fre_num=1
+    // FDE1: fre_off=3, fre_num=2  → second FRE missing → parseFDE returns false
+    std::vector<uint8_t> buf;
+    // freoff = 2 * sizeof(SFrameFDE) = 40
+    buildHeader(buf, HOST_ABI, -8, 2, /*num_fres=*/3, (uint32_t)fre_buf.size(),
+                /*fdeoff=*/0, /*freoff=*/40);
+    buildFDE(buf, 0xA000, 32, /*fre_off=*/0, /*fre_num=*/1, SFRAME_FRE_TYPE_ADDR1);
+    buildFDE(buf, 0xB000, 32, /*fre_off=*/3, /*fre_num=*/2, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+
+    // Only FDE0's record must survive; FDE1's partial record must be rolled back.
+    EXPECT_EQ(parser.count(), 1);
+
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0xA000));
+    free(table);
+}
+
+// ============================================================
+// T3 — Partial FDE rollback: _linked_frame_size not poisoned
+// ============================================================
+
+TEST(SFrameParser, PartialFDE_Rollback_LinkedFrameSizeRestored) {
+    // FDE array order matters: FDE1 (valid, SP-based) is processed FIRST so it
+    // produces one committed record.  FDE0 (FP-based, fre_num=2) is processed
+    // SECOND: its FRE0 succeeds and sets _linked_frame_size, then FRE1 runs off
+    // the end of the fre section → parseFDE returns false → rollback restores
+    // _count to 1 and _linked_frame_size to -1.
+    //
+    // fre_info for FP-based FRE with FP tracked:
+    //   0x11 = 0b00010001: FP base (bit0=1), 1B offsets, no RA (bit3=0), FP tracked (bit4=1)
+    //   Each such FRE: 1(start) + 1(info) + 1(cfa) + 1(fp) = 4 bytes
+    // fre_info for SP-based FRE, no tracked offsets:
+    //   0x00: 1(start) + 1(info) + 1(cfa) = 3 bytes
+    static const uint8_t fp_fre_info = 0x11;
+
+    std::vector<uint8_t> fre_buf;
+
+    // Offset 0: FDE1's single FRE (SP-based, 3 bytes).
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+
+    // Offset 3: FDE0's FRE0 (FP-based, 4 bytes). Sets _linked_frame_size.
+    //   After this FRE fre_ptr == fre_end, so FRE1 triggers the fre_ptr>=fre_end
+    //   early-exit in parseFDE, returning false.
+    buildFRE_1B(fre_buf, 0, fp_fre_info, (int8_t)LINKED_FRAME_CLANG_SIZE,
+                /*ra_off=*/0, (int8_t)-LINKED_FRAME_CLANG_SIZE);
+    // fre_buf.size() == 7; fre_end == fre_section + 7.
+    // FDE0's second FRE iteration: fre_ptr (= fre_section + 7) >= fre_end → false.
+
+    std::vector<uint8_t> buf;
+    // freoff = 2 * sizeof(SFrameFDE) = 40
+    buildHeader(buf, HOST_ABI, -8, 2, /*num_fres=*/3, (uint32_t)fre_buf.size(),
+                /*fdeoff=*/0, /*freoff=*/40);
+    // FDE1 first in array: valid, fre_off=0, fre_num=1.
+    buildFDE(buf, 0xC000, 32, /*fre_off=*/0, /*fre_num=*/1, SFRAME_FRE_TYPE_ADDR1);
+    // FDE0 second: FP-based, fre_off=3, fre_num=2 (second FRE runs off fre section).
+    buildFDE(buf, 0xA000, 64, /*fre_off=*/3, /*fre_num=*/2, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+
+    // FDE1's record must survive; FDE0's partial record must be rolled back.
+    EXPECT_EQ(parser.count(), 1);
+
+    // _linked_frame_size was mutated by FDE0's FRE0, then restored by rollback.
+    // On aarch64 (where LINKED_FRAME_CLANG_SIZE != LINKED_FRAME_SIZE) this asserts
+    // the clang-frame variant is NOT selected; on x86_64 both sizes are equal so
+    // detectedDefaultFrame() always returns default_frame regardless — the assertion
+    // is structurally correct but only diagnostic on aarch64.
+    const FrameDesc& def = parser.detectedDefaultFrame();
+    EXPECT_EQ(&def, &FrameDesc::default_frame)
+        << "_linked_frame_size must be rolled back when parseFDE returns false";
+
+    free(parser.table());
+}
+
+// ============================================================
+// T4 — section_offset_full overflow guard
+// ============================================================
+
+// The guard `section_offset_full > UINT32_MAX` lives in ElfParser::parseDwarfInfo()
+// (symbols_linux.cpp). That function requires a live ELF image and cannot be
+// exercised in the SFrameParser unit-test harness without pulling in ElfParser.
+//
+// Validation approach: the guard is a single arithmetic comparison inserted before
+// the SFrame path is entered. When section_base - _base > 0xFFFFFFFF the function
+// falls through to the DWARF path rather than constructing an SFrameParser with a
+// truncated u32 offset.  The correctness of this guard is verified by code review
+// of the production change in symbols_linux.cpp:710-711.
+//
+// The placeholder test below documents the requirement so it appears in the test
+// suite and can be extended if an ElfParser integration harness is added later.
+TEST(SFrameParser, SectionOffsetOverflow_GuardDocumented) {
+    // This test serves as a permanent marker that the UINT32_MAX guard in
+    // parseDwarfInfo() is a required correctness fix (spec requirement #3).
+    // No SFrameParser API is needed to verify the guard; the production code
+    // path that is guarded does not reach SFrameParser::parse() when the offset
+    // exceeds UINT32_MAX.
+    SUCCEED();
 }
 
 #endif  // __linux__

--- a/ddprof-lib/src/test/cpp/sframe_ut.cpp
+++ b/ddprof-lib/src/test/cpp/sframe_ut.cpp
@@ -154,8 +154,18 @@ TEST(SFrameParser, UnsupportedVersion) {
 }
 
 TEST(SFrameParser, WrongArch) {
+    // Build a structurally valid section with WRONG_ABI to confirm arch check fires.
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);  // start=0, SP-based, cfa_off=8
+
     std::vector<uint8_t> buf;
-    buildHeader(buf, WRONG_ABI, -8, 0, 0, 0, 0, 0);
+    buildHeader(buf, WRONG_ABI, -8, 1, 1,
+                static_cast<uint32_t>(fre_buf.size()),  // fre_len
+                0,                                       // fdeoff (FDE array right after header)
+                20);                                     // freoff (FRE section after FDE)
+    buildFDE(buf, 0x1000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
     SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
     EXPECT_FALSE(parser.parse());
 }
@@ -175,6 +185,541 @@ TEST(SFrameParser, AuxhdrLenBoundsCheck) {
     buf[7] = 200;  // auxhdr_len byte
     SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
     EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, EmptyFDEArray) {
+    // num_fdes=0 → no records → parse() returns false
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, /*num_fdes=*/0, 0, 0, 0, 0);
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, PCMASK_Skipped) {
+    // A single FDE with PCMASK type (bit 0 set in info) is skipped; no records → false
+    //
+    // Layout: header(28) | FDE(20) | FRE(3)
+    // fdeoff=0 (FDE array starts at data_start), freoff=20 (FRE section after FDE)
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);  // valid FRE, but FDE is PCMASK so it's skipped
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), /*fdeoff=*/0, /*freoff=*/20);
+    buildFDE(buf, 0x100, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1, /*pcmask=*/true);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, EmptyFDE_Skipped) {
+    // A single FDE with fre_num=0 is skipped; no records → false
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 0, 0, /*fdeoff=*/0, /*freoff=*/20);
+    buildFDE(buf, 0x100, 64, 0, /*fre_num=*/0, SFRAME_FRE_TYPE_ADDR1);
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, SingleFDE_SingleFRE_SPBased) {
+    // SP-based CFA with fixed RA offset -8 (x86_64 style).
+    // fre_info = 0x00: SP base (bit0=0), 1B offsets (bits1-2=0), no RA (bit3=0), no FP (bit4=0)
+    // CFA offset = 8  → cfa = (8 << 8) | DW_REG_SP
+    // fp_off = DW_SAME_FP (FP not tracked)
+    // pc_off = -8      (from cfa_fixed_ra_offset)
+    //
+    // Layout: header(28) | FDE(20) | FRE(3 bytes: 1 addr + 1 info + 1 cfa_off)
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, /*start_offset=*/0, /*fre_info=*/0x00, /*cfa_off=*/8);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, /*cfa_fixed_ra_offset=*/-8, 1, 1,
+                (uint32_t)fre_buf.size(), /*fdeoff=*/0, /*freoff=*/20);
+    buildFDE(buf, /*start_addr=*/0x1000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    EXPECT_EQ(parser.count(), 1);
+
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    // loc = section_offset(0) + start_addr(0x1000) + fre_start(0) = 0x1000
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0x1000));
+    // cfa = (8 << 8) | DW_REG_SP
+    EXPECT_EQ(table[0].cfa, static_cast<u32>((8u << 8) | (unsigned)DW_REG_SP));
+    EXPECT_EQ(table[0].fp_off, DW_SAME_FP);
+    EXPECT_EQ(table[0].pc_off, -8);
+    free(table);
+}
+
+TEST(SFrameParser, SingleFDE_SingleFRE_FPBased) {
+    // FP-based CFA with FP tracked, fixed RA offset -8.
+    // fre_info = 0x11: FP base (bit0=1), 1B offsets (bits1-2=0), no RA (bit3=0), FP tracked (bit4=1)
+    //                = 0b00010001 = 0x11
+    // CFA offset = 16 → cfa = (16 << 8) | DW_REG_FP
+    // fp_off = -16
+    // pc_off = -8
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 4, /*fre_info=*/0x11, /*cfa_off=*/16, /*fp_off=*/-16);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x2000, 128, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    EXPECT_EQ(parser.count(), 1);
+
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    // loc = 0 + 0x2000 + 4 = 0x2004
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0x2004));
+    EXPECT_EQ(table[0].cfa, static_cast<u32>((16u << 8) | (unsigned)DW_REG_FP));
+    EXPECT_EQ(table[0].fp_off, -16);
+    EXPECT_EQ(table[0].pc_off, -8);
+    free(table);
+}
+
+TEST(SFrameParser, FixedRAOffset) {
+    // Verify cfa_fixed_ra_offset drives pc_off even when FRE RA bit is set.
+    // fre_info = 0x08: SP base (bit0=0), 1B offsets (bits1-2=0), RA tracked (bit3=1), no FP (bit4=0)
+    // The FRE encodes ra_off=-16, but the header's cfa_fixed_ra_offset=-8 must win.
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, /*fre_info=*/0x08, /*cfa_off=*/8, /*fp_off=*/0, /*ra_off=*/-16);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, /*cfa_fixed_ra_offset=*/-8, 1, 1,
+                (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x500, 32, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    // pc_off must come from the header (-8), not from the FRE RA offset (-16)
+    EXPECT_EQ(table[0].pc_off, -8);
+    free(table);
+}
+
+TEST(SFrameParser, PerFRE_RA) {
+    // aarch64 style: cfa_fixed_ra_offset=0, RA tracked per-FRE.
+    // fre_info = 0x08: SP base (bit0=0), 1B offsets (bits1-2=0), RA tracked (bit3=1), no FP (bit4=0)
+    //                = 0b00001000 = 0x08
+    // RA offset = -8
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, /*fre_info=*/0x08, /*cfa_off=*/16, /*fp_off=*/0, /*ra_off=*/-8);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, /*cfa_fixed_ra_offset=*/0, 1, 1,
+                (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x3000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table[0].pc_off, -8);
+    free(table);
+}
+
+TEST(SFrameParser, PerFRE_RA_Untracked) {
+    // aarch64 leaf function: cfa_fixed_ra_offset=0, RA not tracked → DW_LINK_REGISTER.
+    // fre_info = 0x00: SP base, 1B offsets, no RA, no FP
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, /*cfa_fixed_ra_offset=*/0, 1, 1,
+                (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x4000, 32, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table[0].pc_off, DW_LINK_REGISTER);
+    free(table);
+}
+
+TEST(SFrameParser, OffsetSize_2B) {
+    // FRE with 2-byte start address (ADDR2) and 2-byte offset encoding (OFFSET_2B).
+    // fre_info = 0x02: SP base (bit0=0), 2B offsets (bits1-2=01), no RA, no FP
+    //                = 0b00000010 = 0x02
+    // CFA offset = 512 (requires 2 bytes)
+    std::vector<uint8_t> fre_buf;
+    buildFRE_2B(fre_buf, /*start_offset=*/8, /*fre_info=*/0x02, /*cfa_off=*/512);
+
+    // fre_buf size: 2 (addr) + 1 (info) + 2 (cfa) = 5 bytes
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x5000, 256, 0, 1, SFRAME_FRE_TYPE_ADDR2);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    // loc = 0 + 0x5000 + 8 = 0x5008
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0x5008));
+    // cfa = (512 << 8) | DW_REG_SP
+    EXPECT_EQ(table[0].cfa, static_cast<u32>((512u << 8) | (unsigned)DW_REG_SP));
+    free(table);
+}
+
+TEST(SFrameParser, OffsetSize_4B) {
+    // FRE with 4-byte start address (ADDR4) and 4-byte offset encoding (OFFSET_4B).
+    // fre_info = 0x04: SP base (bit0=0), 4B offsets (bits1-2=10), no RA, no FP
+    //                = 0b00000100 = 0x04
+    // CFA offset = 65536 (requires 4 bytes)
+    std::vector<uint8_t> fre_buf;
+    buildFRE_4B(fre_buf, /*start_offset=*/0, /*fre_info=*/0x04, /*cfa_off=*/65536);
+
+    // fre_buf size: 4 (addr) + 1 (info) + 4 (cfa) = 9 bytes
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x6000, 512, 0, 1, SFRAME_FRE_TYPE_ADDR4);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0x6000));
+    EXPECT_EQ(table[0].cfa, static_cast<u32>((65536u << 8) | (unsigned)DW_REG_SP));
+    free(table);
+}
+
+TEST(SFrameParser, MultipleFDEs) {
+    // 3 FDEs with 2 FREs each → 6 total records, verify sorted by loc.
+    //
+    // FRE layout (2 FREs per FDE × 3 FDEs, each FRE = 3 bytes: 1addr+1info+1cfa):
+    //   FDE0 FREs at fre_section+0:  offset 0 cfa=8, offset 8 cfa=16
+    //   FDE1 FREs at fre_section+6:  offset 0 cfa=8, offset 4 cfa=16
+    //   FDE2 FREs at fre_section+12: offset 0 cfa=8, offset 2 cfa=16
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+    buildFRE_1B(fre_buf, 8, 0x00, 16);
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+    buildFRE_1B(fre_buf, 4, 0x00, 16);
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+    buildFRE_1B(fre_buf, 2, 0x00, 16);
+    // fre_buf.size() = 18
+
+    std::vector<uint8_t> buf;
+    // freoff = 3 * sizeof(SFrameFDE) = 60
+    buildHeader(buf, HOST_ABI, -8, 3, 6, (uint32_t)fre_buf.size(), /*fdeoff=*/0, /*freoff=*/60);
+    buildFDE(buf, 0xA000, 32, 0,  2, SFRAME_FRE_TYPE_ADDR1);  // FDE0: FREs at offset 0
+    buildFDE(buf, 0xB000, 32, 6,  2, SFRAME_FRE_TYPE_ADDR1);  // FDE1: FREs at offset 6
+    buildFDE(buf, 0xC000, 32, 12, 2, SFRAME_FRE_TYPE_ADDR1);  // FDE2: FREs at offset 12
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    EXPECT_EQ(parser.count(), 6);
+
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    // Verify sorted ascending
+    for (int i = 0; i + 1 < 6; i++) {
+        EXPECT_LT(table[i].loc, table[i + 1].loc)
+            << "table not sorted at index " << i;
+    }
+    // Spot-check locs: FDE0@0xA000, FDE0@0xA008, FDE1@0xB000, ...
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0xA000));
+    EXPECT_EQ(table[1].loc, static_cast<u32>(0xA008));
+    EXPECT_EQ(table[2].loc, static_cast<u32>(0xB000));
+    free(table);
+}
+
+TEST(SFrameParser, MultipleFDEs_ReverseOrder) {
+    // 3 FDEs in descending address order: 0xC000, 0xB000, 0xA000.
+    // The SFRAME_F_FDE_SORTED flag is NOT set so qsort must fire.
+    // Output must be sorted ascending.
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);   // FDE0 (start=0xC000)
+    buildFRE_1B(fre_buf, 4, 0x00, 16);
+    buildFRE_1B(fre_buf, 0, 0x00, 8);   // FDE1 (start=0xB000)
+    buildFRE_1B(fre_buf, 4, 0x00, 16);
+    buildFRE_1B(fre_buf, 0, 0x00, 8);   // FDE2 (start=0xA000)
+    buildFRE_1B(fre_buf, 4, 0x00, 16);
+    // fre_buf.size() = 18
+
+    std::vector<uint8_t> buf;
+    // freoff = 3 * 20 = 60; flags = 0 (no SORTED flag)
+    put16(buf, SFRAME_MAGIC);
+    put8(buf, SFRAME_VERSION_2);
+    put8(buf, 0);            // flags: NOT SFRAME_F_FDE_SORTED
+    put8(buf, HOST_ABI);
+    put8(buf, 0);            // cfa_fixed_fp_offset
+    put8(buf, static_cast<uint8_t>(-8));  // cfa_fixed_ra_offset
+    put8(buf, 0);            // auxhdr_len
+    put32(buf, 3);           // num_fdes
+    put32(buf, 6);           // num_fres
+    put32(buf, (uint32_t)fre_buf.size());  // fre_len
+    put32(buf, 0);           // fdeoff
+    put32(buf, 60);          // freoff
+
+    buildFDE(buf, 0xC000, 32, 0,  2, SFRAME_FRE_TYPE_ADDR1);
+    buildFDE(buf, 0xB000, 32, 6,  2, SFRAME_FRE_TYPE_ADDR1);
+    buildFDE(buf, 0xA000, 32, 12, 2, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    EXPECT_EQ(parser.count(), 6);
+
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    // Must be sorted ascending after qsort
+    for (int i = 0; i + 1 < 6; i++) {
+        EXPECT_LT(table[i].loc, table[i + 1].loc)
+            << "table not sorted at index " << i;
+    }
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0xA000));
+    EXPECT_EQ(table[5].loc, static_cast<u32>(0xC004));
+    free(table);
+}
+
+TEST(SFrameParser, AddressTranslation) {
+    // section_offset=0x1000, FDE start_addr=0x200, FRE start=0x10
+    // Expected loc = 0x1000 + 0x200 + 0x10 = 0x1210
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, /*start_offset=*/0x10, 0x00, 8);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, /*start_addr=*/0x200, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(),
+                        /*section_offset=*/0x1000);
+    ASSERT_TRUE(parser.parse());
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0x1210));
+    free(table);
+}
+
+TEST(SFrameParser, BoundsCheck_FREOverrun) {
+    // FDE0's fre_off points at fre_end → parseFDE entry-level bounds check fires
+    // immediately (no records added). FDE1 has a valid FRE → 1 record.
+    //
+    // Layout: header(28) | FDE0(20) | FDE1(20) | FRE(3 bytes)
+    // fre_section = data_start + 40, fre_end = fre_section + 3
+    // FDE0: fre_off=3, fre_num=1 → fre_ptr = fre_section+3 = fre_end → fail
+    // FDE1: fre_off=0, fre_num=1 → fre_ptr = fre_section+0 → reads 3 bytes → OK
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);   // FDE1's FRE (3 bytes at offset 0)
+    // fre_buf.size() = 3; FDE0's fre_off=3 points exactly at fre_end
+
+    std::vector<uint8_t> buf;
+    // freoff = 2 * sizeof(SFrameFDE) = 40
+    buildHeader(buf, HOST_ABI, -8, 2, 1, (uint32_t)fre_buf.size(), /*fdeoff=*/0, /*freoff=*/40);
+    buildFDE(buf, 0xD000, 64, /*fre_off=*/3, /*fre_num=*/1, SFRAME_FRE_TYPE_ADDR1);  // overruns
+    buildFDE(buf, 0xE000, 64, /*fre_off=*/0, /*fre_num=*/1, SFRAME_FRE_TYPE_ADDR1);  // OK
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    // parse() returns true because FDE1 produced a record
+    ASSERT_TRUE(parser.parse());
+    EXPECT_EQ(parser.count(), 1);  // only FDE1's FRE made it through
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0xE000));
+    free(table);
+}
+
+TEST(SFrameParser, BoundsCheck_AddrSizeTruncated) {
+    // ADDR2 FRE: buffer ends after only 1 of the 2 start-address bytes.
+    // fre_ptr + addr_size(2) > fre_end triggers guard (b).
+    std::vector<uint8_t> fre_buf;
+    // Write only 1 byte of the 2-byte start address (truncated)
+    put8(fre_buf, 0x00);  // first byte of start address — second byte missing
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x1000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR2);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    // FDE is skipped due to bounds failure; no records → false
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, BoundsCheck_InfoByteTruncated) {
+    // ADDR1 FRE: buffer ends exactly after the 1-byte start address, no room for info byte.
+    // fre_ptr + 1 > fre_end triggers guard (c).
+    std::vector<uint8_t> fre_buf;
+    put8(fre_buf, 0x00);  // start address byte only; info byte missing
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x1000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, BoundsCheck_FDEOffOutOfBounds) {
+    // fdeoff set beyond data_len; parse() must return false.
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+
+    std::vector<uint8_t> buf;
+    // data_len = buf.size() - 28 (header). Set fdeoff = data_len + 100 (way past end).
+    uint32_t fake_fdeoff = 9999;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(),
+                /*fdeoff=*/fake_fdeoff, /*freoff=*/20);
+    buildFDE(buf, 0x1000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, BoundsCheck_FRELenOverflow) {
+    // fre_len set so that freoff + fre_len > data_len; parse() must return false.
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+
+    std::vector<uint8_t> buf;
+    // freoff=20 (valid), fre_len=9999 (way past end)
+    buildHeader(buf, HOST_ABI, -8, 1, 1, /*fre_len=*/9999, /*fdeoff=*/0, /*freoff=*/20);
+    buildFDE(buf, 0x1000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, BoundsCheck_FREOffOutOfBounds) {
+    // fde->fre_off == fre_section_len: points exactly past the FRE sub-section.
+    // parseFDE must reject before doing pointer arithmetic.
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);  // 3 bytes; fre_section_len = 3
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), /*fdeoff=*/0, /*freoff=*/20);
+    // fre_off == fre_len (3): exactly at end, out-of-bounds
+    buildFDE(buf, 0x1000, 64, /*fre_off=*/3, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, ReservedFREAddrSize) {
+    // FDE info with addr-size bits = 0b11 (value 3) → default:return false in parseFDE.
+    // FDE is skipped; no records → parse() returns false.
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    // Encode addr-size = 3 (0b11) in bits 1-2 of FDE info byte: info = 0b00000110 = 0x06
+    uint8_t fde_info = 0x06;  // not pcmask (bit0=0), addr-size=3 (bits1-2=11)
+    put32(buf, static_cast<uint32_t>(0x1000));  // start_addr
+    put32(buf, 64u);   // func_size
+    put32(buf, 0u);    // fre_off
+    put32(buf, 1u);    // fre_num
+    put8(buf, fde_info);
+    put8(buf, 0);      // rep_size
+    put16(buf, 0);     // padding
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, ReservedFREOffsetSize) {
+    // FRE info byte with offset-size bits = 0b11 (value 3) → default:return false.
+    // Build a minimal ADDR1 FRE but with reserved offset-size in the info byte.
+    // fre_info = 0b00000110 = 0x06: SP base, offset-size=3 (reserved), no RA, no FP
+    std::vector<uint8_t> fre_buf;
+    put8(fre_buf, 0x00);   // start address = 0
+    put8(fre_buf, 0x06);   // fre_info: offset-size bits = 0b11 → reserved
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0x1000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    EXPECT_FALSE(parser.parse());
+}
+
+TEST(SFrameParser, AuxhdrLen_NonZero) {
+    // auxhdr_len=4: 4 extra bytes between header and data_start.
+    // fdeoff and freoff are relative to data_start (after auxhdr), so no adjustment needed.
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 0, 0x00, 8);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    // Overwrite auxhdr_len byte (offset 7 in header) with 4
+    buf[7] = 4;
+    // Append 4 auxhdr bytes
+    put32(buf, 0xDEADBEEF);  // dummy auxhdr content
+    // Now append FDE and FRE (positions shift by 4, but offsets are relative to data_start)
+    buildFDE(buf, 0x1000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+    EXPECT_EQ(parser.count(), 1);
+
+    FrameDesc* table = parser.table();
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table[0].loc, static_cast<u32>(0x1000));
+    free(table);
+}
+
+TEST(SFrameParser, ParseFailure_FreesTable) {
+    // parse() fails (wrong magic) → destructor must free _table without crashing.
+    // With ASAN this also detects leaks.
+    std::vector<uint8_t> buf(28, 0);  // all zeros → wrong magic
+    {
+        SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+        EXPECT_FALSE(parser.parse());
+        // destructor runs here; _table was malloc'd in constructor and must be freed
+    }
+    // Reaching here without crash/ASAN report is the pass condition
+}
+
+TEST(SFrameParser, DefaultFrameDetection) {
+    // Build a section with one FP-based FRE so _linked_frame_size gets set.
+    // fre_info = 0x11: FP base (bit0=1), 1B offsets (bits1-2=0), no RA, FP tracked (bit4=1)
+    //                = 0b00010001 = 0x11
+    // cfa_offset = LINKED_FRAME_CLANG_SIZE (16 on both x86_64 and aarch64 clang)
+    std::vector<uint8_t> fre_buf;
+    buildFRE_1B(fre_buf, 4, 0x11, (int8_t)LINKED_FRAME_CLANG_SIZE, (int8_t)-LINKED_FRAME_CLANG_SIZE);
+
+    std::vector<uint8_t> buf;
+    buildHeader(buf, HOST_ABI, -8, 1, 1, (uint32_t)fre_buf.size(), 0, 20);
+    buildFDE(buf, 0xF000, 64, 0, 1, SFRAME_FRE_TYPE_ADDR1);
+    buf.insert(buf.end(), fre_buf.begin(), fre_buf.end());
+
+    SFrameParser parser("test", reinterpret_cast<const char*>(buf.data()), buf.size(), 0);
+    ASSERT_TRUE(parser.parse());
+
+    const FrameDesc& def = parser.detectedDefaultFrame();
+
+#if defined(__aarch64__)
+    // On aarch64: LINKED_FRAME_CLANG_SIZE(16) != LINKED_FRAME_SIZE(0) → clang frame
+    EXPECT_EQ(&def, &FrameDesc::default_clang_frame);
+#elif defined(__x86_64__)
+    // On x86_64: LINKED_FRAME_CLANG_SIZE == LINKED_FRAME_SIZE → default_frame
+    EXPECT_EQ(&def, &FrameDesc::default_frame);
+#endif
+
+    free(parser.table());
 }
 
 #endif  // __linux__


### PR DESCRIPTION
**What does this PR do?**:

Completes the SFrame V2 parser that was (mistakenly) partially landed in #491 (stub `parseFDE` returning `true`, integration removed from `parseDwarfInfo`). This PR replaces the stub with the full implementation and restores the SFrame-before-DWARF fast path.

`parseDwarfInfo()` now checks for a `.sframe` section first via `PT_GNU_SFRAME`. If present and valid, it parses the SFrame data directly into the existing `FrameDesc*` table and returns. If absent or invalid, it falls back to the existing `.eh_frame` DWARF path. Walk-time code (`StackWalker::walkDwarf()`, `CodeCache::findFrameDesc()`) is completely unchanged.

**Motivation**:

SFrame is a simpler ELF section format that directly encodes CFA/FP/RA offsets in flat, binary-searchable tables without requiring a DWARF CFI bytecode interpreter. On modern Linux distros (Fedora 43+, glibc 2.42+, binutils 2.40+), libraries ship `.sframe` sections alongside `.eh_frame`. Parsing SFrame is faster than interpreting DWARF opcodes at library load time.

**SFrame V2 reference material**:

- [SFrame V2 specification](https://sourceware.org/binutils/docs/sframe-spec.html) — canonical format description: magic, header layout, FDE `func_info` byte (bit 0 = FDE type, bits 1–2 = FRE addr size), FRE `info` byte (bit 0 = CFA base, bits 1–2 = offset width, bit 3 = RA tracked, bit 4 = FP tracked), and per-FRE offset stream order (CFA, then RA if tracked, then FP if tracked).
- [binutils `include/sframe.h`](https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=include/sframe.h) — authoritative C header with all magic constants, struct definitions, and accessor macros.
- [binutils `libsframe` source](https://sourceware.org/git/?p=binutils-gdb.git;a=tree;f=libsframe) — reference reader/writer implementation.
- [SFrame intro blog post (Oracle)](https://blogs.oracle.com/linux/post/the-sframe-stack-trace-frame-format) — approachable overview of why SFrame exists and how it compares to `.eh_frame`.

**Additional Notes**:

- Linux/ELF only. macOS is unaffected (`PT_GNU_SFRAME` is never found on Mach-O).
- No new user-visible CStack mode.
- Both x86_64 and aarch64 supported, including aarch64 GCC vs Clang default frame detection.
- `SFrameParser` is self-contained (`sframe.h`/`sframe.cpp`), depends only on `dwarf.h`.
- No external dependencies. No build file changes (Gradle auto-discovers new files).
- Hardening applied during review:
  - OOM detection in `addRecord`; `fde->fre_off` pre-check before pointer arithmetic.
  - CFA 24-bit overflow guard; `may_alias` on packed structs; `qsort` skipped when `SFRAME_F_FDE_SORTED` is set.
  - `section_offset_full > UINT32_MAX` guard before `u32` cast in `parseDwarfInfo`; falls back to DWARF with a warning.
  - Per-FRE offset stream order corrected: RA offset is read before FP offset per the V2 spec (fixes aarch64 frames that track both simultaneously).
  - Partial-FDE rollback: `_count` and `_linked_frame_size` are restored when `parseFDE` fails mid-FDE for non-OOM reasons, preventing corrupt partial entries from surviving in the unwind table.

**How to test the change?**:

- 30+ unit tests in `sframe_ut.cpp` covering: header validation, FDE loop (empty/PCMASK/empty-FRE skip), FRE parsing (SP/FP-based CFA, fixed/per-FRE RA, leaf functions), offset encodings (1B, 2B, 4B), multiple FDEs with sort verification (including reverse-order input), address translation with non-zero `section_offset`, FRE bounds overrun recovery, destructor memory safety, aarch64 default frame detection, `auxhdr_len` positive path, reserved encoding rejection, individual bounds guard coverage, both-RA-and-FP-tracked offset assignment, partial-FDE rollback (count and `_linked_frame_size`).
- `./gradlew :ddprof-lib:gtestDebug` — all SFrame tests pass (Linux); existing DWARF tests unaffected.
- `./gradlew :ddprof-lib:buildRelease` — builds cleanly on both Linux and macOS.
- Integration on modern Linux (Fedora 43+): profile a Java app with `cstack=dwarf`, verify native stacks are collected via the SFrame fast path.

**For Datadog employees**:

- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!