### PR TITLE
fix: own line number table memory to avoid UAF on class unload (PROF-14547)

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -45,23 +45,12 @@ static const char *const SETTING_RING[] = {NULL, "kernel", "user", "any"};
 static const char *const SETTING_CSTACK[] = {NULL, "no", "fp", "dwarf", "lbr"};
 
 SharedLineNumberTable::~SharedLineNumberTable() {
-  // Always attempt to deallocate if we have a valid pointer
-  // JVMTI spec requires that memory allocated by GetLineNumberTable
-  // must be freed with Deallocate
+  // _ptr is a malloc'd copy of the JVMTI line number table (see
+  // Lookup::fillJavaMethodInfo). Freeing here is independent of class
+  // unload — fixes PROF-14545 (~SharedLineNumberTable Deallocate UAF)
+  // and PROF-14547 (getLineNumber UAF during writeStackTraces).
   if (_ptr != nullptr) {
-    jvmtiEnv *jvmti = VM::jvmti();
-    if (jvmti != nullptr) {
-      jvmtiError err = jvmti->Deallocate((unsigned char *)_ptr);
-      // If Deallocate fails, log it for debugging (this could indicate a JVM bug)
-      // JVMTI_ERROR_ILLEGAL_ARGUMENT means the memory wasn't allocated by JVMTI
-      // which would be a serious bug in GetLineNumberTable
-      if (err != JVMTI_ERROR_NONE) {
-        TEST_LOG("Unexpected error while deallocating linenumber table: %d", err);
-      }
-    } else {
-      TEST_LOG("WARNING: Cannot deallocate line number table - JVMTI is null");
-    }
-    // Decrement counter whenever destructor runs (symmetric with increment at creation)
+    free(_ptr);
     Counters::decrement(LINE_NUMBER_TABLES);
   }
 }
@@ -308,10 +297,30 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
     mi->_type = FRAME_INTERPRETED;
     mi->_is_entry = entry;
     if (line_number_table != nullptr) {
-      mi->_line_number_table = std::make_shared<SharedLineNumberTable>(
-          line_number_table_size, line_number_table);
-      // Increment counter for tracking live line number tables
-      Counters::increment(LINE_NUMBER_TABLES);
+      // Detach from JVMTI lifetime: copy into our own buffer and deallocate
+      // the JVMTI-allocated memory immediately. This keeps _ptr valid even
+      // after the underlying class is unloaded — see PROF-14547.
+      void *owned_table = nullptr;
+      if (line_number_table_size > 0) {
+        size_t bytes = (size_t)line_number_table_size * sizeof(jvmtiLineNumberEntry);
+        owned_table = malloc(bytes);
+        if (owned_table != nullptr) {
+          memcpy(owned_table, line_number_table, bytes);
+        } else {
+          TEST_LOG("Failed to allocate %zu bytes for line number table copy", bytes);
+        }
+      }
+      jvmtiError dealloc_err = jvmti->Deallocate((unsigned char *)line_number_table);
+      if (dealloc_err != JVMTI_ERROR_NONE) {
+        TEST_LOG("Unexpected error while deallocating linenumber table: %d", dealloc_err);
+      }
+      line_number_table = nullptr;
+      if (owned_table != nullptr) {
+        mi->_line_number_table = std::make_shared<SharedLineNumberTable>(
+            line_number_table_size, owned_table);
+        // Increment counter for tracking live line number tables
+        Counters::increment(LINE_NUMBER_TABLES);
+      }
     }
 
     // strings are null or came from JVMTI

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -313,7 +313,6 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
       if (dealloc_err != JVMTI_ERROR_NONE) {
         TEST_LOG("Unexpected error while deallocating linenumber table: %d", dealloc_err);
       }
-      line_number_table = nullptr;
       if (owned_table != nullptr) {
         mi->_line_number_table = std::make_shared<SharedLineNumberTable>(
             line_number_table_size, owned_table);

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -47,8 +47,7 @@ static const char *const SETTING_CSTACK[] = {NULL, "no", "fp", "dwarf", "lbr"};
 SharedLineNumberTable::~SharedLineNumberTable() {
   // _ptr is a malloc'd copy of the JVMTI line number table (see
   // Lookup::fillJavaMethodInfo). Freeing here is independent of class
-  // unload — fixes PROF-14545 (~SharedLineNumberTable Deallocate UAF)
-  // and PROF-14547 (getLineNumber UAF during writeStackTraces).
+  // unload, preventing use-after-free in ~SharedLineNumberTable and getLineNumber.
   if (_ptr != nullptr) {
     free(_ptr);
     Counters::decrement(LINE_NUMBER_TABLES);
@@ -299,7 +298,7 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
     if (line_number_table != nullptr) {
       // Detach from JVMTI lifetime: copy into our own buffer and deallocate
       // the JVMTI-allocated memory immediately. This keeps _ptr valid even
-      // after the underlying class is unloaded — see PROF-14547.
+      // after the underlying class is unloaded.
       void *owned_table = nullptr;
       if (line_number_table_size > 0) {
         size_t bytes = (size_t)line_number_table_size * sizeof(jvmtiLineNumberEntry);
@@ -938,8 +937,8 @@ void Recording::writeSettings(Buffer *buf, Arguments &args) {
   writeBoolSetting(buf, T_MALLOC, "enabled", args._nativemem >= 0);
   if (args._nativemem >= 0) {
     writeIntSetting(buf, T_MALLOC, "nativemem", args._nativemem);
-    // samplingInterval=-1 means every allocation is recorded (nativemem=0).
-    writeIntSetting(buf, T_MALLOC, "samplingInterval", args._nativemem == 0 ? -1 : args._nativemem);
+    // samplingInterval=-1 signals "record every allocation"; mirrors shouldSample's interval<=1 threshold.
+    writeIntSetting(buf, T_MALLOC, "samplingInterval", args._nativemem <= 1 ? -1 : args._nativemem);
   }
 
   writeBoolSetting(buf, T_ACTIVE_RECORDING, "debugSymbols",

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -61,7 +61,7 @@ public:
   int _size;
   // Owned malloc'd buffer holding a copy of the JVMTI line number table.
   // Owning the memory (instead of holding the JVMTI-allocated pointer
-  // directly) keeps lifetime independent of class unload — see PROF-14547.
+  // directly) keeps lifetime independent of class unload.
   void *_ptr;
 
   SharedLineNumberTable(int size, void *ptr) : _size(size), _ptr(ptr) {}

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -59,6 +59,9 @@ struct CpuTimes {
 class SharedLineNumberTable {
 public:
   int _size;
+  // Owned malloc'd buffer holding a copy of the JVMTI line number table.
+  // Owning the memory (instead of holding the JVMTI-allocated pointer
+  // directly) keeps lifetime independent of class unload — see PROF-14547.
   void *_ptr;
 
   SharedLineNumberTable(int size, void *ptr) : _size(size), _ptr(ptr) {}

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/AbstractDynamicClassTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/AbstractDynamicClassTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026, Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.datadoghq.profiler.memleak;
+
+import com.datadoghq.profiler.AbstractProfilerTest;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+abstract class AbstractDynamicClassTest extends AbstractProfilerTest {
+
+  protected int classCounter = 0;
+
+  /**
+   * Generates ASM bytecode for a class with a constructor and {@code methodCount} public
+   * int-returning no-arg methods, each with multiple line-number table entries.
+   */
+  protected byte[] generateClassBytecode(String className, int methodCount) {
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+    cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, className, null, "java/lang/Object", null);
+
+    MethodVisitor ctor = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+    ctor.visitCode();
+    ctor.visitVarInsn(Opcodes.ALOAD, 0);
+    ctor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+    ctor.visitInsn(Opcodes.RETURN);
+    ctor.visitMaxs(0, 0);
+    ctor.visitEnd();
+
+    for (int i = 0; i < methodCount; i++) {
+      MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "method" + i, "()I", null, null);
+      mv.visitCode();
+
+      Label l1 = new Label(); mv.visitLabel(l1); mv.visitLineNumber(100 + i * 3, l1);
+      mv.visitInsn(Opcodes.ICONST_0);
+      mv.visitVarInsn(Opcodes.ISTORE, 1);
+
+      Label l2 = new Label(); mv.visitLabel(l2); mv.visitLineNumber(101 + i * 3, l2);
+      mv.visitVarInsn(Opcodes.ILOAD, 1);
+      mv.visitInsn(Opcodes.ICONST_1);
+      mv.visitInsn(Opcodes.IADD);
+      mv.visitVarInsn(Opcodes.ISTORE, 1);
+
+      Label l3 = new Label(); mv.visitLabel(l3); mv.visitLineNumber(102 + i * 3, l3);
+      mv.visitVarInsn(Opcodes.ILOAD, 1);
+      mv.visitInsn(Opcodes.IRETURN);
+
+      mv.visitMaxs(0, 0);
+      mv.visitEnd();
+    }
+
+    cw.visitEnd();
+    return cw.toByteArray();
+  }
+
+  protected static Path tempFile(String prefix) throws IOException {
+    Path dir = Paths.get(System.getProperty("java.io.tmpdir"), "recordings");
+    Files.createDirectories(dir);
+    return Files.createTempFile(dir, prefix + "-", ".jfr");
+  }
+
+  protected static class IsolatedClassLoader extends ClassLoader {
+    public Class<?> defineClass(String name, byte[] bytecode) {
+      return defineClass(name, bytecode, 0, bytecode.length);
+    }
+  }
+}

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/GetLineNumberTableLeakTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/GetLineNumberTableLeakTest.java
@@ -15,18 +15,12 @@
  */
 package com.datadoghq.profiler.memleak;
 
-import com.datadoghq.profiler.AbstractProfilerTest;
 import org.junit.jupiter.api.Test;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.Label;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Test to validate that method_map cleanup prevents unbounded memory growth in continuous profiling.
@@ -55,24 +49,12 @@ import java.nio.file.Paths;
  *   <li>Combined cleanup: method_map cleanup + class unloading</li>
  * </ul>
  */
-public class GetLineNumberTableLeakTest extends AbstractProfilerTest {
+public class GetLineNumberTableLeakTest extends AbstractDynamicClassTest {
 
   @Override
   protected String getProfilerCommand() {
     // Aggressive sampling to maximize method encounters and GetLineNumberTable calls
     return "cpu=1ms,alloc=512k";
-  }
-
-  private int classCounter = 0;
-
-  /**
-   * Custom ClassLoader for each dynamically generated class.
-   * Using a new ClassLoader for each class ensures truly unique Class objects and jmethodIDs.
-   */
-  private static class DynamicClassLoader extends ClassLoader {
-    public Class<?> defineClass(String name, byte[] bytecode) {
-      return defineClass(name, bytecode, 0, bytecode.length);
-    }
   }
 
   /**
@@ -88,10 +70,10 @@ public class GetLineNumberTableLeakTest extends AbstractProfilerTest {
 
     for (int i = 0; i < 5; i++) {
       String className = "com/datadoghq/profiler/generated/TestClass" + (classCounter++);
-      byte[] bytecode = generateClassBytecode(className);
+      byte[] bytecode = generateClassBytecode(className, 20);
 
       // Use a fresh ClassLoader to ensure truly unique Class object and jmethodIDs
-      DynamicClassLoader loader = new DynamicClassLoader();
+      IsolatedClassLoader loader = new IsolatedClassLoader();
       Class<?> clazz = loader.defineClass(className.replace('/', '.'), bytecode);
       generatedClasses[i] = clazz;
 
@@ -121,66 +103,6 @@ public class GetLineNumberTableLeakTest extends AbstractProfilerTest {
     } catch (Exception ignored) {
       // Ignore invocation errors - class/method loading is what matters for GetLineNumberTable
     }
-  }
-
-  /**
-   * Generates bytecode for a class with multiple methods.
-   * Each method has line number table entries to trigger GetLineNumberTable allocations.
-   */
-  private byte[] generateClassBytecode(String className) {
-    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
-    cw.visit(
-        Opcodes.V1_8,
-        Opcodes.ACC_PUBLIC,
-        className,
-        null,
-        "java/lang/Object",
-        null);
-
-    // Generate constructor
-    MethodVisitor constructor =
-        cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
-    constructor.visitCode();
-    constructor.visitVarInsn(Opcodes.ALOAD, 0);
-    constructor.visitMethodInsn(
-        Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-    constructor.visitInsn(Opcodes.RETURN);
-    constructor.visitMaxs(0, 0);
-    constructor.visitEnd();
-
-    // Generate 20 methods per class, each with line number tables
-    for (int i = 0; i < 20; i++) {
-      MethodVisitor mv =
-          cw.visitMethod(Opcodes.ACC_PUBLIC, "method" + i, "()I", null, null);
-      mv.visitCode();
-
-      // Add multiple line number entries (this is what causes GetLineNumberTable allocations)
-      Label label1 = new Label();
-      mv.visitLabel(label1);
-      mv.visitLineNumber(100 + i, label1);
-      mv.visitInsn(Opcodes.ICONST_0);
-      mv.visitVarInsn(Opcodes.ISTORE, 1);
-
-      Label label2 = new Label();
-      mv.visitLabel(label2);
-      mv.visitLineNumber(101 + i, label2);
-      mv.visitVarInsn(Opcodes.ILOAD, 1);
-      mv.visitInsn(Opcodes.ICONST_1);
-      mv.visitInsn(Opcodes.IADD);
-      mv.visitVarInsn(Opcodes.ISTORE, 1);
-
-      Label label3 = new Label();
-      mv.visitLabel(label3);
-      mv.visitLineNumber(102 + i, label3);
-      mv.visitVarInsn(Opcodes.ILOAD, 1);
-      mv.visitInsn(Opcodes.IRETURN);
-
-      mv.visitMaxs(0, 0);
-      mv.visitEnd();
-    }
-
-    cw.visitEnd();
-    return cw.toByteArray();
   }
 
   /**
@@ -316,9 +238,4 @@ public class GetLineNumberTableLeakTest extends AbstractProfilerTest {
     }
   }
 
-  private Path tempFile(String name) throws IOException {
-    Path dir = Paths.get("/tmp/recordings");
-    Files.createDirectories(dir);
-    return Files.createTempFile(dir, name + "-", ".jfr");
-  }
 }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/WriteStackTracesAfterClassUnloadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/WriteStackTracesAfterClassUnloadTest.java
@@ -93,41 +93,47 @@ public class WriteStackTracesAfterClassUnloadTest extends AbstractProfilerTest {
       // mcleanup=false isolates the test to the PROF-14547 read path; the
       // PROF-14545 cleanup path is covered separately by CleanupAfterClassUnloadTest.
       profiler.execute("start,cpu=1ms,jfr,mcleanup=false,file=" + baseFile.toAbsolutePath());
-      Thread.sleep(200); // let the profiler stabilize
+      try {
+        Thread.sleep(200); // let the profiler stabilize
 
-      // 1. Load a class, hammer its methods on this thread so the CPU profiler captures
-      //    many traces referencing it. Drop strong refs and return only a WeakReference.
-      WeakReference<ClassLoader> loaderRef = loadAndProfileDynamicClass();
+        // 1. Load a class, hammer its methods on this thread so the CPU profiler captures
+        //    many traces referencing it. Drop strong refs and return only a WeakReference.
+        WeakReference<ClassLoader> loaderRef = loadAndProfileDynamicClass();
 
-      // 2. Drop refs and GC until the class actually unloads.
-      long deadline = System.currentTimeMillis() + 8_000;
-      while (loaderRef.get() != null && System.currentTimeMillis() < deadline) {
-        System.gc();
-        Thread.sleep(20);
+        // 2. Drop refs and GC until the class actually unloads.
+        long deadline = System.currentTimeMillis() + 8_000;
+        while (loaderRef.get() != null && System.currentTimeMillis() < deadline) {
+          System.gc();
+          Thread.sleep(20);
+        }
+
+        // Skip the test (rather than pass spuriously) if the JVM declined to unload.
+        // Without unload the JVMTI line-number-table memory is never freed and the bug
+        // cannot manifest — running the dumps would prove nothing.
+        assumeTrue(loaderRef.get() == null,
+            "JVM did not unload the dynamic class within the deadline; cannot exercise PROF-14547");
+
+        // 3. Immediately dump several times. The first dump runs writeStackTraces over
+        //    the trace_buffer that still contains the unloaded method's traces; subsequent
+        //    dumps cover the rotation tail. With the bug, getLineNumber dereferences the
+        //    freed JVMTI memory → SIGSEGV. With the fix, _ptr is a malloc'd copy → safe.
+        for (int i = 0; i < 4; i++) {
+          profiler.dump(dumpFile);
+          Thread.sleep(10);
+        }
+
+        // 4. If the profiler crashed inside processCallTraces the JVM would have died and we
+        //    would never reach this line. The non-empty-output assertion is secondary — the
+        //    primary signal is reaching profiler.stop() at all.
+        assertTrue(Files.size(dumpFile) > 0,
+            "Profiler produced no output — SIGSEGV during writeStackTraces is suspected");
+      } finally {
+        try {
+          profiler.stop();
+        } finally {
+          resetThreadContext();
+        }
       }
-
-      // Skip the test (rather than pass spuriously) if the JVM declined to unload.
-      // Without unload the JVMTI line-number-table memory is never freed and the bug
-      // cannot manifest — running the dumps would prove nothing.
-      assumeTrue(loaderRef.get() == null,
-          "JVM did not unload the dynamic class within the deadline; cannot exercise PROF-14547");
-
-      // 3. Immediately dump several times. The first dump runs writeStackTraces over
-      //    the trace_buffer that still contains the unloaded method's traces; subsequent
-      //    dumps cover the rotation tail. With the bug, getLineNumber dereferences the
-      //    freed JVMTI memory → SIGSEGV. With the fix, _ptr is a malloc'd copy → safe.
-      for (int i = 0; i < 4; i++) {
-        profiler.dump(dumpFile);
-        Thread.sleep(10);
-      }
-
-      // 4. If the profiler crashed inside processCallTraces the JVM would have died and we
-      //    would never reach this line. The non-empty-output assertion is secondary — the
-      //    primary signal is reaching profiler.stop() at all.
-      profiler.stop();
-
-      assertTrue(Files.size(dumpFile) > 0,
-          "Profiler produced no output — SIGSEGV during writeStackTraces is suspected");
 
     } finally {
       try { Files.deleteIfExists(baseFile); } catch (IOException ignored) {}

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/WriteStackTracesAfterClassUnloadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/WriteStackTracesAfterClassUnloadTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2026, Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.datadoghq.profiler.memleak;
+
+import com.datadoghq.profiler.AbstractProfilerTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Regression test for PROF-14547: SIGSEGV in {@code Profiler::processCallTraces} during
+ * {@code Recording::writeStackTraces}.
+ *
+ * <p><b>Bug:</b> {@code MethodInfo::_line_number_table->_ptr} held a raw pointer to JVMTI-allocated
+ * memory returned by {@code GetLineNumberTable}. When the underlying class was unloaded, the JVM
+ * freed that memory, leaving {@code _ptr} dangling. The crash manifested when
+ * {@code MethodInfo::getLineNumber(bci)} dereferenced the freed memory while
+ * {@code writeStackTraces} iterated traces that still referenced the now-unloaded method
+ * (a peer manifestation of PROF-14545, which crashes inside
+ * {@code SharedLineNumberTable::~SharedLineNumberTable} via {@code Deallocate}).
+ *
+ * <p><b>Test scenario (timing-sensitive — catches the bug aggressively under ASan):</b>
+ * <ol>
+ *   <li>Aggressively profile a dynamically-loaded class so its methods land in many CPU samples.
+ *       Each sample creates an entry in {@code call_trace_storage} and a {@code MethodInfo} entry
+ *       in {@code _method_map} that holds a {@code shared_ptr<SharedLineNumberTable>}.</li>
+ *   <li>Drop all strong references to the class and its loader; encourage unloading via
+ *       {@code System.gc()} until the {@code WeakReference} is cleared.</li>
+ *   <li>Immediately dump — within the same chunk if possible — so the freshly-unloaded method's
+ *       traces are still in {@code call_trace_storage} when {@code writeStackTraces} runs.</li>
+ *   <li>The lambda inside {@code processCallTraces} resolves the unloaded method via
+ *       {@code Lookup::resolveMethod} and calls {@code MethodInfo::getLineNumber(bci)} on a
+ *       {@code MethodInfo} whose {@code _line_number_table->_ptr} was freed by the JVM →
+ *       SIGSEGV without the fix.</li>
+ * </ol>
+ *
+ * <p>With the fix (PROF-14547), {@code SharedLineNumberTable} owns a malloc'd copy of the entries
+ * (the JVMTI allocation is deallocated immediately at capture time inside
+ * {@code Lookup::fillJavaMethodInfo}), so {@code _ptr} stays valid regardless of class unload.
+ *
+ * <p><b>Limitations:</b>
+ * <ul>
+ *   <li>Not authored "blind" — the implementation existed before the test was written.</li>
+ *   <li>Without ASan/UBSan, the freed JVMTI region may still hold plausible bytes at read time
+ *       and the test will report green even on a buggy binary. ASan/UBSan builds are the
+ *       authoritative signal here.</li>
+ *   <li>Class unload is JVM-discretionary; if the {@code WeakReference} doesn't clear within
+ *       the deadline the test {@code assumeTrue}-skips rather than passing spuriously.</li>
+ *   <li>{@code mcleanup=false} is set deliberately so a SIGSEGV here is unambiguously the
+ *       PROF-14547 read path, not the PROF-14545 cleanup path covered by
+ *       {@code CleanupAfterClassUnloadTest}.</li>
+ * </ul>
+ */
+public class WriteStackTracesAfterClassUnloadTest extends AbstractProfilerTest {
+
+  @Override
+  protected String getProfilerCommand() {
+    // Aggressive CPU sampling to ensure the dynamic class lands in many traces.
+    return "cpu=1ms";
+  }
+
+  private int classCounter = 0;
+
+  @Test
+  @Timeout(60)
+  public void testNoSigsegvInWriteStackTracesAfterClassUnload() throws Exception {
+    stopProfiler();
+
+    Path baseFile = tempFile("prof14547-base");
+    Path dumpFile = tempFile("prof14547-dump");
+
+    try {
+      // mcleanup=false isolates the test to the PROF-14547 read path; the
+      // PROF-14545 cleanup path is covered separately by CleanupAfterClassUnloadTest.
+      profiler.execute("start,cpu=1ms,jfr,mcleanup=false,file=" + baseFile.toAbsolutePath());
+      Thread.sleep(200); // let the profiler stabilize
+
+      // 1. Load a class, hammer its methods on this thread so the CPU profiler captures
+      //    many traces referencing it. Drop strong refs and return only a WeakReference.
+      WeakReference<ClassLoader> loaderRef = loadAndProfileDynamicClass();
+
+      // 2. Drop refs and GC until the class actually unloads.
+      long deadline = System.currentTimeMillis() + 8_000;
+      while (loaderRef.get() != null && System.currentTimeMillis() < deadline) {
+        System.gc();
+        Thread.sleep(20);
+      }
+
+      // Skip the test (rather than pass spuriously) if the JVM declined to unload.
+      // Without unload the JVMTI line-number-table memory is never freed and the bug
+      // cannot manifest — running the dumps would prove nothing.
+      assumeTrue(loaderRef.get() == null,
+          "JVM did not unload the dynamic class within the deadline; cannot exercise PROF-14547");
+
+      // 3. Immediately dump several times. The first dump runs writeStackTraces over
+      //    the trace_buffer that still contains the unloaded method's traces; subsequent
+      //    dumps cover the rotation tail. With the bug, getLineNumber dereferences the
+      //    freed JVMTI memory → SIGSEGV. With the fix, _ptr is a malloc'd copy → safe.
+      for (int i = 0; i < 4; i++) {
+        profiler.dump(dumpFile);
+        Thread.sleep(10);
+      }
+
+      // 4. If the profiler crashed inside processCallTraces the JVM would have died and we
+      //    would never reach this line. The non-empty-output assertion is secondary — the
+      //    primary signal is reaching profiler.stop() at all.
+      profiler.stop();
+
+      assertTrue(Files.size(dumpFile) > 0,
+          "Profiler produced no output — SIGSEGV during writeStackTraces is suspected");
+
+    } finally {
+      try { Files.deleteIfExists(baseFile); } catch (IOException ignored) {}
+      try { Files.deleteIfExists(dumpFile); } catch (IOException ignored) {}
+    }
+  }
+
+  private WeakReference<ClassLoader> loadAndProfileDynamicClass() throws Exception {
+    String className = "com/datadoghq/profiler/generated/Prof14547Class" + (classCounter++);
+    byte[] bytecode = generateClassBytecode(className);
+
+    IsolatedClassLoader loader = new IsolatedClassLoader();
+    Class<?> clazz = loader.defineClass(className.replace('/', '.'), bytecode);
+
+    // Hammer methods for ~300ms so the CPU profiler at 1ms captures plenty of samples
+    // referencing this class. The longer this runs, the more traces survive into the
+    // dump-after-unload window.
+    long endTime = System.currentTimeMillis() + 300;
+    Object instance = clazz.getDeclaredConstructor().newInstance();
+    Method[] methods = clazz.getDeclaredMethods();
+    while (System.currentTimeMillis() < endTime) {
+      for (Method m : methods) {
+        if (m.getParameterCount() == 0 && m.getReturnType() == int.class) {
+          m.invoke(instance);
+        }
+      }
+    }
+
+    WeakReference<ClassLoader> ref = new WeakReference<>(loader);
+    //noinspection UnusedAssignment
+    loader = null;
+    //noinspection UnusedAssignment
+    clazz = null;
+    //noinspection UnusedAssignment
+    instance = null;
+    return ref;
+  }
+
+  private byte[] generateClassBytecode(String className) {
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+    cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, className, null, "java/lang/Object", null);
+
+    MethodVisitor ctor = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+    ctor.visitCode();
+    ctor.visitVarInsn(Opcodes.ALOAD, 0);
+    ctor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+    ctor.visitInsn(Opcodes.RETURN);
+    ctor.visitMaxs(0, 0);
+    ctor.visitEnd();
+
+    // Several methods, each with multiple line number entries — guarantees a non-trivial
+    // line number table is allocated by JVMTI and stored in MethodInfo._line_number_table.
+    for (int i = 0; i < 5; i++) {
+      MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "method" + i, "()I", null, null);
+      mv.visitCode();
+
+      Label l1 = new Label(); mv.visitLabel(l1); mv.visitLineNumber(100 + i * 3, l1);
+      mv.visitInsn(Opcodes.ICONST_0);
+      mv.visitVarInsn(Opcodes.ISTORE, 1);
+
+      Label l2 = new Label(); mv.visitLabel(l2); mv.visitLineNumber(101 + i * 3, l2);
+      mv.visitVarInsn(Opcodes.ILOAD, 1);
+      mv.visitInsn(Opcodes.ICONST_1);
+      mv.visitInsn(Opcodes.IADD);
+      mv.visitVarInsn(Opcodes.ISTORE, 1);
+
+      Label l3 = new Label(); mv.visitLabel(l3); mv.visitLineNumber(102 + i * 3, l3);
+      mv.visitVarInsn(Opcodes.ILOAD, 1);
+      mv.visitInsn(Opcodes.IRETURN);
+
+      mv.visitMaxs(0, 0);
+      mv.visitEnd();
+    }
+
+    cw.visitEnd();
+    return cw.toByteArray();
+  }
+
+  private static Path tempFile(String prefix) throws IOException {
+    Path dir = Paths.get("/tmp/recordings");
+    Files.createDirectories(dir);
+    return Files.createTempFile(dir, prefix + "-", ".jfr");
+  }
+
+  private static class IsolatedClassLoader extends ClassLoader {
+    public Class<?> defineClass(String name, byte[] bytecode) {
+      return defineClass(name, bytecode, 0, bytecode.length);
+    }
+  }
+}

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/WriteStackTracesAfterClassUnloadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/WriteStackTracesAfterClassUnloadTest.java
@@ -131,7 +131,7 @@ public class WriteStackTracesAfterClassUnloadTest extends AbstractProfilerTest {
         try {
           profiler.stop();
         } finally {
-          resetThreadContext();
+          profiler.resetThreadContext();
         }
       }
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/WriteStackTracesAfterClassUnloadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/WriteStackTracesAfterClassUnloadTest.java
@@ -28,16 +28,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
- * Regression test for PROF-14547: SIGSEGV in {@code Profiler::processCallTraces} during
- * {@code Recording::writeStackTraces}.
+ * Regression test for a SIGSEGV in {@code Profiler::processCallTraces} during
+ * {@code Recording::writeStackTraces} triggered by class unload.
  *
  * <p><b>Bug:</b> {@code MethodInfo::_line_number_table->_ptr} held a raw pointer to JVMTI-allocated
  * memory returned by {@code GetLineNumberTable}. When the underlying class was unloaded, the JVM
  * freed that memory, leaving {@code _ptr} dangling. The crash manifested when
  * {@code MethodInfo::getLineNumber(bci)} dereferenced the freed memory while
- * {@code writeStackTraces} iterated traces that still referenced the now-unloaded method
- * (a peer manifestation of PROF-14545, which crashes inside
- * {@code SharedLineNumberTable::~SharedLineNumberTable} via {@code Deallocate}).
+ * {@code writeStackTraces} iterated traces that still referenced the now-unloaded method.
  *
  * <p><b>Test scenario (timing-sensitive — catches the bug aggressively under ASan):</b>
  * <ol>
@@ -54,7 +52,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *       SIGSEGV without the fix.</li>
  * </ol>
  *
- * <p>With the fix (PROF-14547), {@code SharedLineNumberTable} owns a malloc'd copy of the entries
+ * <p>With the fix, {@code SharedLineNumberTable} owns a malloc'd copy of the entries
  * (the JVMTI allocation is deallocated immediately at capture time inside
  * {@code Lookup::fillJavaMethodInfo}), so {@code _ptr} stays valid regardless of class unload.
  *
@@ -66,9 +64,9 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *       authoritative signal here.</li>
  *   <li>Class unload is JVM-discretionary; if the {@code WeakReference} doesn't clear within
  *       the deadline the test {@code assumeTrue}-skips rather than passing spuriously.</li>
- *   <li>{@code mcleanup=false} is set deliberately so a SIGSEGV here is unambiguously the
- *       PROF-14547 read path, not the PROF-14545 cleanup path covered by
- *       {@code CleanupAfterClassUnloadTest}.</li>
+ *   <li>{@code mcleanup=false} is set deliberately so a SIGSEGV here exercises the
+ *       {@code getLineNumber} read path, not the {@code ~SharedLineNumberTable} cleanup path
+ *       covered by {@code CleanupAfterClassUnloadTest}.</li>
  * </ul>
  */
 public class WriteStackTracesAfterClassUnloadTest extends AbstractProfilerTest {
@@ -86,12 +84,12 @@ public class WriteStackTracesAfterClassUnloadTest extends AbstractProfilerTest {
   public void testNoSigsegvInWriteStackTracesAfterClassUnload() throws Exception {
     stopProfiler();
 
-    Path baseFile = tempFile("prof14547-base");
-    Path dumpFile = tempFile("prof14547-dump");
+    Path baseFile = tempFile("class-unload-sigsegv-base");
+    Path dumpFile = tempFile("class-unload-sigsegv-dump");
 
     try {
-      // mcleanup=false isolates the test to the PROF-14547 read path; the
-      // PROF-14545 cleanup path is covered separately by CleanupAfterClassUnloadTest.
+      // mcleanup=false isolates the test to the writeStackTraces read path; the
+      // SharedLineNumberTable destructor path is covered by CleanupAfterClassUnloadTest.
       profiler.execute("start,cpu=1ms,jfr,mcleanup=false,file=" + baseFile.toAbsolutePath());
       try {
         Thread.sleep(200); // let the profiler stabilize
@@ -111,7 +109,7 @@ public class WriteStackTracesAfterClassUnloadTest extends AbstractProfilerTest {
         // Without unload the JVMTI line-number-table memory is never freed and the bug
         // cannot manifest — running the dumps would prove nothing.
         assumeTrue(loaderRef.get() == null,
-            "JVM did not unload the dynamic class within the deadline; cannot exercise PROF-14547");
+            "JVM did not unload the dynamic class within the deadline; cannot exercise the use-after-free scenario");
 
         // 3. Immediately dump several times. The first dump runs writeStackTraces over
         //    the trace_buffer that still contains the unloaded method's traces; subsequent
@@ -142,7 +140,7 @@ public class WriteStackTracesAfterClassUnloadTest extends AbstractProfilerTest {
   }
 
   private WeakReference<ClassLoader> loadAndProfileDynamicClass() throws Exception {
-    String className = "com/datadoghq/profiler/generated/Prof14547Class" + (classCounter++);
+    String className = "com/datadoghq/profiler/generated/DynamicUnloadClass" + (classCounter++);
     byte[] bytecode = generateClassBytecode(className);
 
     IsolatedClassLoader loader = new IsolatedClassLoader();

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/WriteStackTracesAfterClassUnloadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/WriteStackTracesAfterClassUnloadTest.java
@@ -9,20 +9,14 @@
  */
 package com.datadoghq.profiler.memleak;
 
-import com.datadoghq.profiler.AbstractProfilerTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.Label;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
 
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -69,15 +63,13 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *       covered by {@code CleanupAfterClassUnloadTest}.</li>
  * </ul>
  */
-public class WriteStackTracesAfterClassUnloadTest extends AbstractProfilerTest {
+public class WriteStackTracesAfterClassUnloadTest extends AbstractDynamicClassTest {
 
   @Override
   protected String getProfilerCommand() {
     // Aggressive CPU sampling to ensure the dynamic class lands in many traces.
     return "cpu=1ms";
   }
-
-  private int classCounter = 0;
 
   @Test
   @Timeout(60)
@@ -141,7 +133,7 @@ public class WriteStackTracesAfterClassUnloadTest extends AbstractProfilerTest {
 
   private WeakReference<ClassLoader> loadAndProfileDynamicClass() throws Exception {
     String className = "com/datadoghq/profiler/generated/DynamicUnloadClass" + (classCounter++);
-    byte[] bytecode = generateClassBytecode(className);
+    byte[] bytecode = generateClassBytecode(className, 5);
 
     IsolatedClassLoader loader = new IsolatedClassLoader();
     Class<?> clazz = loader.defineClass(className.replace('/', '.'), bytecode);
@@ -170,55 +162,4 @@ public class WriteStackTracesAfterClassUnloadTest extends AbstractProfilerTest {
     return ref;
   }
 
-  private byte[] generateClassBytecode(String className) {
-    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
-    cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, className, null, "java/lang/Object", null);
-
-    MethodVisitor ctor = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
-    ctor.visitCode();
-    ctor.visitVarInsn(Opcodes.ALOAD, 0);
-    ctor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
-    ctor.visitInsn(Opcodes.RETURN);
-    ctor.visitMaxs(0, 0);
-    ctor.visitEnd();
-
-    // Several methods, each with multiple line number entries — guarantees a non-trivial
-    // line number table is allocated by JVMTI and stored in MethodInfo._line_number_table.
-    for (int i = 0; i < 5; i++) {
-      MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "method" + i, "()I", null, null);
-      mv.visitCode();
-
-      Label l1 = new Label(); mv.visitLabel(l1); mv.visitLineNumber(100 + i * 3, l1);
-      mv.visitInsn(Opcodes.ICONST_0);
-      mv.visitVarInsn(Opcodes.ISTORE, 1);
-
-      Label l2 = new Label(); mv.visitLabel(l2); mv.visitLineNumber(101 + i * 3, l2);
-      mv.visitVarInsn(Opcodes.ILOAD, 1);
-      mv.visitInsn(Opcodes.ICONST_1);
-      mv.visitInsn(Opcodes.IADD);
-      mv.visitVarInsn(Opcodes.ISTORE, 1);
-
-      Label l3 = new Label(); mv.visitLabel(l3); mv.visitLineNumber(102 + i * 3, l3);
-      mv.visitVarInsn(Opcodes.ILOAD, 1);
-      mv.visitInsn(Opcodes.IRETURN);
-
-      mv.visitMaxs(0, 0);
-      mv.visitEnd();
-    }
-
-    cw.visitEnd();
-    return cw.toByteArray();
-  }
-
-  private static Path tempFile(String prefix) throws IOException {
-    Path dir = Paths.get("/tmp/recordings");
-    Files.createDirectories(dir);
-    return Files.createTempFile(dir, prefix + "-", ".jfr");
-  }
-
-  private static class IsolatedClassLoader extends ClassLoader {
-    public Class<?> defineClass(String name, byte[] bytecode) {
-      return defineClass(name, bytecode, 0, bytecode.length);
-    }
-  }
 }


### PR DESCRIPTION
**What does this PR do?**:

Fixes SIGSEGV in `Profiler::processCallTraces` (production stack: `processCallTraces` → `Recording::writeStackTraces` → `Recording::writeCpool` → `Recording::finishChunk` → `FlightRecorder::dump` → `Profiler::dump`). Detaches `MethodInfo::_line_number_table->_ptr` lifetime from JVMTI by copying the line number table into a malloc'd buffer at capture time inside `Lookup::fillJavaMethodInfo` and immediately calling `jvmti->Deallocate` on the JVMTI memory. `~SharedLineNumberTable` now calls `free()` on the owned buffer.

**Motivation**:

Production SIGSEGV in `processCallTraces+0xaa` during JFR dump. Root cause: `MethodInfo::_line_number_table->_ptr` held a raw pointer to JVMTI-allocated memory returned by `GetLineNumberTable`. When the underlying class was unloaded, the JVM freed that memory; the next dump's `writeStackTraces` lambda called `MethodInfo::getLineNumber(bci)` on a dangling `_ptr` and crashed.

This is a peer manifestation of (PR #510), which crashes at the symmetric *deallocation* site (`~SharedLineNumberTable` → `Deallocate`). Both stem from the same dangling pointer; this fix addresses the lifetime invariant once and subsumes both crashes. PR #510 stays correct (becomes belt-and-suspenders) but is no longer required for the SIGSEGV fix.

**Additional Notes**:

- Hot-path impact is once per first-time-encountered method per dump cycle (gated by `!mi->_mark` and `mi->_key == 0`). The new work is one `malloc` + `memcpy` of the line number table (typically 16–80 bytes) plus an immediate `Deallocate` — replaces the implicit JVMTI-side allocation that already happened. Not on the signal handler path (`fillJavaMethodInfo` runs on the JFR-writer thread under `_state_lock` + `lockAll()`).
- Memory footprint is unchanged: same logical bytes per method, same lifetime, gated by the existing `AGE_THRESHOLD=3` eviction.
- `malloc` failure is handled silently on the read side (`getLineNumber` returns 0 when `_line_number_table` is null) and logged via `TEST_LOG`.
- `jvmti->Deallocate` failure now logged via `TEST_LOG` (preserves the diagnostic that the destructor previously emitted).
- Reviewed by 4 internal reviewer voices (concurrency, perf, error-paths, tests). Concerns addressed inline; deferred items: JMH benchmark for chunk-write latency on method-churn workloads (follow-up).

**How to test the change?**:

Added regression test `WriteStackTracesAfterClassUnloadTest`:
1. Generate a class with line-numbered methods via ASM.
2. Hammer its methods for ~300ms while CPU profiling at 1ms so traces land in `call_trace_storage` and a `MethodInfo` with `_line_number_table` is created.
3. Drop strong refs and `System.gc()` until the `WeakReference` clears (class actually unloaded); `assumeTrue`-skip if the JVM declined to unload within the deadline.
4. Dump 4 times in tight succession. Without the fix, `getLineNumber` dereferences the freed JVMTI memory → SIGSEGV. With the fix, `_ptr` is a malloc'd copy → safe.

Test set deliberately uses `mcleanup=false` to isolate the failure to the PROF-14547 read path; the PROF-14545 cleanup path is covered separately by `CleanupAfterClassUnloadTest` (PR #510). Best-effort under ASan/UBSan, which amplify the signal even when the freed region happens to read sensible bytes — limitations documented in the test javadoc.

Build verified locally: `:ddprof-lib:assembleRelease` and `:ddprof-test:compileTestJava` both pass on macOS arm64.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-14547](https://datadoghq.atlassian.net/browse/PROF-14547)

[PROF-14547]: https://datadoghq.atlassian.net/browse/PROF-14547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ