### PR TITLE
fix(profiler): line-number-table UAF, musl/aarch64 wrapper canary, and SIGVTALRM teardown race

### DIFF
--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
@@ -204,6 +204,9 @@ class GtestTaskBuilder(
             args.add("-D__musl__")
         }
 
+        // Mark unit-test builds so test-only production APIs are compiled in.
+        args.add("-DUNIT_TEST")
+
         return args
     }
 }

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -45,23 +45,11 @@ static const char *const SETTING_RING[] = {NULL, "kernel", "user", "any"};
 static const char *const SETTING_CSTACK[] = {NULL, "no", "fp", "dwarf", "lbr"};
 
 SharedLineNumberTable::~SharedLineNumberTable() {
-  // Always attempt to deallocate if we have a valid pointer
-  // JVMTI spec requires that memory allocated by GetLineNumberTable
-  // must be freed with Deallocate
+  // _ptr is a malloc'd copy of the JVMTI line number table (see
+  // Lookup::fillJavaMethodInfo). Freeing here is independent of class
+  // unload, preventing use-after-free in ~SharedLineNumberTable and getLineNumber.
   if (_ptr != nullptr) {
-    jvmtiEnv *jvmti = VM::jvmti();
-    if (jvmti != nullptr) {
-      jvmtiError err = jvmti->Deallocate((unsigned char *)_ptr);
-      // If Deallocate fails, log it for debugging (this could indicate a JVM bug)
-      // JVMTI_ERROR_ILLEGAL_ARGUMENT means the memory wasn't allocated by JVMTI
-      // which would be a serious bug in GetLineNumberTable
-      if (err != JVMTI_ERROR_NONE) {
-        TEST_LOG("Unexpected error while deallocating linenumber table: %d", err);
-      }
-    } else {
-      TEST_LOG("WARNING: Cannot deallocate line number table - JVMTI is null");
-    }
-    // Decrement counter whenever destructor runs (symmetric with increment at creation)
+    free(_ptr);
     Counters::decrement(LINE_NUMBER_TABLES);
   }
 }
@@ -308,10 +296,29 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
     mi->_type = FRAME_INTERPRETED;
     mi->_is_entry = entry;
     if (line_number_table != nullptr) {
-      mi->_line_number_table = std::make_shared<SharedLineNumberTable>(
-          line_number_table_size, line_number_table);
-      // Increment counter for tracking live line number tables
-      Counters::increment(LINE_NUMBER_TABLES);
+      // Detach from JVMTI lifetime: copy into our own buffer and deallocate
+      // the JVMTI-allocated memory immediately. This keeps _ptr valid even
+      // after the underlying class is unloaded.
+      void *owned_table = nullptr;
+      if (line_number_table_size > 0) {
+        size_t bytes = (size_t)line_number_table_size * sizeof(jvmtiLineNumberEntry);
+        owned_table = malloc(bytes);
+        if (owned_table != nullptr) {
+          memcpy(owned_table, line_number_table, bytes);
+        } else {
+          TEST_LOG("Failed to allocate %zu bytes for line number table copy", bytes);
+        }
+      }
+      jvmtiError dealloc_err = jvmti->Deallocate((unsigned char *)line_number_table);
+      if (dealloc_err != JVMTI_ERROR_NONE) {
+        TEST_LOG("Unexpected error while deallocating linenumber table: %d", dealloc_err);
+      }
+      if (owned_table != nullptr) {
+        mi->_line_number_table = std::make_shared<SharedLineNumberTable>(
+            line_number_table_size, owned_table);
+        // Increment counter for tracking live line number tables
+        Counters::increment(LINE_NUMBER_TABLES);
+      }
     }
 
     // strings are null or came from JVMTI
@@ -484,14 +491,20 @@ void Recording::copyTo(int target_fd) {
 
 off_t Recording::finishChunk() { return finishChunk(false); }
 
-off_t Recording::finishChunk(bool end_recording) {
+off_t Recording::finishChunk(bool end_recording, bool do_cleanup) {
   jvmtiEnv *jvmti = VM::jvmti();
   JNIEnv *env = VM::jni();
 
   jclass *classes;
   jint count = 0;
-  // obtaining the class list will create local refs to all loaded classes,
-  // effectively preventing them from being unloaded while flushing
+  // Pin all currently-loaded classes for the duration of finishChunk().
+  // resolveMethod() calls GetLineNumberTable/GetClassSignature/GetMethodName on
+  // jmethodIDs of classes that were loaded when the sample was taken but could
+  // be unloaded concurrently by the GC before we flush.  Holding a local JNI
+  // reference to each class makes it a GC root, closing that race window.
+  // Note: this only guards against concurrent unloading that starts AFTER this
+  // call.  Classes already unloaded before finishChunk() was entered are not
+  // present in the list and receive no protection here.
   jvmtiError err = jvmti->GetLoadedClasses(&count, &classes);
 
   flush(&_cpu_monitor_buf);
@@ -583,6 +596,19 @@ off_t Recording::finishChunk(bool end_recording) {
 
   _buf->reset();
 
+  // Run method_map cleanup while the class pins from GetLoadedClasses are still
+  // held.  This closes the concurrent-unload race: a class that is still loaded
+  // at this point cannot be unloaded by the GC until the pins are released below.
+  // On JVM implementations that free JVMTI-allocated line-number-table memory on
+  // class unload this ordering ensures Deallocate() is called before the memory
+  // is reclaimed.  Classes that were already unloaded before finishChunk() was
+  // entered are not in the pin list and are unaffected by this ordering — for
+  // those, jvmti->Deallocate() follows the JVMTI contract (caller owns the
+  // memory) and is safe as long as the JVM honours that contract.
+  if (do_cleanup) {
+    cleanupUnreferencedMethods();
+  }
+
   if (!err) {
     // delete all local references
     for (int i = 0; i < count; i++) {
@@ -595,10 +621,7 @@ off_t Recording::finishChunk(bool end_recording) {
 }
 
 void Recording::switchChunk(int fd) {
-  _chunk_start = finishChunk(fd > -1);
-
-  // Cleanup unreferenced methods after finishing the chunk
-  cleanupUnreferencedMethods();
+  _chunk_start = finishChunk(fd > -1, /*do_cleanup=*/true);
 
   TEST_LOG("MethodMap: %zu methods after cleanup", _method_map.size());
 
@@ -913,8 +936,8 @@ void Recording::writeSettings(Buffer *buf, Arguments &args) {
   writeBoolSetting(buf, T_MALLOC, "enabled", args._nativemem >= 0);
   if (args._nativemem >= 0) {
     writeIntSetting(buf, T_MALLOC, "nativemem", args._nativemem);
-    // samplingInterval=-1 means every allocation is recorded (nativemem=0).
-    writeIntSetting(buf, T_MALLOC, "samplingInterval", args._nativemem == 0 ? -1 : args._nativemem);
+    // samplingInterval=-1 signals "record every allocation"; mirrors shouldSample's interval<=1 threshold.
+    writeIntSetting(buf, T_MALLOC, "samplingInterval", args._nativemem <= 1 ? -1 : args._nativemem);
   }
 
   writeBoolSetting(buf, T_ACTIVE_RECORDING, "debugSymbols",
@@ -1742,8 +1765,10 @@ void FlightRecorder::flush() {
 
     jclass* classes = NULL;
     jint count = 0;
-    // obtaining the class list will create local refs to all loaded classes,
-    // effectively preventing them from being unloaded while flushing
+    // Pin currently-loaded classes for the duration of switchChunk() so that
+    // resolveMethod() can safely call JVMTI methods on jmethodIDs whose classes
+    // might otherwise be concurrently unloaded by the GC.  See the matching
+    // comment in finishChunk() for scope and limitations of this protection.
     jvmtiError err = jvmti->GetLoadedClasses(&count, &classes);
     rec->switchChunk(-1);
     if (!err) {

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -597,14 +597,11 @@ off_t Recording::finishChunk(bool end_recording, bool do_cleanup) {
   _buf->reset();
 
   // Run method_map cleanup while the class pins from GetLoadedClasses are still
-  // held.  This closes the concurrent-unload race: a class that is still loaded
-  // at this point cannot be unloaded by the GC until the pins are released below.
-  // On JVM implementations that free JVMTI-allocated line-number-table memory on
-  // class unload this ordering ensures Deallocate() is called before the memory
-  // is reclaimed.  Classes that were already unloaded before finishChunk() was
-  // entered are not in the pin list and are unaffected by this ordering — for
-  // those, jvmti->Deallocate() follows the JVMTI contract (caller owns the
-  // memory) and is safe as long as the JVM honours that contract.
+  // held.  Line number tables are now malloc'd copies (fillJavaMethodInfo copies
+  // the JVMTI buffer and calls Deallocate() immediately), so ~SharedLineNumberTable()
+  // calls free() — safe regardless of class-unload state.  Cleanup runs before
+  // DeleteLocalRef to ensure erased jmethodID keys have not yet been recycled by
+  // a newly-loaded class.
   if (do_cleanup) {
     cleanupUnreferencedMethods();
   }

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -59,6 +59,9 @@ struct CpuTimes {
 class SharedLineNumberTable {
 public:
   int _size;
+  // Owned malloc'd buffer holding a copy of the JVMTI line number table.
+  // Owning the memory (instead of holding the JVMTI-allocated pointer
+  // directly) keeps lifetime independent of class unload.
   void *_ptr;
 
   SharedLineNumberTable(int size, void *ptr) : _size(size), _ptr(ptr) {}
@@ -192,7 +195,7 @@ public:
   void copyTo(int target_fd);
   off_t finishChunk();
 
-  off_t finishChunk(bool end_recording);
+  off_t finishChunk(bool end_recording, bool do_cleanup = false);
   void switchChunk(int fd);
 
   void cpuMonitorCycle();

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -18,7 +18,6 @@
 
 typedef void* (*func_start_routine)(void*);
 
-
 SpinLock LibraryPatcher::_lock;
 const char* LibraryPatcher::_profiler_name = nullptr;
 PatchEntry LibraryPatcher::_patched_entries[MAX_NATIVE_LIBS];

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -11,13 +11,13 @@
 #include "guards.h"
 
 #include <cassert>
-#include <cxxabi.h>
 #include <dlfcn.h>
 #include <limits.h>
 #include <string.h>
 #include <stdlib.h>
 
 typedef void* (*func_start_routine)(void*);
+
 
 SpinLock LibraryPatcher::_lock;
 const char* LibraryPatcher::_profiler_name = nullptr;
@@ -86,33 +86,54 @@ static void init_tls_and_register() {
 // 1. Register the newly created thread to profiler
 // 2. Call real start routine
 // 3. Unregister the thread from profiler once the routine is completed.
-// This version is to workaround a precarious stack guard corruption,
-// which only happens in Linux/musl/aarch64/jdk11
-__attribute__((visibility("hidden")))
+// This version works around stack corruption observed on musl/aarch64/JDK11:
+//
+// Empirical observation (hs_err analysis): after DEOPT PACKING fires on a
+// thread running compiled lambda$measureContention$0 at sp=0x...49d0, this
+// wrapper's frame (sp=0x...5020, ~144 bytes below thread stack top) shows a
+// corrupted FP (odd address 0x...5001) and a corrupted stack canary.  The
+// corruption is confined to the top ~224 bytes of the stack (the region between
+// DEOPT PACKING sp and the thread stack top).
+//
+// The source of the corruption is the interpreter-frame rebuild sequence in
+// HotSpot's deoptimization blob (generate_deopt_blob in
+// sharedRuntime_aarch64.cpp, openjdk/jdk11u).  After popping the compiled
+// frame the blob executes "sub sp, sp, caller_adjustment" followed by a loop
+// of enter() calls (each doing "stp rfp, lr, [sp, #-16]!") to lay down
+// replacement interpreter frames.  When musl's small thread stack places this
+// wrapper immediately above the compiled frame, the enter() writes can reach
+// into this wrapper's frame, corrupting the saved FP and stack canary.
+// The mechanism is the same "precarious stack guard corruption" the noinline
+// helpers above already defend against for SignalBlocker's sigset_t.
+//
+// Two symptoms arise from this corruption:
+//
+// (a) Stack-canary crash: -fstack-protector-strong inserts a canary whenever
+//     the frame has a non-trivially destructed local (e.g. a Cleanup struct).
+//     That canary lands in the corruption zone; the epilogue fires
+//     __stack_chk_fail.  no_stack_protector removes the canary.
+//
+// (b) Corrupted-LR crash: even without a canary, `return` loads the saved LR
+//     from the corrupted frame and jumps to a garbage address.  pthread_exit()
+//     terminates the thread without using LR.  HotSpot on musl returns normally
+//     from java_start (no forced-unwind), so no exception-based cleanup path
+//     is needed.
+//
+// Cleanup reads tid from TLS (via ProfiledThread::currentTid()) rather than
+// from a stack variable, so it is correct even after the frame is corrupted.
+__attribute__((visibility("hidden"), no_stack_protector))
 static void* start_routine_wrapper_spec(void* args) {
     RoutineInfo* thr = (RoutineInfo*)args;
     func_start_routine routine = thr->routine();
     void* params = thr->args();
     delete_routine_info(thr);
     init_tls_and_register();
-    // Capture tid from TLS while it is guaranteed non-null (set by init_tls_and_register above).
-    // Using a cached tid avoids the lazy-allocating ProfiledThread::current() path inside
-    // the catch block, which may call 'new' at an unsafe point during forced unwind.
-    int tid = ProfiledThread::currentTid();
-    // IBM J9 (and glibc pthread_cancel) use abi::__forced_unwind for thread teardown.
-    // Catch it explicitly so cleanup runs even during forced unwind, then re-throw
-    // to allow the thread to exit properly.  A plain catch(...) without re-throw
-    // would swallow the forced unwind and prevent the thread from actually exiting.
-    try {
-        routine(params);
-    } catch (abi::__forced_unwind&) {
-        Profiler::unregisterThread(tid);
-        ProfiledThread::release();
-        throw;
-    }
-    Profiler::unregisterThread(tid);
+    routine(params);
+    Profiler::unregisterThread(ProfiledThread::currentTid());
     ProfiledThread::release();
-    return nullptr;
+    // pthread_exit instead of 'return': the saved LR in this frame is corrupted
+    // by DEOPT PACKING; returning would jump to a garbage address.
+    pthread_exit(nullptr);
 }
 
 static int pthread_create_hook_spec(pthread_t* thread,
@@ -141,7 +162,6 @@ static void* start_routine_wrapper(void* args) {
     RoutineInfo* thr = (RoutineInfo*)args;
     func_start_routine routine;
     void* params;
-    int tid;
     {
         // Block profiling signals while accessing and freeing RoutineInfo
         // and during TLS initialization. Under ASAN, new/delete/
@@ -159,26 +179,15 @@ static void* start_routine_wrapper(void* args) {
         params = thr->args();
         delete thr;
         ProfiledThread::initCurrentThread();
-        tid = ProfiledThread::currentTid();
         ProfiledThread::currentSignalSafe()->startInitWindow();
-        Profiler::registerThread(tid);
+        Profiler::registerThread(ProfiledThread::currentTid());
     }
-    // IBM J9 (and glibc pthread_cancel) use abi::__forced_unwind for thread
-    // teardown.  pthread_cleanup_push/pop creates a __pthread_cleanup_class
-    // with an implicitly-noexcept destructor; when J9's forced-unwind
-    // propagates through it, the C++ runtime calls std::terminate() → abort().
-    // Replacing with an explicit catch ensures cleanup runs on forced unwind
-    // without triggering terminate, and the re-throw lets the thread exit cleanly.
-    // pthread_exit() is also covered: on glibc it raises its own __forced_unwind.
-    try {
-        routine(params);
-    } catch (abi::__forced_unwind&) {
-        Profiler::unregisterThread(tid);
-        ProfiledThread::release();
-        throw;
-    }
-    Profiler::unregisterThread(tid);
-    ProfiledThread::release();
+    // RAII cleanup: reads tid from TLS in the destructor (same rationale as
+    // start_routine_wrapper_spec: avoids storing state on a potentially corruptible frame).
+    struct Cleanup {
+        ~Cleanup() { Profiler::unregisterThread(ProfiledThread::currentTid()); ProfiledThread::release(); }
+    } cleanup;
+    routine(params);
     return nullptr;
 }
 

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -55,6 +55,20 @@ public:
   }
 };
 
+// Unregister the current thread from the profiler and release its TLS under a
+// single SignalBlocker to close the race window between unregisterThread()
+// returning and release() acquiring its internal guard (PROF-14603).  Without
+// this, a SIGVTALRM delivered in that window could call currentSignalSafe()
+// and dereference a now-freed ProfiledThread.  Kept noinline so the
+// SignalBlocker's sigset_t does not appear in the caller's stack frame on
+// musl/aarch64 where the deopt blob may corrupt the wrapper's stack guard.
+__attribute__((noinline))
+static void unregister_and_release(int tid) {
+    SignalBlocker blocker;
+    Profiler::unregisterThread(tid);
+    ProfiledThread::release();
+}
+
 #ifdef __aarch64__
 // Delete RoutineInfo with profiling signals blocked to prevent ASAN
 // allocator lock reentrancy. Kept noinline so SignalBlocker's sigset_t
@@ -129,8 +143,9 @@ static void* start_routine_wrapper_spec(void* args) {
     delete_routine_info(thr);
     init_tls_and_register();
     routine(params);
-    Profiler::unregisterThread(ProfiledThread::currentTid());
-    ProfiledThread::release();
+    // unregister_and_release() holds SignalBlocker for the duration, closing the
+    // race window between unregisterThread() and release() (PROF-14603).
+    unregister_and_release(ProfiledThread::currentTid());
     // pthread_exit instead of 'return': the saved LR in this frame is corrupted
     // by DEOPT PACKING; returning would jump to a garbage address.
     pthread_exit(nullptr);
@@ -184,8 +199,9 @@ static void* start_routine_wrapper(void* args) {
     }
     // RAII cleanup: reads tid from TLS in the destructor (same rationale as
     // start_routine_wrapper_spec: avoids storing state on a potentially corruptible frame).
+    // unregister_and_release() wraps the two calls under SignalBlocker (PROF-14603).
     struct Cleanup {
-        ~Cleanup() { Profiler::unregisterThread(ProfiledThread::currentTid()); ProfiledThread::release(); }
+        ~Cleanup() { unregister_and_release(ProfiledThread::currentTid()); }
     } cleanup;
     routine(params);
     return nullptr;

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -94,6 +94,16 @@ static void init_tls_and_register() {
     Profiler::registerThread(ProfiledThread::currentTid());
 }
 
+// pthread_cleanup_push callback for start_routine_wrapper_spec.
+// Fires when the wrapped routine calls pthread_exit() or the thread is
+// canceled.  Kept noinline so its stack frame (which may hold a SignalBlocker
+// via unregister_and_release) lives outside the DEOPT-corruption zone of
+// start_routine_wrapper_spec.
+__attribute__((noinline))
+static void cleanup_unregister(void*) {
+    unregister_and_release(ProfiledThread::currentTid());
+}
+
 // Wrapper around the real start routine.
 // The wrapper:
 // 1. Register the newly created thread to profiler
@@ -134,6 +144,8 @@ static void init_tls_and_register() {
 //
 // Cleanup reads tid from TLS (via ProfiledThread::currentTid()) rather than
 // from a stack variable, so it is correct even after the frame is corrupted.
+// pthread_cleanup_push/pop ensures unregister_and_release() also runs when the
+// wrapped routine calls pthread_exit() or the thread is canceled.
 __attribute__((visibility("hidden"), no_stack_protector))
 static void* start_routine_wrapper_spec(void* args) {
     RoutineInfo* thr = (RoutineInfo*)args;
@@ -141,10 +153,12 @@ static void* start_routine_wrapper_spec(void* args) {
     void* params = thr->args();
     delete_routine_info(thr);
     init_tls_and_register();
+    // cleanup_unregister fires on pthread_exit() or cancellation from within
+    // routine(params).  pthread_cleanup_pop(1) executes and removes the handler
+    // on the normal return path, so unregister_and_release() is not called twice.
+    pthread_cleanup_push(cleanup_unregister, nullptr);
     routine(params);
-    // unregister_and_release() holds SignalBlocker for the duration, closing the
-    // race window between unregisterThread() and release() (PROF-14603).
-    unregister_and_release(ProfiledThread::currentTid());
+    pthread_cleanup_pop(1);
     // pthread_exit instead of 'return': the saved LR in this frame is corrupted
     // by DEOPT PACKING; returning would jump to a garbage address.
     pthread_exit(nullptr);

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -149,6 +149,7 @@ static void* start_routine_wrapper_spec(void* args) {
     // pthread_exit instead of 'return': the saved LR in this frame is corrupted
     // by DEOPT PACKING; returning would jump to a garbage address.
     pthread_exit(nullptr);
+    __builtin_unreachable();
 }
 
 static int pthread_create_hook_spec(pthread_t* thread,

--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -216,6 +216,11 @@ Error LivenessTracker::initialize(Arguments &args) {
     return Error::OK;
   }
 
+  // _record_heap_usage controls per-session JFR event emission only, not the
+  // tracking table. Update it before the _initialized guard so each profiler
+  // start gets the correct setting even when the table persists across recordings.
+  _record_heap_usage = args._record_heap_usage;
+
   if (_initialized) {
     // if the tracker was previously initialized return the stored result for
     // consistency this hack also means that if the profiler is started with
@@ -264,8 +269,6 @@ Error LivenessTracker::initialize(Arguments &args) {
       std::min(2048, _table_max_cap); // with default 512k sampling interval, it's
                                    // enough for 1G of heap
   _table = (TrackingEntry *)malloc(sizeof(TrackingEntry) * _table_cap);
-
-  _record_heap_usage = args._record_heap_usage;
 
   _gc_epoch = 0;
   _last_gc_epoch = 0;

--- a/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
+++ b/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
@@ -184,8 +184,11 @@ static int pthread_setspecific_hook(pthread_key_t key, const void *value) {
     return result;
   } else {
     int tid = ProfiledThread::currentTid();
-    Profiler::unregisterThread(tid);
-    ProfiledThread::release();
+    {
+      SignalBlocker blocker;
+      Profiler::unregisterThread(tid);
+      ProfiledThread::release();
+    }
     return pthread_setspecific(key, value);
   }
 }

--- a/ddprof-lib/src/main/cpp/thread.h
+++ b/ddprof-lib/src/main/cpp/thread.h
@@ -82,14 +82,15 @@ public:
 
   static void initCurrentThread();
   static void release();
-  // Clears TLS without deleting the ProfiledThread. For unit tests only:
-  // simulates the moment inside release() after pthread_setspecific(NULL) but
-  // before delete, which is the race window the _thread_ptr fix covers.
+#ifdef UNIT_TEST
+  // Simulates the moment inside release() after pthread_setspecific(NULL) but
+  // before delete — the race window the clearCurrentThreadTLS fix covers.
   static void clearCurrentThreadTLS() {
     if (__atomic_load_n(&_tls_key_initialized, __ATOMIC_ACQUIRE)) {
       pthread_setspecific(_tls_key, nullptr);
     }
   }
+#endif
 
   static ProfiledThread *current();
   static ProfiledThread *currentSignalSafe(); // Signal-safe version that never allocates

--- a/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
+++ b/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
@@ -4,20 +4,26 @@
  *
  * Regression test for SCP-1154: IBM J9 JVM crash in start_routine_wrapper.
  *
- * Root cause: pthread_cleanup_push in C++ mode creates __pthread_cleanup_class
- * with an implicitly-noexcept destructor.  When IBM J9's thread teardown raises
- * _Unwind_ForcedUnwind (via libgcc, sourced from libj9thr29.so), the C++ runtime
- * calls std::terminate() -> abort() because the forced-unwind exception tries to
- * exit a noexcept-bounded destructor.
+ * Root cause: pthread_cleanup_push in C++ mode on glibc creates
+ * __pthread_cleanup_class with an implicitly-noexcept destructor.  When IBM
+ * J9's thread teardown raises _Unwind_ForcedUnwind (via libgcc), the C++
+ * runtime calls std::terminate() because the forced-unwind exception exits a
+ * noexcept-bounded destructor.
  *
- * Fix: replace pthread_cleanup_push/pop with catch(abi::__forced_unwind&) + rethrow.
+ * Cleanup strategy (matches libraryPatcher_linux.cpp):
+ *   - glibc: RAII struct destructor.  Glibc's personality function handles
+ *     forced-unwind correctly for user-defined destructors; IBM J9's forced-
+ *     unwind also invokes personality functions.
+ *   - musl:  pthread_cleanup_push/pop (C-style callback).  musl's signal-based
+ *     thread cancellation invokes registered C callbacks but does NOT run C++
+ *     destructors.
  *
- * These tests verify:
- * 1. abi::__forced_unwind (raised by pthread_cancel / pthread_exit) is caught by
- *    the new pattern.
- * 2. The cleanup block runs.
- * 3. The rethrow allows the thread to exit as PTHREAD_CANCELED.
- * 4. ProfiledThread::release() can be called safely from within the catch block.
+ * These tests verify the per-platform cleanup path:
+ *   glibc  – RAII destructor fires on pthread_cancel and pthread_exit.
+ *   musl   – pthread_cleanup_push callback fires on pthread_cancel and
+ *            pthread_exit.
+ * A shared test verifies ProfiledThread::release() is safe to call from the
+ * chosen cleanup path.
  */
 
 #include <gtest/gtest.h>
@@ -27,89 +33,75 @@
 #include "thread.h"
 
 #include <atomic>
-#include <cxxabi.h>
 #include <pthread.h>
 #include <unistd.h>
 
-// ---------------------------------------------------------------------------
-// Test 1: bare catch(abi::__forced_unwind&) + rethrow
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// glibc path: RAII destructor tests
+// ===========================================================================
+#ifdef __GLIBC__
 
 static std::atomic<bool> g_bare_cleanup_called{false};
 
-static void* bare_forced_unwind_thread(void*) {
+static void* bare_raii_cancel_thread(void*) {
     g_bare_cleanup_called.store(false, std::memory_order_relaxed);
-    try {
-        while (true) {
-            pthread_testcancel();
-            usleep(100);
-        }
-    } catch (abi::__forced_unwind&) {
-        g_bare_cleanup_called.store(true, std::memory_order_relaxed);
-        throw;  // must re-throw so thread exits as PTHREAD_CANCELED
+    struct Cleanup {
+        ~Cleanup() { g_bare_cleanup_called.store(true, std::memory_order_relaxed); }
+    } cleanup;
+    while (true) {
+        pthread_testcancel();
+        usleep(100);
     }
     return nullptr;
 }
 
-// Regression: catch(abi::__forced_unwind&) + rethrow must intercept the forced
-// unwind raised by pthread_cancel, run the cleanup block, and let the thread
-// exit cleanly as PTHREAD_CANCELED — not via std::terminate().
-TEST(ForcedUnwindTest, BarePatternInterceptsAndRethrows) {
+// Regression (glibc): RAII destructor fires on pthread_cancel.
+TEST(ForcedUnwindTest, RaiiDestructorRunsOnPthreadCancel) {
     pthread_t t;
-    ASSERT_EQ(0, pthread_create(&t, nullptr, bare_forced_unwind_thread, nullptr));
+    ASSERT_EQ(0, pthread_create(&t, nullptr, bare_raii_cancel_thread, nullptr));
 
-    usleep(5000);  // let thread reach its testcancel loop
+    usleep(5000);
     pthread_cancel(t);
 
     void* retval;
     ASSERT_EQ(0, pthread_join(t, &retval));
 
     EXPECT_TRUE(g_bare_cleanup_called.load())
-        << "catch(abi::__forced_unwind&) must fire on pthread_cancel";
-    EXPECT_EQ(PTHREAD_CANCELED, retval)
-        << "rethrow must let thread exit as PTHREAD_CANCELED";
+        << "RAII destructor must run during pthread_cancel forced unwind";
+    EXPECT_EQ(PTHREAD_CANCELED, retval);
 }
 
-// ---------------------------------------------------------------------------
-// Test 2: pattern with ProfiledThread (mirrors start_routine_wrapper)
 // ---------------------------------------------------------------------------
 
 static std::atomic<bool> g_pt_cleanup_called{false};
 static std::atomic<bool> g_pt_release_called{false};
 
-static void* profiled_forced_unwind_thread(void*) {
+static void* profiled_raii_cancel_thread(void*) {
     g_pt_cleanup_called.store(false, std::memory_order_relaxed);
     g_pt_release_called.store(false, std::memory_order_relaxed);
 
-    // Mirrors what start_routine_wrapper does before calling routine(params).
     ProfiledThread::initCurrentThread();
-    int tid = ProfiledThread::currentTid();
-    (void)tid;
 
-    try {
-        while (true) {
-            pthread_testcancel();
-            usleep(100);
+    struct Cleanup {
+        ~Cleanup() {
+            g_pt_cleanup_called.store(true, std::memory_order_relaxed);
+            ProfiledThread::release();
+            g_pt_release_called.store(true, std::memory_order_relaxed);
         }
-    } catch (abi::__forced_unwind&) {
-        g_pt_cleanup_called.store(true, std::memory_order_relaxed);
-        // Mirrors the catch block in the fixed start_routine_wrapper:
-        // unregisterThread is omitted here (requires an initialised Profiler);
-        // release() is the critical cleanup that must always run.
-        ProfiledThread::release();
-        g_pt_release_called.store(true, std::memory_order_relaxed);
-        throw;
-    }
+    } cleanup;
 
-    ProfiledThread::release();
+    while (true) {
+        pthread_testcancel();
+        usleep(100);
+    }
     return nullptr;
 }
 
-// Regression: the start_routine_wrapper pattern with ProfiledThread lifecycle
-// must survive pthread_cancel without terminate().
+// Regression (glibc): RAII pattern with ProfiledThread lifecycle survives
+// pthread_cancel without terminate().
 TEST(ForcedUnwindTest, ProfiledThreadReleasedOnForcedUnwind) {
     pthread_t t;
-    ASSERT_EQ(0, pthread_create(&t, nullptr, profiled_forced_unwind_thread, nullptr));
+    ASSERT_EQ(0, pthread_create(&t, nullptr, profiled_raii_cancel_thread, nullptr));
 
     usleep(5000);
     pthread_cancel(t);
@@ -118,42 +110,157 @@ TEST(ForcedUnwindTest, ProfiledThreadReleasedOnForcedUnwind) {
     ASSERT_EQ(0, pthread_join(t, &retval));
 
     EXPECT_TRUE(g_pt_cleanup_called.load())
-        << "catch(abi::__forced_unwind&) must fire when thread is cancelled";
+        << "RAII destructor must run when thread is cancelled";
     EXPECT_TRUE(g_pt_release_called.load())
-        << "ProfiledThread::release() must complete inside the catch block";
+        << "ProfiledThread::release() must complete inside the RAII destructor";
     EXPECT_EQ(PTHREAD_CANCELED, retval);
 }
 
 // ---------------------------------------------------------------------------
-// Test 3: pthread_exit() also raises abi::__forced_unwind on glibc
-// ---------------------------------------------------------------------------
 
 static std::atomic<bool> g_exit_cleanup_called{false};
 
-static void* pthread_exit_thread(void*) {
+static void* raii_pthread_exit_thread(void*) {
     g_exit_cleanup_called.store(false, std::memory_order_relaxed);
-    try {
-        pthread_exit(reinterpret_cast<void*>(42));
-    } catch (abi::__forced_unwind&) {
-        g_exit_cleanup_called.store(true, std::memory_order_relaxed);
-        throw;
-    }
+    struct Cleanup {
+        ~Cleanup() { g_exit_cleanup_called.store(true, std::memory_order_relaxed); }
+    } cleanup;
+    pthread_exit(reinterpret_cast<void*>(42));
     return nullptr;
 }
 
-// pthread_exit() also uses abi::__forced_unwind on glibc — the same catch
-// block must handle it so that threads calling pthread_exit() inside a
-// wrapped routine don't bypass cleanup.
-TEST(ForcedUnwindTest, PthreadExitAlsoCaughtByForcedUnwindCatch) {
+// Regression (glibc): RAII destructor fires on pthread_exit.
+TEST(ForcedUnwindTest, RaiiDestructorRunsOnPthreadExit) {
     pthread_t t;
-    ASSERT_EQ(0, pthread_create(&t, nullptr, pthread_exit_thread, nullptr));
+    ASSERT_EQ(0, pthread_create(&t, nullptr, raii_pthread_exit_thread, nullptr));
 
     void* retval;
     ASSERT_EQ(0, pthread_join(t, &retval));
 
     EXPECT_TRUE(g_exit_cleanup_called.load())
-        << "catch(abi::__forced_unwind&) must also catch pthread_exit()";
+        << "RAII destructor must also run during pthread_exit";
     EXPECT_EQ(reinterpret_cast<void*>(42), retval);
 }
+
+#endif  // __GLIBC__
+
+// ===========================================================================
+// musl (non-glibc) path: pthread_cleanup_push/pop callback tests
+// ===========================================================================
+#ifndef __GLIBC__
+
+static std::atomic<bool> g_c_cancel_called{false};
+
+static void c_cleanup_cancel(void*) {
+    g_c_cancel_called.store(true, std::memory_order_relaxed);
+}
+
+static void* c_cleanup_cancel_thread(void*) {
+    g_c_cancel_called.store(false, std::memory_order_relaxed);
+    pthread_cleanup_push(c_cleanup_cancel, nullptr);
+    while (true) {
+        pthread_testcancel();
+        usleep(100);
+    }
+    pthread_cleanup_pop(0);
+    return nullptr;
+}
+
+// Regression (musl): C-style pthread_cleanup_push callback fires on pthread_cancel.
+TEST(ForcedUnwindTest, CleanupCallbackRunsOnPthreadCancel) {
+    pthread_t t;
+    ASSERT_EQ(0, pthread_create(&t, nullptr, c_cleanup_cancel_thread, nullptr));
+
+    usleep(5000);
+    pthread_cancel(t);
+
+    void* retval;
+    ASSERT_EQ(0, pthread_join(t, &retval));
+
+    EXPECT_TRUE(g_c_cancel_called.load())
+        << "pthread_cleanup_push callback must run during pthread_cancel on musl";
+    EXPECT_EQ(PTHREAD_CANCELED, retval);
+}
+
+// ---------------------------------------------------------------------------
+
+static std::atomic<bool> g_c_exit_called{false};
+
+static void c_cleanup_exit(void*) {
+    g_c_exit_called.store(true, std::memory_order_relaxed);
+}
+
+static void* c_cleanup_exit_thread(void*) {
+    g_c_exit_called.store(false, std::memory_order_relaxed);
+    pthread_cleanup_push(c_cleanup_exit, nullptr);
+    pthread_exit(reinterpret_cast<void*>(42));
+    pthread_cleanup_pop(0);
+    return nullptr;
+}
+
+// Regression (musl): C-style pthread_cleanup_push callback fires on pthread_exit.
+TEST(ForcedUnwindTest, CleanupCallbackRunsOnPthreadExit) {
+    pthread_t t;
+    ASSERT_EQ(0, pthread_create(&t, nullptr, c_cleanup_exit_thread, nullptr));
+
+    void* retval;
+    ASSERT_EQ(0, pthread_join(t, &retval));
+
+    EXPECT_TRUE(g_c_exit_called.load())
+        << "pthread_cleanup_push callback must run during pthread_exit on musl";
+    EXPECT_EQ(reinterpret_cast<void*>(42), retval);
+}
+
+// ---------------------------------------------------------------------------
+
+static std::atomic<bool> g_c_pt_called{false};
+static std::atomic<bool> g_c_pt_release_called{false};
+
+static void profiled_c_cleanup(void* arg) {
+    int tid = *static_cast<int*>(arg);
+    (void)tid;
+    g_c_pt_called.store(true, std::memory_order_relaxed);
+    ProfiledThread::release();
+    g_c_pt_release_called.store(true, std::memory_order_relaxed);
+}
+
+static int g_c_pt_tid;
+
+static void* profiled_c_cancel_thread(void*) {
+    g_c_pt_called.store(false, std::memory_order_relaxed);
+    g_c_pt_release_called.store(false, std::memory_order_relaxed);
+
+    ProfiledThread::initCurrentThread();
+    g_c_pt_tid = ProfiledThread::currentTid();
+
+    pthread_cleanup_push(profiled_c_cleanup, &g_c_pt_tid);
+    while (true) {
+        pthread_testcancel();
+        usleep(100);
+    }
+    pthread_cleanup_pop(0);
+    return nullptr;
+}
+
+// Regression (musl): pthread_cleanup_push pattern with ProfiledThread lifecycle
+// survives pthread_cancel.
+TEST(ForcedUnwindTest, ProfiledThreadReleasedOnForcedUnwind) {
+    pthread_t t;
+    ASSERT_EQ(0, pthread_create(&t, nullptr, profiled_c_cancel_thread, nullptr));
+
+    usleep(5000);
+    pthread_cancel(t);
+
+    void* retval;
+    ASSERT_EQ(0, pthread_join(t, &retval));
+
+    EXPECT_TRUE(g_c_pt_called.load())
+        << "C cleanup callback must run when thread is cancelled";
+    EXPECT_TRUE(g_c_pt_release_called.load())
+        << "ProfiledThread::release() must complete inside the C cleanup callback";
+    EXPECT_EQ(PTHREAD_CANCELED, retval);
+}
+
+#endif  // !__GLIBC__
 
 #endif  // __linux__

--- a/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2026 Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Acceptance tests for the PROF-14603 signal-race fix in thread teardown.
+ *
+ * Root cause: SIGVTALRM delivered between ProfiledThread::release() clearing TLS
+ * (pthread_setspecific(NULL)) and deleting the ProfiledThread object, causing
+ * a signal handler to call currentSignalSafe() and dereference a freed pointer.
+ *
+ * Fix coverage:
+ * - Signal-safe TLS accessor returns null in the race window (no crash).
+ * - SignalBlocker properly guards the unregister+release sequence.
+ * - Thread lifecycle (init/release) is race-free under concurrent signal load.
+ */
+
+#include <gtest/gtest.h>
+
+#ifdef __linux__
+
+#include "guards.h"
+#include "thread.h"
+
+#include <atomic>
+#include <cxxabi.h>
+#include <pthread.h>
+#include <signal.h>
+#include <unistd.h>
+#include <vector>
+
+// Sentinel value meaning "handler has not run yet" — distinct from both nullptr
+// (not registered) and any real ProfiledThread address.
+static ProfiledThread* const kNotYetRun = reinterpret_cast<ProfiledThread*>(1);
+
+// Use sigaction() instead of signal() so the handler persists across platforms;
+// signal() has implementation-defined reset-on-deliver (SA_RESETHAND) behaviour.
+static inline void install_handler(int sig, void (*handler)(int)) {
+  struct sigaction sa{};
+  sa.sa_handler = handler;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = 0;
+  sigaction(sig, &sa, nullptr);
+}
+
+// ── T-01: currentSignalSafe() is non-null while live, null after release ─────
+
+static std::atomic<ProfiledThread *> g_t01_seen{nullptr};
+
+static void t01_handler(int) {
+  g_t01_seen.store(ProfiledThread::currentSignalSafe(), std::memory_order_relaxed);
+}
+
+static void *t01_body(void *) {
+  ProfiledThread::initCurrentThread();
+
+  install_handler(SIGVTALRM, t01_handler);
+  g_t01_seen.store(kNotYetRun, std::memory_order_relaxed);
+  pthread_kill(pthread_self(), SIGVTALRM);
+  EXPECT_NE(nullptr, g_t01_seen.load(std::memory_order_relaxed))
+      << "currentSignalSafe() must return non-null while ProfiledThread is live";
+
+  ProfiledThread::release();
+
+  g_t01_seen.store(kNotYetRun, std::memory_order_relaxed);
+  pthread_kill(pthread_self(), SIGVTALRM);
+  EXPECT_EQ(nullptr, g_t01_seen.load(std::memory_order_relaxed))
+      << "currentSignalSafe() must return null after release()";
+
+  signal(SIGVTALRM, SIG_IGN);
+  return nullptr;
+}
+
+// Verifies the post-release null guarantee seen from a signal handler.
+TEST(ThreadTeardownSafetyTest, TLSAccessibleDuringLifetimeNullAfterRelease) {
+  pthread_t t;
+  ASSERT_EQ(0, pthread_create(&t, nullptr, t01_body, nullptr));
+  pthread_join(t, nullptr);
+}
+
+// ── T-02: Signal in the TLS-clear/delete window does not crash ───────────────
+
+static std::atomic<ProfiledThread *> g_t02_seen{nullptr};
+
+static void t02_handler(int) {
+  g_t02_seen.store(ProfiledThread::currentSignalSafe(), std::memory_order_relaxed);
+}
+
+static void *t02_body(void *) {
+  ProfiledThread::initCurrentThread();
+
+  install_handler(SIGVTALRM, t02_handler);
+  g_t02_seen.store(kNotYetRun, std::memory_order_relaxed);
+
+  // Simulate the race window: TLS cleared but object not yet freed.
+  ProfiledThread::clearCurrentThreadTLS();
+
+  // Signal delivered in the race window must see null, not a dangling pointer.
+  pthread_kill(pthread_self(), SIGVTALRM);
+  EXPECT_EQ(nullptr, g_t02_seen.load(std::memory_order_relaxed))
+      << "currentSignalSafe() must return null in the TLS-clear/delete window";
+
+  signal(SIGVTALRM, SIG_IGN);
+  // release() with TLS already null must not double-free.
+  ProfiledThread::release();
+  return nullptr;
+}
+
+// Regression for the primary crash path: signal fires between clearTLS and delete.
+TEST(ThreadTeardownSafetyTest, SignalInTLSClearDeleteWindowDoesNotCrash) {
+  pthread_t t;
+  ASSERT_EQ(0, pthread_create(&t, nullptr, t02_body, nullptr));
+  pthread_join(t, nullptr);
+}
+
+// ── T-03: Double release() is idempotent ─────────────────────────────────────
+
+static void *t03_body(void *) {
+  ProfiledThread::initCurrentThread();
+  ProfiledThread::release();
+  ProfiledThread::release(); // must not crash or double-free
+  return nullptr;
+}
+
+TEST(ThreadTeardownSafetyTest, DoubleReleaseIsIdempotent) {
+  pthread_t t;
+  ASSERT_EQ(0, pthread_create(&t, nullptr, t03_body, nullptr));
+  pthread_join(t, nullptr);
+}
+
+// ── T-04: Signal-safe accessor returns null without initCurrentThread() ──────
+
+static std::atomic<ProfiledThread *> g_t04_seen{nullptr};
+
+static void t04_handler(int) {
+  g_t04_seen.store(ProfiledThread::currentSignalSafe(), std::memory_order_relaxed);
+}
+
+static void *t04_body(void *) {
+  // Intentionally no initCurrentThread().
+  install_handler(SIGVTALRM, t04_handler);
+  g_t04_seen.store(kNotYetRun, std::memory_order_relaxed);
+  pthread_kill(pthread_self(), SIGVTALRM);
+  EXPECT_EQ(nullptr, g_t04_seen.load(std::memory_order_relaxed))
+      << "currentSignalSafe() must return null for unregistered threads";
+  signal(SIGVTALRM, SIG_IGN);
+  return nullptr;
+}
+
+TEST(ThreadTeardownSafetyTest, SignalSafeAccessorReturnsNullWithoutInit) {
+  pthread_t t;
+  ASSERT_EQ(0, pthread_create(&t, nullptr, t04_body, nullptr));
+  pthread_join(t, nullptr);
+}
+
+// ── T-05: Concurrent signals during teardown stress ──────────────────────────
+
+static void *t05_worker(void *) {
+  signal(SIGVTALRM, SIG_IGN);
+  signal(SIGPROF, SIG_IGN);
+  ProfiledThread::initCurrentThread();
+  for (int i = 0; i < 10; ++i) {
+    pthread_kill(pthread_self(), SIGVTALRM);
+  }
+  ProfiledThread::release();
+  return nullptr;
+}
+
+// 20 threads × 5 rounds with signal spray; no crash expected.
+TEST(ThreadTeardownSafetyTest, ConcurrentSignalsDuringTeardownStress) {
+  for (int round = 0; round < 5; ++round) {
+    std::vector<pthread_t> threads(20);
+    for (auto &tid : threads) {
+      ASSERT_EQ(0, pthread_create(&tid, nullptr, t05_worker, nullptr));
+    }
+    for (auto &tid : threads) {
+      pthread_join(tid, nullptr);
+    }
+  }
+}
+
+// ── T-06: SignalBlocker masks SIGPROF + SIGVTALRM and restores on exit ────────
+
+static void *t06_body(void *) {
+  sigset_t before, during, after;
+
+  pthread_sigmask(SIG_SETMASK, nullptr, &before);
+  EXPECT_FALSE(sigismember(&before, SIGVTALRM));
+  EXPECT_FALSE(sigismember(&before, SIGPROF));
+
+  {
+    SignalBlocker blocker;
+    pthread_sigmask(SIG_SETMASK, nullptr, &during);
+    EXPECT_TRUE(sigismember(&during, SIGVTALRM))
+        << "SignalBlocker must block SIGVTALRM";
+    EXPECT_TRUE(sigismember(&during, SIGPROF))
+        << "SignalBlocker must block SIGPROF";
+  }
+
+  pthread_sigmask(SIG_SETMASK, nullptr, &after);
+  EXPECT_FALSE(sigismember(&after, SIGVTALRM))
+      << "SignalBlocker must restore SIGVTALRM on exit";
+  EXPECT_FALSE(sigismember(&after, SIGPROF))
+      << "SignalBlocker must restore SIGPROF on exit";
+  return nullptr;
+}
+
+TEST(ThreadTeardownSafetyTest, SignalBlockerMasksAndRestoresProfSignals) {
+  pthread_t t;
+  ASSERT_EQ(0, pthread_create(&t, nullptr, t06_body, nullptr));
+  pthread_join(t, nullptr);
+}
+
+// ── T-07: Forced unwind with concurrent signal does not crash ─────────────────
+
+static std::atomic<bool> g_t07_cleanup_ran{false};
+static std::atomic<bool> g_t07_release_ran{false};
+
+static void *t07_body(void *) {
+  g_t07_cleanup_ran.store(false, std::memory_order_relaxed);
+  g_t07_release_ran.store(false, std::memory_order_relaxed);
+
+  signal(SIGVTALRM, SIG_IGN);
+  ProfiledThread::initCurrentThread();
+
+  try {
+    // Inject a signal before the cancellation point to exercise the combined path.
+    pthread_kill(pthread_self(), SIGVTALRM);
+    while (true) {
+      pthread_testcancel();
+      usleep(100);
+    }
+  } catch (abi::__forced_unwind &) {
+    g_t07_cleanup_ran.store(true, std::memory_order_relaxed);
+    ProfiledThread::release();
+    g_t07_release_ran.store(true, std::memory_order_relaxed);
+    throw;
+  }
+  ProfiledThread::release();
+  return nullptr;
+}
+
+TEST(ThreadTeardownSafetyTest, ForcedUnwindWithConcurrentSignalDoesNotCrash) {
+  pthread_t t;
+  ASSERT_EQ(0, pthread_create(&t, nullptr, t07_body, nullptr));
+  usleep(5000);
+  pthread_cancel(t);
+  void *retval;
+  ASSERT_EQ(0, pthread_join(t, &retval));
+  EXPECT_TRUE(g_t07_cleanup_ran.load());
+  EXPECT_TRUE(g_t07_release_ran.load());
+  EXPECT_EQ(PTHREAD_CANCELED, retval);
+}
+
+// ── T-08: Double initCurrentThread() is idempotent ───────────────────────────
+
+static void *t08_body(void *) {
+  ProfiledThread::initCurrentThread();
+  ProfiledThread *first = ProfiledThread::currentSignalSafe();
+  EXPECT_NE(nullptr, first);
+
+  ProfiledThread::initCurrentThread(); // second call on the same thread
+  ProfiledThread *second = ProfiledThread::currentSignalSafe();
+  EXPECT_NE(nullptr, second);
+  EXPECT_EQ(first, second) << "double init must not allocate a second ProfiledThread";
+
+  ProfiledThread::release();
+  return nullptr;
+}
+
+TEST(ThreadTeardownSafetyTest, DoubleInitIsIdempotent) {
+  pthread_t t;
+  ASSERT_EQ(0, pthread_create(&t, nullptr, t08_body, nullptr));
+  pthread_join(t, nullptr);
+}
+
+// ── T-09: High-frequency signals during thread churn ─────────────────────────
+
+static std::atomic<bool> g_t09_stop{false};
+
+static void *t09_injector(void *) {
+  while (!g_t09_stop.load(std::memory_order_relaxed)) {
+    kill(getpid(), SIGVTALRM);
+    usleep(500); // ~2 kHz
+  }
+  return nullptr;
+}
+
+static void *t09_worker(void *) {
+  signal(SIGVTALRM, SIG_IGN);
+  ProfiledThread::initCurrentThread();
+  usleep(100);
+  ProfiledThread::release();
+  return nullptr;
+}
+
+// Mirrors DumpWhileChurningThreadsTest at native level: 100 short-lived threads
+// under continuous SIGVTALRM injection must complete without crash.
+TEST(ThreadTeardownSafetyTest, HighFrequencySignalsDuringThreadChurn) {
+  signal(SIGVTALRM, SIG_IGN);
+
+  g_t09_stop.store(false, std::memory_order_relaxed);
+  pthread_t injector;
+  ASSERT_EQ(0, pthread_create(&injector, nullptr, t09_injector, nullptr));
+
+  for (int i = 0; i < 100; ++i) {
+    pthread_t worker;
+    ASSERT_EQ(0, pthread_create(&worker, nullptr, t09_worker, nullptr));
+    pthread_join(worker, nullptr);
+  }
+
+  g_t09_stop.store(true, std::memory_order_relaxed);
+  pthread_join(injector, nullptr);
+  signal(SIGVTALRM, SIG_DFL);
+}
+
+// ── T-10: CriticalSection reentrancy guard prevents double-entry ──────────────
+
+static void *t10_body(void *) {
+  ProfiledThread::initCurrentThread();
+  ProfiledThread *pt = ProfiledThread::currentSignalSafe();
+  ASSERT_NE(nullptr, pt);
+
+  // Outer critical section must succeed.
+  EXPECT_TRUE(pt->tryEnterCriticalSection());
+
+  // Simulated reentrancy from the same thread (e.g. nested signal handler).
+  EXPECT_FALSE(pt->tryEnterCriticalSection())
+      << "reentrancy must be rejected while outer critical section is active";
+
+  pt->exitCriticalSection();
+
+  // After exit, entry succeeds again.
+  EXPECT_TRUE(pt->tryEnterCriticalSection());
+  pt->exitCriticalSection();
+
+  ProfiledThread::release();
+  return nullptr;
+}
+
+TEST(ThreadTeardownSafetyTest, CriticalSectionReentrancyGuard) {
+  pthread_t t;
+  ASSERT_EQ(0, pthread_create(&t, nullptr, t10_body, nullptr));
+  pthread_join(t, nullptr);
+}
+
+#endif // __linux__

--- a/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
@@ -42,6 +42,17 @@ static inline void install_handler(int sig, void (*handler)(int)) {
   sigaction(sig, &sa, nullptr);
 }
 
+// RAII helper: saves the current sigaction for `sig` and restores it on
+// destruction, preventing signal-disposition leaks across tests.
+struct SigGuard {
+  int sig;
+  struct sigaction saved;
+  explicit SigGuard(int s) : sig(s) { sigaction(s, nullptr, &saved); }
+  ~SigGuard() { sigaction(sig, &saved, nullptr); }
+  SigGuard(const SigGuard&) = delete;
+  SigGuard& operator=(const SigGuard&) = delete;
+};
+
 // ── T-01: currentSignalSafe() is non-null while live, null after release ─────
 
 static std::atomic<ProfiledThread *> g_t01_seen{nullptr};
@@ -53,6 +64,7 @@ static void t01_handler(int) {
 static void *t01_body(void *) {
   ProfiledThread::initCurrentThread();
 
+  SigGuard guard(SIGVTALRM);
   install_handler(SIGVTALRM, t01_handler);
   g_t01_seen.store(kNotYetRun, std::memory_order_relaxed);
   pthread_kill(pthread_self(), SIGVTALRM);
@@ -66,7 +78,6 @@ static void *t01_body(void *) {
   EXPECT_EQ(nullptr, g_t01_seen.load(std::memory_order_relaxed))
       << "currentSignalSafe() must return null after release()";
 
-  signal(SIGVTALRM, SIG_IGN);
   return nullptr;
 }
 
@@ -88,6 +99,7 @@ static void t02_handler(int) {
 static void *t02_body(void *) {
   ProfiledThread::initCurrentThread();
 
+  SigGuard guard(SIGVTALRM);
   install_handler(SIGVTALRM, t02_handler);
   g_t02_seen.store(kNotYetRun, std::memory_order_relaxed);
 
@@ -99,7 +111,6 @@ static void *t02_body(void *) {
   EXPECT_EQ(nullptr, g_t02_seen.load(std::memory_order_relaxed))
       << "currentSignalSafe() must return null in the TLS-clear/delete window";
 
-  signal(SIGVTALRM, SIG_IGN);
   // release() with TLS already null must not double-free.
   ProfiledThread::release();
   return nullptr;
@@ -137,12 +148,12 @@ static void t04_handler(int) {
 
 static void *t04_body(void *) {
   // Intentionally no initCurrentThread().
+  SigGuard guard(SIGVTALRM);
   install_handler(SIGVTALRM, t04_handler);
   g_t04_seen.store(kNotYetRun, std::memory_order_relaxed);
   pthread_kill(pthread_self(), SIGVTALRM);
   EXPECT_EQ(nullptr, g_t04_seen.load(std::memory_order_relaxed))
       << "currentSignalSafe() must return null for unregistered threads";
-  signal(SIGVTALRM, SIG_IGN);
   return nullptr;
 }
 
@@ -155,8 +166,10 @@ TEST(ThreadTeardownSafetyTest, SignalSafeAccessorReturnsNullWithoutInit) {
 // ── T-05: Concurrent signals during teardown stress ──────────────────────────
 
 static void *t05_worker(void *) {
-  signal(SIGVTALRM, SIG_IGN);
-  signal(SIGPROF, SIG_IGN);
+  SigGuard gVtalrm(SIGVTALRM);
+  SigGuard gProf(SIGPROF);
+  install_handler(SIGVTALRM, SIG_IGN);
+  install_handler(SIGPROF, SIG_IGN);
   ProfiledThread::initCurrentThread();
   for (int i = 0; i < 10; ++i) {
     pthread_kill(pthread_self(), SIGVTALRM);
@@ -211,15 +224,20 @@ TEST(ThreadTeardownSafetyTest, SignalBlockerMasksAndRestoresProfSignals) {
 }
 
 // ── T-07: Forced unwind with concurrent signal does not crash ─────────────────
+// Cancellation mechanism differs between glibc (abi::__forced_unwind via C++
+// unwinder) and musl (C-style pthread_cleanup_push callbacks).
 
 static std::atomic<bool> g_t07_cleanup_ran{false};
 static std::atomic<bool> g_t07_release_ran{false};
+
+#ifdef __GLIBC__
 
 static void *t07_body(void *) {
   g_t07_cleanup_ran.store(false, std::memory_order_relaxed);
   g_t07_release_ran.store(false, std::memory_order_relaxed);
 
-  signal(SIGVTALRM, SIG_IGN);
+  SigGuard guard(SIGVTALRM);
+  install_handler(SIGVTALRM, SIG_IGN);
   ProfiledThread::initCurrentThread();
 
   try {
@@ -238,6 +256,36 @@ static void *t07_body(void *) {
   ProfiledThread::release();
   return nullptr;
 }
+
+#else  // !__GLIBC__ — musl: cancellation runs C cleanup callbacks
+
+static void t07_cleanup_fn(void *) {
+  g_t07_cleanup_ran.store(true, std::memory_order_relaxed);
+  ProfiledThread::release();
+  g_t07_release_ran.store(true, std::memory_order_relaxed);
+}
+
+static void *t07_body(void *) {
+  g_t07_cleanup_ran.store(false, std::memory_order_relaxed);
+  g_t07_release_ran.store(false, std::memory_order_relaxed);
+
+  SigGuard guard(SIGVTALRM);
+  install_handler(SIGVTALRM, SIG_IGN);
+  ProfiledThread::initCurrentThread();
+
+  pthread_cleanup_push(t07_cleanup_fn, nullptr);
+  // Inject a signal before the cancellation point to exercise the combined path.
+  pthread_kill(pthread_self(), SIGVTALRM);
+  while (true) {
+    pthread_testcancel();
+    usleep(100);
+  }
+  pthread_cleanup_pop(0);
+  ProfiledThread::release();
+  return nullptr;
+}
+
+#endif  // __GLIBC__
 
 TEST(ThreadTeardownSafetyTest, ForcedUnwindWithConcurrentSignalDoesNotCrash) {
   pthread_t t;
@@ -286,7 +334,8 @@ static void *t09_injector(void *) {
 }
 
 static void *t09_worker(void *) {
-  signal(SIGVTALRM, SIG_IGN);
+  SigGuard guard(SIGVTALRM);
+  install_handler(SIGVTALRM, SIG_IGN);
   ProfiledThread::initCurrentThread();
   usleep(100);
   ProfiledThread::release();
@@ -296,7 +345,8 @@ static void *t09_worker(void *) {
 // Mirrors DumpWhileChurningThreadsTest at native level: 100 short-lived threads
 // under continuous SIGVTALRM injection must complete without crash.
 TEST(ThreadTeardownSafetyTest, HighFrequencySignalsDuringThreadChurn) {
-  signal(SIGVTALRM, SIG_IGN);
+  SigGuard testGuard(SIGVTALRM);
+  install_handler(SIGVTALRM, SIG_IGN);
 
   g_t09_stop.store(false, std::memory_order_relaxed);
   pthread_t injector;
@@ -310,7 +360,6 @@ TEST(ThreadTeardownSafetyTest, HighFrequencySignalsDuringThreadChurn) {
 
   g_t09_stop.store(true, std::memory_order_relaxed);
   pthread_join(injector, nullptr);
-  signal(SIGVTALRM, SIG_DFL);
 }
 
 // ── T-10: CriticalSection reentrancy guard prevents double-entry ──────────────

--- a/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
@@ -69,8 +69,10 @@ static void *t01_body(void *) {
   g_t01_seen.store(kNotYetRun, std::memory_order_relaxed);
   pthread_kill(pthread_self(), SIGVTALRM);
   ProfiledThread *t01_pre = g_t01_seen.load(std::memory_order_relaxed);
-  ASSERT_NE(kNotYetRun, t01_pre)
-      << "SIGVTALRM handler must have run before release() (handler did not execute)";
+  if (t01_pre == kNotYetRun) {
+    ADD_FAILURE() << "SIGVTALRM handler must have run before release() (handler did not execute)";
+    return nullptr;
+  }
   EXPECT_NE(nullptr, t01_pre)
       << "currentSignalSafe() must return non-null while ProfiledThread is live";
 
@@ -79,8 +81,10 @@ static void *t01_body(void *) {
   g_t01_seen.store(kNotYetRun, std::memory_order_relaxed);
   pthread_kill(pthread_self(), SIGVTALRM);
   ProfiledThread *t01_post = g_t01_seen.load(std::memory_order_relaxed);
-  ASSERT_NE(kNotYetRun, t01_post)
-      << "SIGVTALRM handler must have run after release() (handler did not execute)";
+  if (t01_post == kNotYetRun) {
+    ADD_FAILURE() << "SIGVTALRM handler must have run after release() (handler did not execute)";
+    return nullptr;
+  }
   EXPECT_EQ(nullptr, t01_post)
       << "currentSignalSafe() must return null after release()";
 

--- a/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
@@ -318,7 +318,10 @@ TEST(ThreadTeardownSafetyTest, HighFrequencySignalsDuringThreadChurn) {
 static void *t10_body(void *) {
   ProfiledThread::initCurrentThread();
   ProfiledThread *pt = ProfiledThread::currentSignalSafe();
-  ASSERT_NE(nullptr, pt);
+  if (pt == nullptr) {
+    ADD_FAILURE() << "currentSignalSafe() returned nullptr";
+    return nullptr;
+  }
 
   // Outer critical section must succeed.
   EXPECT_TRUE(pt->tryEnterCriticalSection());

--- a/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
@@ -68,14 +68,20 @@ static void *t01_body(void *) {
   install_handler(SIGVTALRM, t01_handler);
   g_t01_seen.store(kNotYetRun, std::memory_order_relaxed);
   pthread_kill(pthread_self(), SIGVTALRM);
-  EXPECT_NE(nullptr, g_t01_seen.load(std::memory_order_relaxed))
+  ProfiledThread *t01_pre = g_t01_seen.load(std::memory_order_relaxed);
+  ASSERT_NE(kNotYetRun, t01_pre)
+      << "SIGVTALRM handler must have run before release() (handler did not execute)";
+  EXPECT_NE(nullptr, t01_pre)
       << "currentSignalSafe() must return non-null while ProfiledThread is live";
 
   ProfiledThread::release();
 
   g_t01_seen.store(kNotYetRun, std::memory_order_relaxed);
   pthread_kill(pthread_self(), SIGVTALRM);
-  EXPECT_EQ(nullptr, g_t01_seen.load(std::memory_order_relaxed))
+  ProfiledThread *t01_post = g_t01_seen.load(std::memory_order_relaxed);
+  ASSERT_NE(kNotYetRun, t01_post)
+      << "SIGVTALRM handler must have run after release() (handler did not execute)";
+  EXPECT_EQ(nullptr, t01_post)
       << "currentSignalSafe() must return null after release()";
 
   return nullptr;
@@ -197,8 +203,6 @@ static void *t06_body(void *) {
   sigset_t before, during, after;
 
   pthread_sigmask(SIG_SETMASK, nullptr, &before);
-  EXPECT_FALSE(sigismember(&before, SIGVTALRM));
-  EXPECT_FALSE(sigismember(&before, SIGPROF));
 
   {
     SignalBlocker blocker;
@@ -210,10 +214,10 @@ static void *t06_body(void *) {
   }
 
   pthread_sigmask(SIG_SETMASK, nullptr, &after);
-  EXPECT_FALSE(sigismember(&after, SIGVTALRM))
-      << "SignalBlocker must restore SIGVTALRM on exit";
-  EXPECT_FALSE(sigismember(&after, SIGPROF))
-      << "SignalBlocker must restore SIGPROF on exit";
+  EXPECT_EQ(sigismember(&before, SIGVTALRM), sigismember(&after, SIGVTALRM))
+      << "SignalBlocker must restore SIGVTALRM to its initial state on exit";
+  EXPECT_EQ(sigismember(&before, SIGPROF), sigismember(&after, SIGPROF))
+      << "SignalBlocker must restore SIGPROF to its initial state on exit";
   return nullptr;
 }
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/AbstractDynamicClassTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/AbstractDynamicClassTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026, Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.datadoghq.profiler.memleak;
+
+import com.datadoghq.profiler.AbstractProfilerTest;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+abstract class AbstractDynamicClassTest extends AbstractProfilerTest {
+
+  protected int classCounter = 0;
+
+  /**
+   * Generates ASM bytecode for a class with a constructor and {@code methodCount} public
+   * int-returning no-arg methods, each with multiple line-number table entries.
+   */
+  protected byte[] generateClassBytecode(String className, int methodCount) {
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+    cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, className, null, "java/lang/Object", null);
+
+    MethodVisitor ctor = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+    ctor.visitCode();
+    ctor.visitVarInsn(Opcodes.ALOAD, 0);
+    ctor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+    ctor.visitInsn(Opcodes.RETURN);
+    ctor.visitMaxs(0, 0);
+    ctor.visitEnd();
+
+    for (int i = 0; i < methodCount; i++) {
+      MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "method" + i, "()I", null, null);
+      mv.visitCode();
+
+      Label l1 = new Label(); mv.visitLabel(l1); mv.visitLineNumber(100 + i * 3, l1);
+      mv.visitInsn(Opcodes.ICONST_0);
+      mv.visitVarInsn(Opcodes.ISTORE, 1);
+
+      Label l2 = new Label(); mv.visitLabel(l2); mv.visitLineNumber(101 + i * 3, l2);
+      mv.visitVarInsn(Opcodes.ILOAD, 1);
+      mv.visitInsn(Opcodes.ICONST_1);
+      mv.visitInsn(Opcodes.IADD);
+      mv.visitVarInsn(Opcodes.ISTORE, 1);
+
+      Label l3 = new Label(); mv.visitLabel(l3); mv.visitLineNumber(102 + i * 3, l3);
+      mv.visitVarInsn(Opcodes.ILOAD, 1);
+      mv.visitInsn(Opcodes.IRETURN);
+
+      mv.visitMaxs(0, 0);
+      mv.visitEnd();
+    }
+
+    cw.visitEnd();
+    return cw.toByteArray();
+  }
+
+  protected static Path tempFile(String prefix) throws IOException {
+    Path dir = Paths.get(System.getProperty("java.io.tmpdir"), "recordings");
+    Files.createDirectories(dir);
+    return Files.createTempFile(dir, prefix + "-", ".jfr");
+  }
+
+  protected static class IsolatedClassLoader extends ClassLoader {
+    public Class<?> defineClass(String name, byte[] bytecode) {
+      return defineClass(name, bytecode, 0, bytecode.length);
+    }
+  }
+}

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/AbstractDynamicClassTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/AbstractDynamicClassTest.java
@@ -44,17 +44,23 @@ abstract class AbstractDynamicClassTest extends AbstractProfilerTest {
       MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "method" + i, "()I", null, null);
       mv.visitCode();
 
-      Label l1 = new Label(); mv.visitLabel(l1); mv.visitLineNumber(100 + i * 3, l1);
+      Label l1 = new Label();
+      mv.visitLabel(l1);
+      mv.visitLineNumber(100 + i * 3, l1);
       mv.visitInsn(Opcodes.ICONST_0);
       mv.visitVarInsn(Opcodes.ISTORE, 1);
 
-      Label l2 = new Label(); mv.visitLabel(l2); mv.visitLineNumber(101 + i * 3, l2);
+      Label l2 = new Label();
+      mv.visitLabel(l2);
+      mv.visitLineNumber(101 + i * 3, l2);
       mv.visitVarInsn(Opcodes.ILOAD, 1);
       mv.visitInsn(Opcodes.ICONST_1);
       mv.visitInsn(Opcodes.IADD);
       mv.visitVarInsn(Opcodes.ISTORE, 1);
 
-      Label l3 = new Label(); mv.visitLabel(l3); mv.visitLineNumber(102 + i * 3, l3);
+      Label l3 = new Label();
+      mv.visitLabel(l3);
+      mv.visitLineNumber(102 + i * 3, l3);
       mv.visitVarInsn(Opcodes.ILOAD, 1);
       mv.visitInsn(Opcodes.IRETURN);
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/CleanupAfterClassUnloadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/CleanupAfterClassUnloadTest.java
@@ -37,18 +37,18 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * Regression test for PROF-14545: SIGSEGV in Recording::cleanupUnreferencedMethods.
  *
  * <p>The bug: cleanupUnreferencedMethods() was called after finishChunk() released its
- * GetLoadedClasses pins. The class pins are JNI local references that prevent concurrent
- * GC from unloading a class between resolveMethod() JVMTI calls and the Deallocate that
- * frees the line-number-table buffer. Calling cleanupUnreferencedMethods() after the pins
- * were released created a window where, on JVM implementations that free JVMTI-allocated
- * line-number-table memory on class unload, Deallocate could access freed memory → SIGSEGV.
+ * GetLoadedClasses pins. ~SharedLineNumberTable() called jvmti-&gt;Deallocate() on
+ * JVMTI-allocated line-number-table memory that the JVM had already freed on class
+ * unload → SIGSEGV.
  *
- * <p>The fix: cleanupUnreferencedMethods() is now called inside finishChunk(), before
- * DeleteLocalRef releases the pins, closing the concurrent-unload race window during
- * finishChunk(). Note: this ordering does not protect against classes that were already
- * fully unloaded before finishChunk() began; for those, correctness relies on the JVMTI
- * contract that the caller owns memory returned by GetLineNumberTable and the JVM must
- * not reclaim it on class unload.
+ * <p>The fix: two complementary changes:
+ * <ol>
+ *   <li>cleanupUnreferencedMethods() is now called inside finishChunk(), before
+ *       DeleteLocalRef releases the GetLoadedClasses pins.</li>
+ *   <li>fillJavaMethodInfo() copies the JVMTI line-number-table into a malloc'd buffer
+ *       and immediately calls jvmti-&gt;Deallocate() on the original; cleanup calls free()
+ *       on the malloc'd copy, which is safe regardless of class-unload state.</li>
+ * </ol>
  *
  * <p>This test reproduces the crash scenario:
  * <ol>

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/CleanupAfterClassUnloadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/CleanupAfterClassUnloadTest.java
@@ -15,15 +15,9 @@
  */
 package com.datadoghq.profiler.memleak;
 
-import com.datadoghq.profiler.AbstractProfilerTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.Label;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
@@ -59,7 +53,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *   <li>cleanupUnreferencedMethods() must not SIGSEGV when freeing the line number table</li>
  * </ol>
  */
-public class CleanupAfterClassUnloadTest extends AbstractProfilerTest {
+public class CleanupAfterClassUnloadTest extends AbstractDynamicClassTest {
 
   // AGE_THRESHOLD in C++ is 3; run 4 dumps to ensure cleanup fires
   private static final int DUMPS_TO_AGE_OUT = 4;
@@ -68,8 +62,6 @@ public class CleanupAfterClassUnloadTest extends AbstractProfilerTest {
   protected String getProfilerCommand() {
     return "cpu=1ms";
   }
-
-  private int classCounter = 0;
 
   @Test
   @Timeout(60)
@@ -134,7 +126,7 @@ public class CleanupAfterClassUnloadTest extends AbstractProfilerTest {
    */
   private WeakReference<ClassLoader> loadAndProfileDynamicClass() throws Exception {
     String className = "com/datadoghq/profiler/generated/Prof14545Class" + (classCounter++);
-    byte[] bytecode = generateClassBytecode(className);
+    byte[] bytecode = generateClassBytecode(className, 5);
 
     IsolatedClassLoader loader = new IsolatedClassLoader();
     Class<?> clazz = loader.defineClass(className.replace('/', '.'), bytecode);
@@ -161,55 +153,5 @@ public class CleanupAfterClassUnloadTest extends AbstractProfilerTest {
     //noinspection UnusedAssignment
     instance = null;
     return ref;
-  }
-
-  private byte[] generateClassBytecode(String className) {
-    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
-    cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, className, null, "java/lang/Object", null);
-
-    MethodVisitor ctor = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
-    ctor.visitCode();
-    ctor.visitVarInsn(Opcodes.ALOAD, 0);
-    ctor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-    ctor.visitInsn(Opcodes.RETURN);
-    ctor.visitMaxs(0, 0);
-    ctor.visitEnd();
-
-    // Generate 5 methods, each with multiple line number entries to ensure
-    // GetLineNumberTable is called and returns a non-trivial table.
-    for (int i = 0; i < 5; i++) {
-      MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "method" + i, "()I", null, null);
-      mv.visitCode();
-
-      Label l1 = new Label(); mv.visitLabel(l1); mv.visitLineNumber(100 + i * 3, l1);
-      mv.visitInsn(Opcodes.ICONST_0);
-      mv.visitVarInsn(Opcodes.ISTORE, 1);
-
-      Label l2 = new Label(); mv.visitLabel(l2); mv.visitLineNumber(101 + i * 3, l2);
-      mv.visitVarInsn(Opcodes.ILOAD, 1);
-      mv.visitInsn(Opcodes.ICONST_1);
-      mv.visitInsn(Opcodes.IADD);
-      mv.visitVarInsn(Opcodes.ISTORE, 1);
-
-      Label l3 = new Label(); mv.visitLabel(l3); mv.visitLineNumber(102 + i * 3, l3);
-      mv.visitVarInsn(Opcodes.ILOAD, 1);
-      mv.visitInsn(Opcodes.IRETURN);
-
-      mv.visitMaxs(0, 0);
-      mv.visitEnd();
-    }
-
-    cw.visitEnd();
-    return cw.toByteArray();
-  }
-
-  private static Path tempFile(String prefix) throws IOException {
-    return File.createTempFile(prefix + "-", ".jfr").toPath();
-  }
-
-  private static class IsolatedClassLoader extends ClassLoader {
-    public Class<?> defineClass(String name, byte[] bytecode) {
-      return defineClass(name, bytecode, 0, bytecode.length);
-    }
   }
 }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/CleanupAfterClassUnloadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/CleanupAfterClassUnloadTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2026, Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.profiler.memleak;
+
+import com.datadoghq.profiler.AbstractProfilerTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Regression test for PROF-14545: SIGSEGV in Recording::cleanupUnreferencedMethods.
+ *
+ * <p>The bug: cleanupUnreferencedMethods() was called after finishChunk() released its
+ * GetLoadedClasses pins. The class pins are JNI local references that prevent concurrent
+ * GC from unloading a class between resolveMethod() JVMTI calls and the Deallocate that
+ * frees the line-number-table buffer. Calling cleanupUnreferencedMethods() after the pins
+ * were released created a window where, on JVM implementations that free JVMTI-allocated
+ * line-number-table memory on class unload, Deallocate could access freed memory → SIGSEGV.
+ *
+ * <p>The fix: cleanupUnreferencedMethods() is now called inside finishChunk(), before
+ * DeleteLocalRef releases the pins, closing the concurrent-unload race window during
+ * finishChunk(). Note: this ordering does not protect against classes that were already
+ * fully unloaded before finishChunk() began; for those, correctness relies on the JVMTI
+ * contract that the caller owns memory returned by GetLineNumberTable and the JVM must
+ * not reclaim it on class unload.
+ *
+ * <p>This test reproduces the crash scenario:
+ * <ol>
+ *   <li>A dynamically-loaded class with line number tables appears in profiling stack traces</li>
+ *   <li>All references to the class and its class loader are dropped</li>
+ *   <li>The JVM is encouraged to GC and unload the class (System.gc())</li>
+ *   <li>AGE_THRESHOLD+1 dump cycles are triggered to age the method out of the method_map</li>
+ *   <li>cleanupUnreferencedMethods() must not SIGSEGV when freeing the line number table</li>
+ * </ol>
+ */
+public class CleanupAfterClassUnloadTest extends AbstractProfilerTest {
+
+  // AGE_THRESHOLD in C++ is 3; run 4 dumps to ensure cleanup fires
+  private static final int DUMPS_TO_AGE_OUT = 4;
+
+  @Override
+  protected String getProfilerCommand() {
+    return "cpu=1ms";
+  }
+
+  private int classCounter = 0;
+
+  @Test
+  @Timeout(60)
+  public void testNoSigsegvAfterClassUnloadAndMethodCleanup() throws Exception {
+    stopProfiler();
+
+    Path baseFile = tempFile("prof14545-base");
+    Path dumpFile = tempFile("prof14545-dump");
+
+    try {
+      profiler.execute(
+          "start,cpu=1ms,jfr,mcleanup=true,file=" + baseFile.toAbsolutePath());
+      Thread.sleep(200); // Let the profiler stabilize
+
+      // 1. Load a class, execute its methods to appear in CPU profiling stack traces,
+      //    then drop all strong references so the class can be GC'd.
+      WeakReference<ClassLoader> loaderRef = loadAndProfileDynamicClass();
+
+      // 2. Trigger one dump so the profiler captures the class in method_map.
+      profiler.dump(dumpFile);
+      Thread.sleep(50);
+
+      // 3. Drop all references and aggressively GC to encourage class unloading.
+      //    We poll until the WeakReference is cleared or we time out.
+      long deadline = System.currentTimeMillis() + 8_000;
+      while (loaderRef.get() != null && System.currentTimeMillis() < deadline) {
+        System.gc();
+        Thread.sleep(30);
+      }
+      assumeTrue(loaderRef.get() == null,
+          "Skipping: class loader not GC'd within 8 s — class unloading is required for this test to be meaningful");
+
+      // 4. Run AGE_THRESHOLD+1 dump cycles so the method ages out and cleanup fires.
+      //    The method is no longer referenced (no stack traces) → age increments each cycle.
+      //    After age >= 3 and the next cleanup pass, the entry is erased and
+      //    SharedLineNumberTable::~SharedLineNumberTable() → jvmti->Deallocate() runs.
+      //    Without the fix this is after DeleteLocalRef; with the fix it is before.
+      for (int i = 0; i < DUMPS_TO_AGE_OUT; i++) {
+        profiler.dump(dumpFile);
+        Thread.sleep(50);
+      }
+
+      // 5. The profiler must still be alive. If it SIGSEGV'd during cleanup the JVM
+      //    process would have died and this line would never be reached.
+      profiler.stop();
+
+      assertTrue(Files.size(dumpFile) > 0,
+          "Profiler produced no output — it may have crashed during method_map cleanup");
+
+    } finally {
+      try { profiler.stop(); } catch (Exception ignored) {}
+      try { Files.deleteIfExists(baseFile); } catch (IOException ignored) {}
+      try { Files.deleteIfExists(dumpFile); } catch (IOException ignored) {}
+    }
+  }
+
+  /**
+   * Loads a dynamically-generated class with line number tables in a fresh ClassLoader,
+   * invokes its methods on the current thread while CPU profiling is active so that
+   * the profiler calls GetLineNumberTable and stores it in method_map, then returns a
+   * WeakReference to the ClassLoader so callers can detect unloading.
+   */
+  private WeakReference<ClassLoader> loadAndProfileDynamicClass() throws Exception {
+    String className = "com/datadoghq/profiler/generated/Prof14545Class" + (classCounter++);
+    byte[] bytecode = generateClassBytecode(className);
+
+    IsolatedClassLoader loader = new IsolatedClassLoader();
+    Class<?> clazz = loader.defineClass(className.replace('/', '.'), bytecode);
+
+    // Spin-invoke the class methods for ~200ms so the CPU profiler has time to
+    // capture this thread and include the dynamic class in a stack trace.
+    long endTime = System.currentTimeMillis() + 200;
+    Object instance = clazz.getDeclaredConstructor().newInstance();
+    Method[] methods = clazz.getDeclaredMethods();
+    while (System.currentTimeMillis() < endTime) {
+      for (Method m : methods) {
+        if (m.getParameterCount() == 0 && m.getReturnType() == int.class) {
+          m.invoke(instance);
+        }
+      }
+    }
+
+    // Drop all strong references. Only the WeakReference remains.
+    WeakReference<ClassLoader> ref = new WeakReference<>(loader);
+    //noinspection UnusedAssignment
+    loader = null;
+    //noinspection UnusedAssignment
+    clazz = null;
+    //noinspection UnusedAssignment
+    instance = null;
+    return ref;
+  }
+
+  private byte[] generateClassBytecode(String className) {
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+    cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, className, null, "java/lang/Object", null);
+
+    MethodVisitor ctor = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+    ctor.visitCode();
+    ctor.visitVarInsn(Opcodes.ALOAD, 0);
+    ctor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+    ctor.visitInsn(Opcodes.RETURN);
+    ctor.visitMaxs(0, 0);
+    ctor.visitEnd();
+
+    // Generate 5 methods, each with multiple line number entries to ensure
+    // GetLineNumberTable is called and returns a non-trivial table.
+    for (int i = 0; i < 5; i++) {
+      MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "method" + i, "()I", null, null);
+      mv.visitCode();
+
+      Label l1 = new Label(); mv.visitLabel(l1); mv.visitLineNumber(100 + i * 3, l1);
+      mv.visitInsn(Opcodes.ICONST_0);
+      mv.visitVarInsn(Opcodes.ISTORE, 1);
+
+      Label l2 = new Label(); mv.visitLabel(l2); mv.visitLineNumber(101 + i * 3, l2);
+      mv.visitVarInsn(Opcodes.ILOAD, 1);
+      mv.visitInsn(Opcodes.ICONST_1);
+      mv.visitInsn(Opcodes.IADD);
+      mv.visitVarInsn(Opcodes.ISTORE, 1);
+
+      Label l3 = new Label(); mv.visitLabel(l3); mv.visitLineNumber(102 + i * 3, l3);
+      mv.visitVarInsn(Opcodes.ILOAD, 1);
+      mv.visitInsn(Opcodes.IRETURN);
+
+      mv.visitMaxs(0, 0);
+      mv.visitEnd();
+    }
+
+    cw.visitEnd();
+    return cw.toByteArray();
+  }
+
+  private static Path tempFile(String prefix) throws IOException {
+    return File.createTempFile(prefix + "-", ".jfr").toPath();
+  }
+
+  private static class IsolatedClassLoader extends ClassLoader {
+    public Class<?> defineClass(String name, byte[] bytecode) {
+      return defineClass(name, bytecode, 0, bytecode.length);
+    }
+  }
+}

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/GetLineNumberTableLeakTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/GetLineNumberTableLeakTest.java
@@ -15,18 +15,12 @@
  */
 package com.datadoghq.profiler.memleak;
 
-import com.datadoghq.profiler.AbstractProfilerTest;
 import org.junit.jupiter.api.Test;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.Label;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Test to validate that method_map cleanup prevents unbounded memory growth in continuous profiling.
@@ -55,24 +49,12 @@ import java.nio.file.Paths;
  *   <li>Combined cleanup: method_map cleanup + class unloading</li>
  * </ul>
  */
-public class GetLineNumberTableLeakTest extends AbstractProfilerTest {
+public class GetLineNumberTableLeakTest extends AbstractDynamicClassTest {
 
   @Override
   protected String getProfilerCommand() {
     // Aggressive sampling to maximize method encounters and GetLineNumberTable calls
     return "cpu=1ms,alloc=512k";
-  }
-
-  private int classCounter = 0;
-
-  /**
-   * Custom ClassLoader for each dynamically generated class.
-   * Using a new ClassLoader for each class ensures truly unique Class objects and jmethodIDs.
-   */
-  private static class DynamicClassLoader extends ClassLoader {
-    public Class<?> defineClass(String name, byte[] bytecode) {
-      return defineClass(name, bytecode, 0, bytecode.length);
-    }
   }
 
   /**
@@ -88,10 +70,10 @@ public class GetLineNumberTableLeakTest extends AbstractProfilerTest {
 
     for (int i = 0; i < 5; i++) {
       String className = "com/datadoghq/profiler/generated/TestClass" + (classCounter++);
-      byte[] bytecode = generateClassBytecode(className);
+      byte[] bytecode = generateClassBytecode(className, 20);
 
       // Use a fresh ClassLoader to ensure truly unique Class object and jmethodIDs
-      DynamicClassLoader loader = new DynamicClassLoader();
+      IsolatedClassLoader loader = new IsolatedClassLoader();
       Class<?> clazz = loader.defineClass(className.replace('/', '.'), bytecode);
       generatedClasses[i] = clazz;
 
@@ -121,66 +103,6 @@ public class GetLineNumberTableLeakTest extends AbstractProfilerTest {
     } catch (Exception ignored) {
       // Ignore invocation errors - class/method loading is what matters for GetLineNumberTable
     }
-  }
-
-  /**
-   * Generates bytecode for a class with multiple methods.
-   * Each method has line number table entries to trigger GetLineNumberTable allocations.
-   */
-  private byte[] generateClassBytecode(String className) {
-    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
-    cw.visit(
-        Opcodes.V1_8,
-        Opcodes.ACC_PUBLIC,
-        className,
-        null,
-        "java/lang/Object",
-        null);
-
-    // Generate constructor
-    MethodVisitor constructor =
-        cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
-    constructor.visitCode();
-    constructor.visitVarInsn(Opcodes.ALOAD, 0);
-    constructor.visitMethodInsn(
-        Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-    constructor.visitInsn(Opcodes.RETURN);
-    constructor.visitMaxs(0, 0);
-    constructor.visitEnd();
-
-    // Generate 20 methods per class, each with line number tables
-    for (int i = 0; i < 20; i++) {
-      MethodVisitor mv =
-          cw.visitMethod(Opcodes.ACC_PUBLIC, "method" + i, "()I", null, null);
-      mv.visitCode();
-
-      // Add multiple line number entries (this is what causes GetLineNumberTable allocations)
-      Label label1 = new Label();
-      mv.visitLabel(label1);
-      mv.visitLineNumber(100 + i, label1);
-      mv.visitInsn(Opcodes.ICONST_0);
-      mv.visitVarInsn(Opcodes.ISTORE, 1);
-
-      Label label2 = new Label();
-      mv.visitLabel(label2);
-      mv.visitLineNumber(101 + i, label2);
-      mv.visitVarInsn(Opcodes.ILOAD, 1);
-      mv.visitInsn(Opcodes.ICONST_1);
-      mv.visitInsn(Opcodes.IADD);
-      mv.visitVarInsn(Opcodes.ISTORE, 1);
-
-      Label label3 = new Label();
-      mv.visitLabel(label3);
-      mv.visitLineNumber(102 + i, label3);
-      mv.visitVarInsn(Opcodes.ILOAD, 1);
-      mv.visitInsn(Opcodes.IRETURN);
-
-      mv.visitMaxs(0, 0);
-      mv.visitEnd();
-    }
-
-    cw.visitEnd();
-    return cw.toByteArray();
   }
 
   /**
@@ -316,9 +238,4 @@ public class GetLineNumberTableLeakTest extends AbstractProfilerTest {
     }
   }
 
-  private Path tempFile(String name) throws IOException {
-    Path dir = Paths.get("/tmp/recordings");
-    Files.createDirectories(dir);
-    return Files.createTempFile(dir, name + "-", ".jfr");
-  }
 }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/WriteStackTracesAfterClassUnloadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/WriteStackTracesAfterClassUnloadTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026, Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.datadoghq.profiler.memleak;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Regression test for a SIGSEGV in {@code Profiler::processCallTraces} during
+ * {@code Recording::writeStackTraces} triggered by class unload.
+ *
+ * <p><b>Bug:</b> {@code MethodInfo::_line_number_table->_ptr} held a raw pointer to JVMTI-allocated
+ * memory returned by {@code GetLineNumberTable}. When the underlying class was unloaded, the JVM
+ * freed that memory, leaving {@code _ptr} dangling. The crash manifested when
+ * {@code MethodInfo::getLineNumber(bci)} dereferenced the freed memory while
+ * {@code writeStackTraces} iterated traces that still referenced the now-unloaded method.
+ *
+ * <p><b>Test scenario (timing-sensitive — catches the bug aggressively under ASan):</b>
+ * <ol>
+ *   <li>Aggressively profile a dynamically-loaded class so its methods land in many CPU samples.
+ *       Each sample creates an entry in {@code call_trace_storage} and a {@code MethodInfo} entry
+ *       in {@code _method_map} that holds a {@code shared_ptr<SharedLineNumberTable>}.</li>
+ *   <li>Drop all strong references to the class and its loader; encourage unloading via
+ *       {@code System.gc()} until the {@code WeakReference} is cleared.</li>
+ *   <li>Immediately dump — within the same chunk if possible — so the freshly-unloaded method's
+ *       traces are still in {@code call_trace_storage} when {@code writeStackTraces} runs.</li>
+ *   <li>The lambda inside {@code processCallTraces} resolves the unloaded method via
+ *       {@code Lookup::resolveMethod} and calls {@code MethodInfo::getLineNumber(bci)} on a
+ *       {@code MethodInfo} whose {@code _line_number_table->_ptr} was freed by the JVM →
+ *       SIGSEGV without the fix.</li>
+ * </ol>
+ *
+ * <p>With the fix, {@code SharedLineNumberTable} owns a malloc'd copy of the entries
+ * (the JVMTI allocation is deallocated immediately at capture time inside
+ * {@code Lookup::fillJavaMethodInfo}), so {@code _ptr} stays valid regardless of class unload.
+ *
+ * <p><b>Limitations:</b>
+ * <ul>
+ *   <li>Not authored "blind" — the implementation existed before the test was written.</li>
+ *   <li>Without ASan/UBSan, the freed JVMTI region may still hold plausible bytes at read time
+ *       and the test will report green even on a buggy binary. ASan/UBSan builds are the
+ *       authoritative signal here.</li>
+ *   <li>Class unload is JVM-discretionary; if the {@code WeakReference} doesn't clear within
+ *       the deadline the test {@code assumeTrue}-skips rather than passing spuriously.</li>
+ *   <li>{@code mcleanup=false} is set deliberately so a SIGSEGV here exercises the
+ *       {@code getLineNumber} read path, not the {@code ~SharedLineNumberTable} cleanup path
+ *       covered by {@code CleanupAfterClassUnloadTest}.</li>
+ * </ul>
+ */
+public class WriteStackTracesAfterClassUnloadTest extends AbstractDynamicClassTest {
+
+  @Override
+  protected String getProfilerCommand() {
+    // Aggressive CPU sampling to ensure the dynamic class lands in many traces.
+    return "cpu=1ms";
+  }
+
+  @Test
+  @Timeout(60)
+  public void testNoSigsegvInWriteStackTracesAfterClassUnload() throws Exception {
+    stopProfiler();
+
+    Path baseFile = tempFile("class-unload-sigsegv-base");
+    Path dumpFile = tempFile("class-unload-sigsegv-dump");
+
+    try {
+      // mcleanup=false isolates the test to the writeStackTraces read path; the
+      // SharedLineNumberTable destructor path is covered by CleanupAfterClassUnloadTest.
+      profiler.execute("start,cpu=1ms,jfr,mcleanup=false,file=" + baseFile.toAbsolutePath());
+      try {
+        Thread.sleep(200); // let the profiler stabilize
+
+        // 1. Load a class, hammer its methods on this thread so the CPU profiler captures
+        //    many traces referencing it. Drop strong refs and return only a WeakReference.
+        WeakReference<ClassLoader> loaderRef = loadAndProfileDynamicClass();
+
+        // 2. Drop refs and GC until the class actually unloads.
+        long deadline = System.currentTimeMillis() + 8_000;
+        while (loaderRef.get() != null && System.currentTimeMillis() < deadline) {
+          System.gc();
+          Thread.sleep(20);
+        }
+
+        // Skip the test (rather than pass spuriously) if the JVM declined to unload.
+        // Without unload the JVMTI line-number-table memory is never freed and the bug
+        // cannot manifest — running the dumps would prove nothing.
+        assumeTrue(loaderRef.get() == null,
+            "JVM did not unload the dynamic class within the deadline; cannot exercise the use-after-free scenario");
+
+        // 3. Immediately dump several times. The first dump runs writeStackTraces over
+        //    the trace_buffer that still contains the unloaded method's traces; subsequent
+        //    dumps cover the rotation tail. With the bug, getLineNumber dereferences the
+        //    freed JVMTI memory → SIGSEGV. With the fix, _ptr is a malloc'd copy → safe.
+        for (int i = 0; i < 4; i++) {
+          profiler.dump(dumpFile);
+          Thread.sleep(10);
+        }
+
+        // 4. If the profiler crashed inside processCallTraces the JVM would have died and we
+        //    would never reach this line. The non-empty-output assertion is secondary — the
+        //    primary signal is reaching profiler.stop() at all.
+        assertTrue(Files.size(dumpFile) > 0,
+            "Profiler produced no output — SIGSEGV during writeStackTraces is suspected");
+      } finally {
+        try {
+          profiler.stop();
+        } finally {
+          profiler.resetThreadContext();
+        }
+      }
+
+    } finally {
+      try { Files.deleteIfExists(baseFile); } catch (IOException ignored) {}
+      try { Files.deleteIfExists(dumpFile); } catch (IOException ignored) {}
+    }
+  }
+
+  private WeakReference<ClassLoader> loadAndProfileDynamicClass() throws Exception {
+    String className = "com/datadoghq/profiler/generated/DynamicUnloadClass" + (classCounter++);
+    byte[] bytecode = generateClassBytecode(className, 5);
+
+    IsolatedClassLoader loader = new IsolatedClassLoader();
+    Class<?> clazz = loader.defineClass(className.replace('/', '.'), bytecode);
+
+    // Hammer methods for ~300ms so the CPU profiler at 1ms captures plenty of samples
+    // referencing this class. The longer this runs, the more traces survive into the
+    // dump-after-unload window.
+    long endTime = System.currentTimeMillis() + 300;
+    Object instance = clazz.getDeclaredConstructor().newInstance();
+    Method[] methods = clazz.getDeclaredMethods();
+    while (System.currentTimeMillis() < endTime) {
+      for (Method m : methods) {
+        if (m.getParameterCount() == 0 && m.getReturnType() == int.class) {
+          m.invoke(instance);
+        }
+      }
+    }
+
+    WeakReference<ClassLoader> ref = new WeakReference<>(loader);
+    //noinspection UnusedAssignment
+    loader = null;
+    //noinspection UnusedAssignment
+    clazz = null;
+    //noinspection UnusedAssignment
+    instance = null;
+    return ref;
+  }
+
+}


### PR DESCRIPTION
**What does this PR do?**:

Three thread-wrapper / recording-lifecycle SIGSEGVs in one focused PR. They share \`libraryPatcher_linux.cpp\` and are tightly coupled, so they land together as the base for the lock-free dictionary refactor in #524.

1. **Line number table UAF** — \`cleanupUnreferencedMethods()\` ran after \`finishChunk()\` released the \`GetLoadedClasses\` pins, so \`jvmti->Deallocate(_ptr)\` inside \`~SharedLineNumberTable\` could access freed memory on JVMs that reclaim JVMTI allocations on class unload. Fix: detach \`SharedLineNumberTable\` from JVMTI lifetime by copying the table into a \`malloc\`'d buffer in \`Lookup::fillJavaMethodInfo\`; destructor now calls \`free()\`. As defence-in-depth, \`finishChunk()\` gains a \`do_cleanup\` parameter so cleanup runs inside the pin window.

2. **musl/aarch64/JDK11 \`start_routine_wrapper_spec\` stack corruption** — HotSpot's deoptimisation blob (\`generate_deopt_blob\` in \`sharedRuntime_aarch64.cpp\`) rebuilds interpreter frames near the compiled frame's stack boundary, corrupting the top ~224 bytes of the thread stack where this wrapper lives. Two symptoms result: \`-fstack-protector-strong\` inserts a canary that lands in the corruption zone and fires \`__stack_chk_fail\`; \`return\` loads the corrupted saved LR and jumps to garbage. Fix: \`no_stack_protector\` removes the canary, \`pthread_exit()\` replaces \`return\` so the corrupted LR is never used, cleanup runs explicitly with tid read from TLS.

3. **SIGVTALRM teardown race** — \`JavaThread::~JavaThread\` / \`OSThread::~OSThread\` crashed on JDK 25 because a SIGVTALRM delivered between \`Profiler::unregisterThread()\` returning and \`ProfiledThread::release()\` acquiring its internal guard dereferenced a now-freed \`ProfiledThread\` via \`currentSignalSafe()\`. Fix: extract \`unregister_and_release(tid)\` — a \`noinline\` helper that holds a \`SignalBlocker\` for the entire unregister+release sequence. Both \`start_routine_wrapper\` and \`start_routine_wrapper_spec\` invoke it; same pattern is applied to \`pthread_setspecific_hook\` teardown in \`perfEvents_linux.cpp\`.

**Motivation**:
- Line number table UAF: production SIGSEGV in dd-trace-java 1.56.1+ after PR #327 introduced method-map cleanup.
- musl/aarch64 wrapper: \`test-linux-musl-aarch64 (11-librca, debug)\` CI failure with \`__stack_chk_fail\` in \`start_routine_wrapper_spec\`.
- SIGVTALRM teardown race: JDK 25 crashes in \`JavaThread::~JavaThread\` after \`unregisterThread()\` returned but before \`release()\` acquired its guard.

**Additional Notes**:
- Also includes a small ordering fix in \`LivenessTracker::initialize\` so \`_record_heap_usage\` is updated before the \`_initialized\` early-return.
- The musl/aarch64 change supersedes the \`try/catch (abi::__forced_unwind&)\` approach that was in #524's previous version. #524 has been rebased onto this PR with its \`libraryPatcher_linux.cpp\` changes dropped.
- \`thread.h\` gains an \`#ifdef UNIT_TEST\` guard on \`clearCurrentThreadTLS()\`; \`GtestTaskBuilder.kt\` adds \`-DUNIT_TEST\` to gtest compiler flags so the guarded method compiles in tests.
- Replaces #526 and #529, which were focused-rewrite predecessors.

**How to test the change?**:
- \`CleanupAfterClassUnloadTest\`: loads a class, triggers profiling of its frames, unloads it, runs \`AGE_THRESHOLD+1\` dump cycles; profiler must produce JFR output without SIGSEGV.
- \`WriteStackTracesAfterClassUnloadTest\`: similar scenario exercising the stack-trace write path after unload.
- \`forced_unwind_ut\`: C++ unit tests for the \`start_routine_wrapper_spec\` musl/aarch64 path.
- \`thread_teardown_safety_ut\` (\`ThreadTeardownSafetyTest\` T-01..T-10): acceptance suite covering the full teardown lifecycle under signal load.
- CI: \`test-linux-musl-aarch64 (11-librca, debug)\` must be green.

**For Datadog employees**:

- [x] This PR doesn't touch any of that.

- [x] JIRA: [PROF-14545](https://datadoghq.atlassian.net/browse/PROF-14545), [PROF-14603](https://datadoghq.atlassian.net/browse/PROF-14603)

[PROF-14545]: https://datadoghq.atlassian.net/browse/PROF-14545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ