### PR TITLE
Fix WallClockASGCT::timerLoop skipping every other thread (PROF-14332)

### DIFF
--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -170,7 +170,6 @@ void WallClockASGCT::timerLoop() {
           if (tid != OS::threadId()) {
             tids.push_back(tid);
           }
-          tid = thread_list->next();
         }
         delete thread_list;
       }


### PR DESCRIPTION
**What does this PR do?**:

Fixes a bug in `WallClockASGCT::timerLoop` where the `collectThreads` lambda's no-filter fallback advances the `ThreadList` iterator twice per loop body, silently skipping every other thread when the wallclock thread filter is disabled.

The fix removes one spurious `tid = thread_list->next();` call at the tail of the loop in `ddprof-lib/src/main/cpp/wallClock.cpp`. The `while (thread_list->hasNext()) { tid = thread_list->next(); ... }` pattern now correctly reads one tid per iteration.

**Motivation**:

When `threadFilter->enabled()` is false (no context-based wallclock filtering), every wallclock tick was sampling only half the eligible threads, producing under-sampled wallclock profiles. The typical context-filtered path is unaffected; this only bit on the fallback.

Flagged by a muse chorus review as an unrelated pre-existing bug and filed separately so it can land on its own small PR.

**Additional Notes**:

Pre-existing bug — not introduced by any recent change. Scope is intentionally narrow: only the redundant `next()` call is removed. Related concerns (e.g. `ThreadList::next()` lacking an internal bounds check for misuse) are pre-existing API issues and out of scope for this PR.

**How to test the change?**:

Manual validation: run the wallclock profiler with the context-based thread filter disabled and confirm all eligible threads appear in the sampled output rather than every other one. The change is a 1-line deletion inside the `threadFilter->enabled() == false` branch; the filter-enabled path is untouched.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-14332](https://datadoghq.atlassian.net/browse/PROF-14332)

<!-- muse-session:impl-20260422-124935 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code) via muse implement