### PR TITLE
fix: use deliberately misaligned buffer in MarkOnNonNativeFuncPointerReturnsSafe

### DIFF
--- a/ddprof-lib/src/test/cpp/nativefunc_ut.cpp
+++ b/ddprof-lib/src/test/cpp/nativefunc_ut.cpp
@@ -122,16 +122,22 @@ TEST_F(NativeFuncTest, OverwriteMark) {
 }
 
 TEST_F(NativeFuncTest, MarkOnNonNativeFuncPointerReturnsSafe) {
-    // Test that reading marks from random strings returns safe defaults
-    // without crashing (due to alignment check protection)
-    const char* random_string = "not_a_nativefunc";
+    // Use a deliberately misaligned pointer rather than a string literal.
+    // String literals live in .rodata whose base address is linker-determined;
+    // on some platforms/compilers the literal ends up at an address where
+    // (ptr - sizeof(NativeFunc)) is also naturally aligned, causing the
+    // is_aligned() guard to pass and the methods to read garbage.
+    // A 64-byte-aligned buffer with a +1 offset is guaranteed to be misaligned
+    // with respect to sizeof(NativeFunc*) (4 or 8 bytes) on every platform,
+    // so the guard reliably rejects it and returns safe defaults.
+    alignas(64) char buf[64] = "not_a_nativefunc";
+    const char* unaligned = buf + 1;
 
-    // Should return safe defaults without crashing
-    EXPECT_FALSE(NativeFunc::is_marked(random_string))
+    EXPECT_FALSE(NativeFunc::is_marked(unaligned))
         << "is_marked() on non-NativeFunc string should return false (safe default)";
-    EXPECT_EQ(NativeFunc::read_mark(random_string), 0)
+    EXPECT_EQ(NativeFunc::read_mark(unaligned), 0)
         << "read_mark() on non-NativeFunc string should return 0 (safe default)";
-    EXPECT_EQ(NativeFunc::libIndex(random_string), -1)
+    EXPECT_EQ(NativeFunc::libIndex(unaligned), -1)
         << "libIndex() on non-NativeFunc string should return -1 (safe default)";
 }
 


### PR DESCRIPTION
**What does this PR do?**:
Replace the string literal in `NativeFuncTest.MarkOnNonNativeFuncPointerReturnsSafe` with a deliberately misaligned stack buffer, eliminating the test's intermittent failures on 8-ibm and other platforms.

**Motivation**:
Fixes #469. The test was passing `"not_a_nativefunc"` — a `.rodata` string literal — to `NativeFunc::is_marked()`, `read_mark()`, and `libIndex()`, expecting the alignment guard in `NativeFunc::from()` to reject it. String literals in `.rodata` are placed at linker-determined addresses that can satisfy the 8-byte alignment requirement on some platforms (notably `test-linux-glibc-amd64 (8-ibm, debug)`), causing the guard to pass and the methods to read garbage from memory as if it were a valid `NativeFunc`.

The fix uses `alignas(64) char buf[64]` and passes `buf + 1`. Since `buf` is 64-byte aligned, `buf+1` has address ≡ 1 mod 64. The alignment guard checks `(ptr - sizeof(NativeFunc)) % sizeof(NativeFunc*)`, which equals `(buf+1-4) % 8 = 61 % 8 = 5 ≠ 0` — guaranteed to be rejected on all platforms (32-bit and 64-bit).

**Additional Notes**:
This is a test-design fix only. No production code (`codeCache.h`, `codeCache.cpp`) is changed. A comment was added explaining why deliberate misalignment is necessary, to prevent future regression.

**How to test the change?**:
Run `NativeFuncTest.MarkOnNonNativeFuncPointerReturnsSafe` on all CI configurations, particularly `test-linux-glibc-amd64 (8-ibm, debug)`. The test should pass deterministically.

The existing test already covers all three assertions (`is_marked`, `read_mark`, `libIndex`).

**For Datadog employees**:
- [x] This PR doesn't touch any of that.
- [ ] JIRA: N/A (tracked via GitHub issue #469)

Resolves #475

<!-- muse-session:impl-20260415-184223 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code) via muse implement