### PR TITLE
Implement option to use JVMTI/JFR stack-walker for CPU- and wall-clock-profiler

### DIFF
--- a/ddprof-lib/src/main/cpp/arguments.cpp
+++ b/ddprof-lib/src/main/cpp/arguments.cpp
@@ -364,6 +364,21 @@ Error Arguments::parse(const char *args) {
         _remote_symbolication = true;
       }
 
+      CASE("jvmtistacks")
+      if (value != NULL) {
+        switch (value[0]) {
+        case 'y': // yes
+        case 't': // true
+        case '1': // 1
+          _jvmtistacks = true;
+          break;
+        default:
+          _jvmtistacks = false;
+        }
+      } else {
+        _jvmtistacks = true;
+      }
+
       CASE("wallsampler")
       if (value != NULL) {
           switch (value[0]) {

--- a/ddprof-lib/src/main/cpp/arguments.h
+++ b/ddprof-lib/src/main/cpp/arguments.h
@@ -192,6 +192,7 @@ public:
   bool _lightweight;
   bool _enable_method_cleanup;
   bool _remote_symbolication;  // Enable remote symbolication for native frames
+  bool _jvmtistacks;           // Delegate CPU/wall stack walks to HotSpot JFR RequestStackTrace extension
 
   Arguments(bool persistent = false)
       : _buf(NULL),
@@ -227,7 +228,8 @@ public:
         _context_attributes({}),
         _lightweight(false),
         _enable_method_cleanup(true),
-        _remote_symbolication(false) {}
+        _remote_symbolication(false),
+        _jvmtistacks(false) {}
 
   ~Arguments();
 

--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -98,11 +98,17 @@
   X(WALKVM_CONT_ENTRY_NULL,     "walkvm_cont_entry_null")                      \
   X(NATIVE_LIBS_DROPPED, "native_libs_dropped")                                \
   X(SIGACTION_PATCHED_LIBS, "sigaction_patched_libs")                          \
-  X(SIGACTION_INTERCEPTED, "sigaction_intercepted")                             \
-  X(CTIMER_SIGNAL_OWN, "ctimer_signal_own")                                     \
-  X(CTIMER_SIGNAL_FOREIGN, "ctimer_signal_foreign")                             \
-  X(WALLCLOCK_SIGNAL_OWN, "wallclock_signal_own")                               \
-  X(WALLCLOCK_SIGNAL_FOREIGN, "wallclock_signal_foreign")
+  X(SIGACTION_INTERCEPTED, "sigaction_intercepted")                            \
+  X(CTIMER_SIGNAL_OWN, "ctimer_signal_own")                                    \
+  X(CTIMER_SIGNAL_FOREIGN, "ctimer_signal_foreign")                            \
+  X(WALLCLOCK_SIGNAL_OWN, "wallclock_signal_own")                              \
+  X(WALLCLOCK_SIGNAL_FOREIGN, "wallclock_signal_foreign")                      \
+  X(JVMTI_STACKS_INIT_OK, "jvmti_stacks_init_ok")                             \
+  X(JVMTI_STACKS_INIT_FAILED, "jvmti_stacks_init_failed")                     \
+  X(JVMTI_STACKS_REQUESTED, "jvmti_stacks_requested")                         \
+  X(JVMTI_STACKS_FAILED_WRONG_PHASE, "jvmti_stacks_failed_wrong_phase")       \
+  X(JVMTI_STACKS_FAILED_OTHER, "jvmti_stacks_failed_other")                  \
+  X(JVMTI_STACKS_DROPPED_LOCK, "jvmti_stacks_dropped_lock")
 #define X_ENUM(a, b) a,
 typedef enum CounterId : int {
   DD_COUNTER_TABLE(X_ENUM) DD_NUM_COUNTERS

--- a/ddprof-lib/src/main/cpp/ctimer.h
+++ b/ddprof-lib/src/main/cpp/ctimer.h
@@ -25,7 +25,7 @@
 #include <signal.h>
 
 class CTimer : public Engine {
-private:
+protected:
   // This is accessed from signal handlers, so must be async-signal-safe
   static bool _enabled;
   static long _interval;
@@ -38,6 +38,7 @@ private:
   int registerThread(int tid);
   void unregisterThread(int tid);
 
+private:
   // cppcheck-suppress unusedPrivateFunction
   static void signalHandler(int signo, siginfo_t *siginfo, void *ucontext);
 
@@ -60,6 +61,24 @@ public:
   static int getSignal() { return _signal; }
 };
 
+// A CPU-time engine that reuses CTimer's per-thread timer_create / SIGPROF
+// dispatch, but instead of walking the stack in the signal handler delegates
+// the walk to HotSpot's JFR RequestStackTrace JVMTI extension. The sampled
+// event is emitted on our side with only a correlation ID; the JVM writes
+// the stack trace (and its own JFR stack-trace id) into the concurrent JFR
+// recording as jdk.StackTraceRequest. See VM::canRequestStackTrace().
+class CTimerJvmti : public CTimer {
+private:
+  // cppcheck-suppress unusedPrivateFunction
+  static void signalHandler(int signo, siginfo_t *siginfo, void *ucontext);
+
+public:
+  const char *name() { return "CTimerJvmti"; }
+
+  Error check(Arguments &args);
+  Error start(Arguments &args);
+};
+
 #else
 
 class CTimer : public Engine {
@@ -73,6 +92,19 @@ public:
   }
 
   static bool supported() { return false; }
+};
+
+class CTimerJvmti : public Engine {
+public:
+  const char *name() { return "CTimerJvmti"; }
+
+  Error check(Arguments &args) {
+    return Error("CTimerJvmti is not supported on this platform");
+  }
+
+  Error start(Arguments &args) {
+    return Error("CTimerJvmti is not supported on this platform");
+  }
 };
 
 #endif // __linux__

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -163,15 +163,13 @@ Error CTimer::start(Arguments &args) {
 
   OS::installSignalHandler(_signal, signalHandler);
 
-  // Register all existing threads
-  Error result = Error::OK;
+  // Register all existing threads. Individual failures are benign — a thread
+  // may exit between listThreads() and registerThread(), and new threads
+  // will register themselves on creation. check() already validated that the
+  // timer mechanism works on this system.
   ThreadList *thread_list = OS::listThreads();
-  while (thread_list->hasNext()) { 
-    int tid = thread_list->next();
-    int err = registerThread(tid);
-    if (err != 0) {
-      result = Error("Failed to register thread");
-    }
+  while (thread_list->hasNext()) {
+    registerThread(thread_list->next());
   }
   delete thread_list;
 
@@ -182,6 +180,71 @@ void CTimer::stop() {
   for (int i = 0; i < _max_timers; i++) {
     unregisterThread(i);
   }
+}
+
+Error CTimerJvmti::check(Arguments &args) {
+  if (!VM::canRequestStackTrace()) {
+    return Error("HotSpot RequestStackTrace JVMTI extension not available");
+  }
+  return CTimer::check(args);
+}
+
+Error CTimerJvmti::start(Arguments &args) {
+  if (!VM::canRequestStackTrace()) {
+    return Error("HotSpot RequestStackTrace JVMTI extension not available");
+  }
+  Error result = CTimer::start(args);
+  if (result) return result;
+  // Override the signal handler installed by CTimer::start with our own,
+  // which delegates stack walking to the HotSpot JFR extension.
+  OS::installSignalHandler(_signal, CTimerJvmti::signalHandler);
+  return Error::OK;
+}
+
+void CTimerJvmti::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
+  if (!OS::shouldProcessSignal(siginfo, SI_TIMER, SignalCookie::cpu())) {
+    Counters::increment(CTIMER_SIGNAL_FOREIGN);
+    OS::forwardForeignSignal(signo, siginfo, ucontext);
+    return;
+  }
+  Counters::increment(CTIMER_SIGNAL_OWN);
+
+  CriticalSection cs;
+  if (!cs.entered()) {
+    return;
+  }
+  int saved_errno = errno;
+  if (!__atomic_load_n(&_enabled, __ATOMIC_ACQUIRE)) {
+    errno = saved_errno;
+    return;
+  }
+  int tid = 0;
+  ProfiledThread *current = ProfiledThread::currentSignalSafe();
+  assert(current == nullptr || !current->isDeepCrashHandler());
+  if (current != nullptr && JVMThread::isInitialized() && JVMThread::current() == nullptr
+      && current->inInitWindow()) {
+    current->tickInitWindow();
+    errno = saved_errno;
+    return;
+  }
+  if (current != NULL) {
+    current->noteCPUSample(Profiler::instance()->recordingEpoch());
+    tid = current->tid();
+  } else {
+    tid = OS::threadId();
+  }
+  Shims::instance().setSighandlerTid(tid);
+
+  ExecutionEvent event;
+  event._execution_mode = getThreadExecutionMode();
+  // Opted into JVMTI delegation; drop the sample if the JVM rejects the
+  // request (WRONG_PHASE if JFR is not recording, NOT_AVAILABLE if
+  // jdk.StackTraceRequest is disabled). recordSampleDelegated() bumps the
+  // failure counters; there is no fallback to ASGCT in this engine.
+  Profiler::instance()->recordSampleDelegated(ucontext, _interval, tid,
+                                               BCI_CPU, &event);
+  Shims::instance().setSighandlerTid(-1);
+  errno = saved_errno;
 }
 
 void CTimer::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1520,6 +1520,7 @@ void Recording::writeEventSizePrefix(Buffer *buf, int start) {
 }
 
 void Recording::recordExecutionSample(Buffer *buf, int tid, u64 call_trace_id,
+                                      u64 correlation_id,
                                       ExecutionEvent *event) {
   int start = buf->skip(1);
   buf->putVar64(T_EXECUTION_SAMPLE);
@@ -1529,12 +1530,14 @@ void Recording::recordExecutionSample(Buffer *buf, int tid, u64 call_trace_id,
   buf->put8(static_cast<int>(event->_thread_state));
   buf->put8(static_cast<int>(event->_execution_mode));
   buf->putVar64(event->_weight);
+  buf->putVar64(correlation_id);
   writeCurrentContext(buf);
   writeEventSizePrefix(buf, start);
   flushIfNeeded(buf);
 }
 
 void Recording::recordMethodSample(Buffer *buf, int tid, u64 call_trace_id,
+                                   u64 correlation_id,
                                    ExecutionEvent *event) {
   int start = buf->skip(1);
   buf->putVar64(T_METHOD_SAMPLE);
@@ -1544,6 +1547,7 @@ void Recording::recordMethodSample(Buffer *buf, int tid, u64 call_trace_id,
   buf->put8(static_cast<int>(event->_thread_state));
   buf->put8(static_cast<int>(event->_execution_mode));
   buf->putVar64(event->_weight);
+  buf->putVar64(correlation_id);
   writeCurrentContext(buf);
   writeEventSizePrefix(buf, start);
   flushIfNeeded(buf);
@@ -1848,11 +1852,11 @@ void FlightRecorder::recordEvent(int lock_index, int tid, u64 call_trace_id,
       RecordingBuffer *buf = rec->buffer(lock_index);
       switch (event_type) {
       case BCI_CPU:
-          rec->recordExecutionSample(buf, tid, call_trace_id,
+          rec->recordExecutionSample(buf, tid, call_trace_id, 0,
                                      (ExecutionEvent *)event);
           break;
         case BCI_WALL:
-          rec->recordMethodSample(buf, tid, call_trace_id,
+          rec->recordMethodSample(buf, tid, call_trace_id, 0,
                                   (ExecutionEvent *)event);
           break;
         case BCI_ALLOC:
@@ -1875,6 +1879,32 @@ void FlightRecorder::recordEvent(int lock_index, int tid, u64 call_trace_id,
         rec->flushIfNeeded(buf);
         rec->addThread(lock_index, tid);
       }
+  }
+}
+
+void FlightRecorder::recordEventDelegated(int lock_index, int tid,
+                                          u64 correlation_id, int event_type,
+                                          Event *event) {
+  OptionalSharedLockGuard locker(&_rec_lock);
+  if (locker.ownsLock()) {
+    Recording* rec = _rec;
+    if (rec != nullptr) {
+      RecordingBuffer *buf = rec->buffer(lock_index);
+      switch (event_type) {
+        case BCI_CPU:
+          rec->recordExecutionSample(buf, tid, 0, correlation_id,
+                                     (ExecutionEvent *)event);
+          break;
+        case BCI_WALL:
+          rec->recordMethodSample(buf, tid, 0, correlation_id,
+                                  (ExecutionEvent *)event);
+          break;
+        default:
+          // Delegation is only wired for CPU/wall samples in v1.
+          break;
+      }
+      rec->addThread(lock_index, tid);
+    }
   }
 }
 

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -276,9 +276,9 @@ public:
   void writeCurrentContext(Buffer *buf);
 
   void recordExecutionSample(Buffer *buf, int tid, u64 call_trace_id,
-                             ExecutionEvent *event);
+                             u64 correlation_id, ExecutionEvent *event);
   void recordMethodSample(Buffer *buf, int tid, u64 call_trace_id,
-                          ExecutionEvent *event);
+                          u64 correlation_id, ExecutionEvent *event);
   void recordWallClockEpoch(Buffer *buf, WallClockEpochEvent *event);
   void recordTraceRoot(Buffer *buf, int tid, TraceRootEvent *event);
   void recordQueueTime(Buffer *buf, int tid, QueueTimeEvent *event);
@@ -355,6 +355,13 @@ public:
 
   void recordEvent(int lock_index, int tid, u64 call_trace_id, int event_type,
                    Event *event);
+
+  // Emit a BCI_CPU / BCI_WALL sample with no stack-trace attached to our
+  // recording. `correlation_id` is the same jlong passed to the HotSpot
+  // RequestStackTrace extension so downstream tooling can join our event with
+  // the JVM-emitted jdk.StackTraceRequest.
+  void recordEventDelegated(int lock_index, int tid, u64 correlation_id,
+                            int event_type, Event *event);
 
   void recordLog(LogLevel level, const char *message, size_t len);
 

--- a/ddprof-lib/src/main/cpp/hotspot/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/hotspot/vmStructs.h
@@ -300,7 +300,7 @@ typedef void* address;
         field(_flag_type_offset, offset, MATCH_SYMBOLS("_type", "type"))                                            \
     type_end()                                                                                                      \
     type_begin(VMOop, MATCH_SYMBOLS("oopDesc"))                                                                     \
-        field(_oop_klass_offset, offset, MATCH_SYMBOLS("_metadata._klass"))                                         \
+        field(_oop_klass_offset, offset, MATCH_SYMBOLS("_metadata._klass", "_compressed_klass"))                    \
     type_end()                                                                                                      \
     type_begin(VMUniverse, MATCH_SYMBOLS("Universe", "CompressedKlassPointers"))                                    \
         field(_narrow_klass_base_addr, address, MATCH_SYMBOLS("_narrow_klass._base", "_base"))                      \

--- a/ddprof-lib/src/main/cpp/itimer.cpp
+++ b/ddprof-lib/src/main/cpp/itimer.cpp
@@ -17,6 +17,7 @@
 
 #include "itimer.h"
 #include "debugSupport.h"
+#include "jvmThread.h"
 #include "os.h"
 #include "profiler.h"
 #include "stackWalker.h"
@@ -95,4 +96,86 @@ Error ITimer::start(Arguments &args) {
 void ITimer::stop() {
   struct itimerval tv = {{0, 0}, {0, 0}};
   setitimer(ITIMER_PROF, &tv, NULL);
+}
+
+volatile bool ITimerJvmti::_enabled = false;
+long ITimerJvmti::_interval = 0;
+
+void ITimerJvmti::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
+  CriticalSection cs;
+  if (!cs.entered()) {
+    return;
+  }
+  int saved_errno = errno;
+  if (!__atomic_load_n(&_enabled, __ATOMIC_ACQUIRE)) {
+    errno = saved_errno;
+    return;
+  }
+  ProfiledThread *current = ProfiledThread::currentSignalSafe();
+  if (current != nullptr && JVMThread::isInitialized() && JVMThread::current() == nullptr
+      && current->inInitWindow()) {
+    current->tickInitWindow();
+    errno = saved_errno;
+    return;
+  }
+  int tid = current ? current->tid() : OS::threadId();
+  if (current) {
+    current->noteCPUSample(Profiler::instance()->recordingEpoch());
+  }
+  Shims::instance().setSighandlerTid(tid);
+
+  ExecutionEvent event;
+  event._execution_mode = getThreadExecutionMode();
+  // setitimer(ITIMER_PROF) delivers SIGPROF to an arbitrary thread chosen by
+  // the OS, so ucontext may be from a JVM-internal thread.  Pass nullptr to
+  // force the JVM into safepoint-based stack walking instead.
+  Profiler::instance()->recordSampleDelegated(nullptr, _interval, tid,
+                                               BCI_CPU, &event);
+  Shims::instance().setSighandlerTid(-1);
+  errno = saved_errno;
+}
+
+Error ITimerJvmti::check(Arguments &args) {
+  if (!VM::canRequestStackTrace()) {
+    return Error("HotSpot RequestStackTrace JVMTI extension not available");
+  }
+
+  struct sigaction oldsa;
+  struct sigaction ign = {};
+  sigemptyset(&ign.sa_mask);
+  ign.sa_handler = SIG_IGN;
+  sigaction(SIGPROF, &ign, &oldsa);
+
+  struct itimerval tv_on = {{1, 0}, {1, 0}};
+  Error err = setitimer(ITIMER_PROF, &tv_on, nullptr) != 0
+      ? Error("ITIMER_PROF is not supported on this system")
+      : Error::OK;
+  struct itimerval tv_off = {{0, 0}, {0, 0}};
+  setitimer(ITIMER_PROF, &tv_off, nullptr);
+
+  sigaction(SIGPROF, &oldsa, nullptr);
+  return err;
+}
+
+Error ITimerJvmti::start(Arguments &args) {
+  if (args._interval < 0) {
+    return Error("interval must be positive");
+  }
+  _interval = args.cpuSamplerInterval();
+
+  OS::installSignalHandler(SIGPROF, signalHandler);
+
+  time_t sec = _interval / 1000000000;
+  suseconds_t usec = (_interval % 1000000000) / 1000;
+  struct itimerval tv = {{sec, usec}, {sec, usec}};
+  if (setitimer(ITIMER_PROF, &tv, nullptr) != 0) {
+    return Error("ITIMER_PROF is not supported on this system");
+  }
+  return Error::OK;
+}
+
+void ITimerJvmti::stop() {
+  struct itimerval tv = {};
+  setitimer(ITIMER_PROF, &tv, nullptr);
+  OS::installSignalHandler(SIGPROF, nullptr, SIG_IGN);
 }

--- a/ddprof-lib/src/main/cpp/itimer.h
+++ b/ddprof-lib/src/main/cpp/itimer.h
@@ -42,4 +42,32 @@ public:
   inline void enableEvents(bool enabled) { _enabled = enabled; }
 };
 
+// CPU-time engine identical to ITimer in its timer mechanism (process-wide
+// setitimer(ITIMER_PROF) / SIGPROF) but delegates stack collection to the
+// HotSpot JFR RequestStackTrace JVMTI extension instead of ASGCT.  Used on
+// platforms where per-thread CPU timers are unavailable (e.g. macOS), as a
+// macOS-compatible alternative to CTimerJvmti.  Because SIGPROF may land on
+// any thread, nullptr is passed as ucontext so the JVM uses safepoint-based
+// stack walking rather than relying on the signal-frame PC.
+class ITimerJvmti : public Engine {
+private:
+  static volatile bool _enabled;
+  static long _interval;
+
+  static void signalHandler(int signo, siginfo_t *siginfo, void *ucontext);
+
+public:
+  const char *units() { return "ns"; }
+  const char *name()  { return "ITimerJvmti"; }
+  long interval() const { return _interval; }
+
+  Error check(Arguments &args);
+  Error start(Arguments &args);
+  void  stop();
+
+  inline void enableEvents(bool enabled) {
+    __atomic_store_n(&_enabled, enabled, __ATOMIC_RELEASE);
+  }
+};
+
 #endif // _ITIMER_H

--- a/ddprof-lib/src/main/cpp/jfrMetadata.cpp
+++ b/ddprof-lib/src/main/cpp/jfrMetadata.cpp
@@ -124,6 +124,7 @@ void JfrMetadata::initialize(
                   << field("state", T_THREAD_STATE, "Thread State", F_CPOOL)
                   << field("mode", T_EXECUTION_MODE, "Execution Mode", F_CPOOL)
                   << field("weight", T_LONG, "Sample weight")
+                  << field("correlationId", T_LONG, "Async Stack Trace Correlation ID")
                   << field("spanId", T_LONG, "Span ID")
                   << field("localRootSpanId", T_LONG, "Local Root Span ID") ||
               contextAttributes)
@@ -137,6 +138,7 @@ void JfrMetadata::initialize(
                   << field("state", T_THREAD_STATE, "Thread State", F_CPOOL)
                   << field("mode", T_EXECUTION_MODE, "Execution Mode", F_CPOOL)
                   << field("weight", T_LONG, "Sample weight")
+                  << field("correlationId", T_LONG, "Async Stack Trace Correlation ID")
                   << field("spanId", T_LONG, "Span ID")
                   << field("localRootSpanId", T_LONG, "Local Root Span ID") ||
               contextAttributes)

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -63,9 +63,12 @@ static Engine noop_engine;
 static MallocTracer malloc_tracer;
 static PerfEvents perf_events;
 static WallClockASGCT wall_asgct_engine;
+static WallClockJvmti wall_jvmti_engine;
 static J9WallClock j9_engine;
 static ITimer itimer;
+static ITimerJvmti itimer_jvmti;
 static CTimer ctimer;
+static CTimerJvmti ctimer_jvmti;
 
 void Profiler::onThreadStart(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread) {
   ProfiledThread::initCurrentThread();
@@ -595,6 +598,43 @@ void Profiler::recordSample(void *ucontext, u64 counter, int tid,
   _locks[lock_index].unlock();
 }
 
+void Profiler::recordSampleDelegated(void *ucontext, u64 weight, int tid,
+                                     jint event_type, Event *event) {
+  if (!VM::canRequestStackTrace()) {
+    return;
+  }
+
+  // Reserve the correlation ID up-front so we can pass the same value to the
+  // JVM (as user_data) and to our own event.
+  u64 correlation_id = atomicIncRelaxed(_sample_seq);
+
+  Counters::increment(JVMTI_STACKS_REQUESTED);
+  jvmtiError rc = VM::requestStackTrace(ucontext, (jlong)correlation_id);
+  if (rc != JVMTI_ERROR_NONE) {
+    if (rc == JVMTI_ERROR_WRONG_PHASE) {
+      Counters::increment(JVMTI_STACKS_FAILED_WRONG_PHASE);
+    } else {
+      Counters::increment(JVMTI_STACKS_FAILED_OTHER);
+    }
+    return;
+  }
+
+  atomicIncRelaxed(_total_samples);
+  u32 lock_index = getLockIndex(tid);
+  if (!_locks[lock_index].tryLock() &&
+      !_locks[lock_index = (lock_index + 1) % CONCURRENCY_LEVEL].tryLock() &&
+      !_locks[lock_index = (lock_index + 2) % CONCURRENCY_LEVEL].tryLock()) {
+    atomicIncRelaxed(_failures[-ticks_skipped]);
+    Counters::increment(JVMTI_STACKS_DROPPED_LOCK);
+    // The JVM-side stack trace request is already in flight; we just drop our
+    // sample event. The dangling StackTraceRequest entry in the JVM recording
+    // will simply have no matching datadog event, which is harmless.
+    return;
+  }
+
+  _jfr.recordEventDelegated(lock_index, tid, correlation_id, event_type, event);
+  _locks[lock_index].unlock();
+}
 
 void Profiler::recordWallClockEpoch(int tid, WallClockEpochEvent *event) {
   u32 lock_index = getLockIndex(tid);
@@ -950,6 +990,21 @@ Engine *Profiler::selectCpuEngine(Arguments &args) {
       }
       TEST_LOG("J9[cpu]=asgct");
     }
+    // Prefer the JVMTI JFR-delegated engine when the HotSpot extension is
+    // available and the user opted into jvmtistacks.  On Linux, CTimerJvmti
+    // uses per-thread CPU timers.  On other platforms (e.g. macOS) it is not
+    // supported, so fall back to ITimerJvmti which uses setitimer(ITIMER_PROF).
+    if (args._jvmtistacks) {
+      if (!ctimer_jvmti.check(args)) {
+        TEST_LOG("HS[cpu]=ctimer_jvmti");
+        return &ctimer_jvmti;
+      }
+      if (!itimer_jvmti.check(args)) {
+        TEST_LOG("HS[cpu]=itimer_jvmti");
+        return &itimer_jvmti;
+      }
+      Log::warn("jvmtistacks requested but no JVMTI CPU engine is available; falling back to ASGCT");
+    }
     return !ctimer.check(args)
                ? (Engine *)&ctimer
                : (!perf_events.check(args) ? (Engine *)&perf_events
@@ -984,6 +1039,11 @@ Engine *Profiler::selectWallEngine(Arguments &args) {
       TEST_LOG("J9[wall]=asgct");
       return (Engine *)&wall_asgct_engine;
     }
+  }
+  // jvmtistacks overrides _wallclock_sampler when the HotSpot extension is available.
+  if (args._jvmtistacks && VM::canRequestStackTrace()) {
+    TEST_LOG("HS[wall]=jvmti");
+    return (Engine *)&wall_jvmti_engine;
   }
   switch (args._wallclock_sampler) {
         case JVMTI:
@@ -1075,7 +1135,9 @@ Error Profiler::start(Arguments &args, bool reset) {
   }
 
   if (reset || _start_time == 0) {
-    // Reset counters
+    // Reset counters. _sample_seq is intentionally not reset: it is a
+    // monotonically increasing uniqueness generator for correlation IDs and
+    // must not repeat values across recording sessions.
     _total_samples = 0;
     memset(_failures, 0, sizeof(_failures));
 
@@ -1295,6 +1357,44 @@ Error Profiler::stop() {
   switchThreadEvents(JVMTI_DISABLE);
   updateJavaThreadNames();
   updateNativeThreadNames();
+
+  // If jvmtistacks delegation was used this recording, surface likely
+  // misconfigurations. The JVM returns WRONG_PHASE when JFR is not recording
+  // and NOT_AVAILABLE when JFR is recording but the StackTraceRequest event is
+  // disabled. If the request was accepted the JVM will have written the
+  // stack trace, so no warning is needed.
+  if (VM::canRequestStackTrace()) {
+    long long requested =
+        Counters::getCounter(JVMTI_STACKS_REQUESTED);
+    long long wrong_phase =
+        Counters::getCounter(JVMTI_STACKS_FAILED_WRONG_PHASE);
+    long long other =
+        Counters::getCounter(JVMTI_STACKS_FAILED_OTHER);
+    long long dropped_lock =
+        Counters::getCounter(JVMTI_STACKS_DROPPED_LOCK);
+    if (requested > 0 && wrong_phase * 2 >= requested) {
+      fprintf(stderr,
+              "[java-profiler] jvmtistacks: %lld of %lld stack-trace requests "
+              "were rejected with WRONG_PHASE, so no async stack traces were "
+              "emitted by the JVM. Start JFR (e.g. "
+              "-XX:StartFlightRecording=...) before or as the profiler starts.\n",
+              wrong_phase, requested);
+    } else if (requested > 0 && other * 2 >= requested) {
+      fprintf(stderr,
+              "[java-profiler] jvmtistacks: %lld of %lld stack-trace requests "
+              "were rejected with NOT_AVAILABLE. The jdk.StackTraceRequest event "
+              "is likely disabled; enable it in the JFR configuration, e.g. "
+              "-XX:StartFlightRecording=...,+jdk.StackTraceRequest#enabled=true.\n",
+              other, requested);
+    }
+    if (dropped_lock > 0) {
+      fprintf(stderr,
+              "[java-profiler] jvmtistacks: %lld of %lld stack-trace requests "
+              "were dropped due to lock contention; the corresponding "
+              "jdk.StackTraceRequest events will have no matching profiler event.\n",
+              dropped_lock, requested);
+    }
+  }
 
   // writing these out before stopping the JFR recording allows to report the
   // correct counts in the recording

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -97,6 +97,7 @@ private:
   void *_timer_id;
 
   volatile u64 _total_samples;
+  alignas(DEFAULT_CACHE_LINE_SIZE) volatile u64 _sample_seq;
   u64 _failures[ASGCT_FAILURE_TYPES];
 
   SpinLock _class_map_lock;
@@ -155,7 +156,7 @@ public:
         _call_trace_storage(), _jfr(), _cpu_engine(NULL), _wall_engine(NULL),
         _alloc_engine(NULL), _event_mask(0),
         _start_time(0), _stop_time(0), _epoch(0), _timer_id(NULL),
-        _total_samples(0), _failures(), _class_map_lock(),
+        _total_samples(0), _sample_seq(0), _failures(), _class_map_lock(),
         _max_stack_depth(0), _features(), _safe_mode(0), _cstack(CSTACK_NO),
         _thread_events_state(JVMTI_DISABLE), _libs(Libraries::instance()),
         _num_context_attributes(0), _omit_stacktraces(false),
@@ -331,6 +332,13 @@ public:
                          ASGCT_CallFrame *frames, int lock_index);
   void recordSample(void *ucontext, u64 weight, int tid, jint event_type,
                     u64 call_trace_id, Event *event);
+  // Delegated sample path: stack-walking is performed by the HotSpot JFR
+  // RequestStackTrace extension (the JVM emits the stack trace into its own
+  // JFR recording). We only emit the CPU/wall sample event with no
+  // stack-trace reference, tagged by the correlation ID we passed to
+  // RequestStackTrace as user_data.
+  void recordSampleDelegated(void *ucontext, u64 weight, int tid,
+                             jint event_type, Event *event);
   u64 recordJVMTISample(u64 weight, int tid, jthread thread, jint event_type, Event *event, bool deferred);
   void recordDeferredSample(int tid, u64 call_trace_id, jint event_type, Event *event);
   void recordExternalSample(u64 weight, int tid, int num_frames,

--- a/ddprof-lib/src/main/cpp/vmEntry.cpp
+++ b/ddprof-lib/src/main/cpp/vmEntry.cpp
@@ -8,6 +8,7 @@
 #include "vmEntry.h"
 #include "arguments.h"
 #include "context.h"
+#include "counters.h"
 #include "j9/j9Support.h"
 #include "jniHelper.h"
 #include "jvmThread.h"
@@ -41,6 +42,9 @@ bool VM::_zing = false;
 bool VM::_can_sample_objects = false;
 bool VM::_can_intercept_binding = false;
 bool VM::_is_adaptive_gc_boundary_flag_set = false;
+
+jvmtiExtensionFunction VM::_request_stack_trace = nullptr;
+jvmtiExtensionFunction VM::_init_request_stack_trace = nullptr;
 
 jvmtiError(JNICALL *VM::_orig_RedefineClasses)(jvmtiEnv *, jint,
                                                const jvmtiClassDefinition *);
@@ -375,6 +379,56 @@ bool VM::initLibrary(JavaVM *vm) {
   return true;
 }
 
+void VM::probeJFRRequestStackTrace() {
+  jint ext_count = 0;
+  jvmtiExtensionFunctionInfo *ext_functions = nullptr;
+  if (_jvmti->GetExtensionFunctions(&ext_count, &ext_functions) == 0) {
+    for (jint i = 0; i < ext_count; i++) {
+      if (strcmp(ext_functions[i].id,
+                 "com.sun.hotspot.functions.RequestStackTrace") == 0) {
+        __atomic_store_n(&_request_stack_trace, ext_functions[i].func, __ATOMIC_RELEASE);
+      } else if (strcmp(ext_functions[i].id,
+                        "com.sun.hotspot.functions.InitializeRequestStackTrace") == 0) {
+        _init_request_stack_trace = ext_functions[i].func;
+      }
+      for (jint j = 0; j < ext_functions[i].param_count; j++) {
+        _jvmti->Deallocate((unsigned char *)ext_functions[i].params[j].name);
+      }
+      _jvmti->Deallocate((unsigned char *)ext_functions[i].params);
+      _jvmti->Deallocate((unsigned char *)ext_functions[i].errors);
+      _jvmti->Deallocate((unsigned char *)ext_functions[i].id);
+      _jvmti->Deallocate((unsigned char *)ext_functions[i].short_description);
+    }
+    _jvmti->Deallocate((unsigned char *)ext_functions);
+  }
+
+  if (_agent_args._jvmtistacks) {
+    if (_request_stack_trace == nullptr || _init_request_stack_trace == nullptr) {
+      Log::warn("jvmtistacks requested but HotSpot RequestStackTrace extension "
+                "is not available on this JVM");
+      Counters::increment(JVMTI_STACKS_INIT_FAILED);
+    } else {
+      initializeRequestStackTrace();
+    }
+  }
+}
+
+// Must not be called from a signal handler — invokes JVMTI which is not async-signal-safe.
+bool VM::initializeRequestStackTrace() {
+  if (__atomic_load_n(&_request_stack_trace, __ATOMIC_RELAXED) == nullptr || _init_request_stack_trace == nullptr) {
+    return false;
+  }
+  jvmtiError rc = _init_request_stack_trace(_jvmti);
+  if (rc == JVMTI_ERROR_NONE) {
+    Counters::increment(JVMTI_STACKS_INIT_OK);
+    return true;
+  }
+  Log::warn("InitializeRequestStackTrace failed: %d", rc);
+  __atomic_store_n(&_request_stack_trace, (jvmtiExtensionFunction)nullptr, __ATOMIC_RELEASE);
+  Counters::increment(JVMTI_STACKS_INIT_FAILED);
+  return false;
+}
+
 bool VM::initProfilerBridge(JavaVM *vm, bool attach) {
   TEST_LOG("VM::initProfilerBridge");
   if (!initShared(vm)) {
@@ -425,6 +479,10 @@ bool VM::initProfilerBridge(JavaVM *vm, bool attach) {
   capabilities.can_tag_objects = 1;
 
   _jvmti->AddCapabilities(&capabilities);
+
+  if (_hotspot) {
+    probeJFRRequestStackTrace();
+  }
 
   jvmtiEventCallbacks callbacks = {0};
   callbacks.VMInit = VMInit;

--- a/ddprof-lib/src/main/cpp/vmEntry.h
+++ b/ddprof-lib/src/main/cpp/vmEntry.h
@@ -128,6 +128,11 @@ private:
   static bool _can_intercept_binding;
   static bool _is_adaptive_gc_boundary_flag_set;
 
+  // HotSpot JFR async stack-trace extension (optional, JDK 27+).
+  // Null until InitializeRequestStackTrace succeeds; published with RELEASE.
+  static jvmtiExtensionFunction _request_stack_trace;
+  static jvmtiExtensionFunction _init_request_stack_trace;
+
   static jvmtiError(JNICALL *_orig_RedefineClasses)(
       jvmtiEnv *, jint, const jvmtiClassDefinition *);
   static jvmtiError(JNICALL *_orig_RetransformClasses)(jvmtiEnv *, jint,
@@ -140,6 +145,7 @@ private:
   static void loadAllMethodIDs(jvmtiEnv *jvmti, JNIEnv *jni);
 
   static bool initShared(JavaVM *vm);
+  static void probeJFRRequestStackTrace();
 
   static CodeCache* openJvmLibrary();
 
@@ -188,6 +194,19 @@ public:
 
   static bool isUseAdaptiveGCBoundarySet() {
     return _is_adaptive_gc_boundary_flag_set;
+  }
+
+  static bool canRequestStackTrace() {
+    return __atomic_load_n(&_request_stack_trace, __ATOMIC_ACQUIRE) != nullptr;
+  }
+
+  // Must not be called from a signal handler — invokes JVMTI which is not async-signal-safe.
+  static bool initializeRequestStackTrace();
+
+  static jvmtiError requestStackTrace(void* ucontext, jlong user_data) {
+    jvmtiExtensionFunction fn = __atomic_load_n(&_request_stack_trace, __ATOMIC_ACQUIRE);
+    if (!fn) return JVMTI_ERROR_NOT_AVAILABLE;
+    return fn(_jvmti, (jthread)nullptr, ucontext, user_data);
   }
 
   static void JNICALL VMInit(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread);

--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -220,3 +220,124 @@ void WallClockASGCT::timerLoop() {
 
     timerLoopCommon<int>(collectThreads, sampleThreads, doNothing, _reservoir_size, _interval);
 }
+
+// WallClockJvmti: mirrors WallClockASGCT's dispatch, but the signal handler
+// delegates the stack walk to HotSpot's JFR RequestStackTrace JVMTI extension
+// instead of invoking ASGCT. Used only when VM::canRequestStackTrace() is true
+// and the profiler has opted into jvmtistacks.
+
+bool WallClockJvmti::inSyscall(void *ucontext) {
+  StackFrame frame(ucontext);
+  uintptr_t pc = frame.pc();
+
+  if (StackFrame::isSyscall((instruction_t *)pc)) {
+    return true;
+  }
+
+  uintptr_t prev_pc = pc - SYSCALL_SIZE;
+  if ((pc & 0xfff) >= SYSCALL_SIZE ||
+      Libraries::instance()->findLibraryByAddress((instruction_t *)prev_pc) !=
+          NULL) {
+    if (StackFrame::isSyscall((instruction_t *)prev_pc) &&
+        frame.checkInterruptedSyscall()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void WallClockJvmti::sharedSignalHandler(int signo, siginfo_t *siginfo,
+                                         void *ucontext) {
+  WallClockJvmti *engine =
+      reinterpret_cast<WallClockJvmti *>(Profiler::instance()->wallEngine());
+  if (signo == SIGVTALRM) {
+    engine->signalHandler(signo, siginfo, ucontext, engine->_interval);
+  }
+}
+
+void WallClockJvmti::signalHandler(int signo, siginfo_t *siginfo,
+                                   void *ucontext, u64 last_sample) {
+  CriticalSection cs;
+  if (!cs.entered()) {
+    return;
+  }
+  int saved_errno = errno;
+  ProfiledThread *current = ProfiledThread::currentSignalSafe();
+  if (current != nullptr && JVMThread::isInitialized() && JVMThread::current() == nullptr
+      && current->inInitWindow()) {
+    current->tickInitWindow();
+    errno = saved_errno;
+    return;
+  }
+  int tid = current != NULL ? current->tid() : OS::threadId();
+  Shims::instance().setSighandlerTid(tid);
+
+  ExecutionEvent event;
+  OSThreadState state = getOSThreadState();
+  ExecutionMode mode = getThreadExecutionMode();
+  if (state == OSThreadState::UNKNOWN) {
+    if (inSyscall(ucontext)) {
+      state = OSThreadState::SYSCALL;
+      mode = ExecutionMode::SYSCALL;
+    } else {
+      state = OSThreadState::RUNNABLE;
+    }
+  }
+  event._thread_state = state;
+  event._execution_mode = mode;
+  event._weight = 1;
+  // Pass nullptr ucontext so the JVM uses safepoint-based stack walking.
+  // Passing the signal-frame PC causes the extension to reject samples where
+  // the thread is currently inside JVM-internal (non-Java) code.
+  Profiler::instance()->recordSampleDelegated(nullptr, last_sample, tid,
+                                               BCI_WALL, &event);
+  Shims::instance().setSighandlerTid(-1);
+  errno = saved_errno;
+}
+
+void WallClockJvmti::initialize(Arguments &args) {
+  // Caller must have verified VM::canRequestStackTrace() before selecting
+  // this engine; see Profiler::selectWallEngine().
+  OS::installSignalHandler(SIGVTALRM, sharedSignalHandler);
+}
+
+void WallClockJvmti::timerLoop() {
+  auto collectThreads = [&](std::vector<int> &tids) {
+    if (Profiler::instance()->threadFilter()->enabled()) {
+      Profiler::instance()->threadFilter()->collect(tids);
+    } else {
+      ThreadList *thread_list = OS::listThreads();
+      while (thread_list->hasNext()) {
+        int tid = thread_list->next();
+        if (tid != OS::threadId()) {
+          tids.push_back(tid);
+        }
+      }
+      delete thread_list;
+    }
+  };
+
+  auto sampleThreads = [&](int tid, int &num_failures,
+                           int &threads_already_exited, int &permission_denied) {
+    if (!OS::sendSignalToThread(tid, SIGVTALRM)) {
+      num_failures++;
+      if (errno != 0) {
+        if (errno == ESRCH) {
+          threads_already_exited++;
+        } else if (errno == EPERM) {
+          permission_denied++;
+        } else {
+          Log::debug("unexpected error %s", strerror(errno));
+        }
+      }
+      return false;
+    }
+    return true;
+  };
+
+  auto doNothing = []() {};
+
+  timerLoopCommon<int>(collectThreads, sampleThreads, doNothing,
+                      _reservoir_size, _interval);
+}

--- a/ddprof-lib/src/main/cpp/wallClock.h
+++ b/ddprof-lib/src/main/cpp/wallClock.h
@@ -157,4 +157,25 @@ class WallClockASGCT : public BaseWallClock {
     }
 };
 
+// Wall-clock engine that uses BaseWallClock's pthread reservoir sampling loop
+// to signal target threads, but in its signal handler delegates the stack walk
+// to HotSpot's JFR RequestStackTrace JVMTI extension. Requires
+// VM::canRequestStackTrace().
+class WallClockJvmti : public BaseWallClock {
+  private:
+    static bool inSyscall(void* ucontext);
+
+    static void sharedSignalHandler(int signo, siginfo_t* siginfo, void* ucontext);
+    void signalHandler(int signo, siginfo_t* siginfo, void* ucontext, u64 last_sample);
+
+    void initialize(Arguments& args) override;
+    void timerLoop() override;
+
+  public:
+    WallClockJvmti() : BaseWallClock() {}
+    const char* name() override {
+        return "WallClock (JVMTI)";
+    }
+};
+
 #endif // _WALLCLOCK_H


### PR DESCRIPTION
**What does this PR do?**:

We are working to contribute a JVMTI/JFR-based stack-walker into upstream JDK (see [JEP Draft: Native Profiler Hook for Unbiased Stack Traces (Experimental)](https://bugs.openjdk.org/browse/JDK-8380294)). This feature adds a JVMTI extension to trigger a stack-trace to be emitted via the JVM's JFR. This PR wires that feature to our CPU and wall-clock profilers. When the feature is enabled, and the JVMTI extension is detected, it will prefer that over the other stack-walkers.

**Motivation**:

I would like to be able to test the new JDK feature end-to-end. Eventually, when the feature is released in upstream JDK, it will be ready to go on our side.

**Additional Notes**:

The feature needs to be enabled by the jvmtistacks option.

The stack-traces will be emitted via the JVM's JFR stream. We merge the JVM JFR with the agent's JFR, the backend will receive the combined JFR. I'll post a separate PR in the backend which implements the necessary post-processing.

I also made a small unrelated addition to vmStructs to deal with removed uncompressed class-pointers support in JDK 27.

**How to test the change?**:

I manually verified that the CPU and wall-clock profiler produce the desired AsyncStackTrace events.

<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [x] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-14350]

Unsure? Have a question? Request a review!


[PROF-14350]: https://datadoghq.atlassian.net/browse/PROF-14350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ