### PR TITLE
fix(profiler): make _class_map access signal-safe in walkVM

### DIFF
--- a/ddprof-lib/src/main/cpp/dictionary.h
+++ b/ddprof-lib/src/main/cpp/dictionary.h
@@ -75,6 +75,10 @@ public:
   void clear();
 
   bool         check(const char* key);
+  // NOT signal-safe: the inserting lookup overloads call malloc/calloc on miss
+  // (see allocateKey and the calloc in dictionary.cpp). Signal handlers must use
+  // bounded_lookup(key, length, 0) instead, which never inserts and returns
+  // INT_MAX on miss.
   unsigned int lookup(const char *key);
   unsigned int lookup(const char *key, size_t length);
   unsigned int bounded_lookup(const char *key, size_t length, int size_limit);

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1152,9 +1152,9 @@ void Recording::writeCpool(Buffer *buf) {
   // constant pool count - bump each time a new pool is added
   buf->put8(12);
 
-  // _class_map is shared across the dump (this thread) and the JVMTI shared-lock
+  // classMap() is shared across the dump (this thread) and the JVMTI shared-lock
   // writers (Profiler::lookupClass and friends). writeClasses() takes
-  // _class_map_lock shared while reading; the exclusive _class_map.clear() in
+  // classMapLock() shared while reading; the exclusive classMap()->clear() in
   // Profiler::dump runs only after this method returns.
   Lookup lookup(this, &_method_map, Profiler::instance()->classMap());
   writeFrameTypes(buf);
@@ -1369,10 +1369,10 @@ void Recording::writeMethods(Buffer *buf, Lookup *lookup) {
 
 void Recording::writeClasses(Buffer *buf, Lookup *lookup) {
   std::map<u32, const char *> classes;
-  // Hold _class_map_lock shared while reading. JVMTI writers
+  // Hold classMapLock() shared while reading. JVMTI writers
   // (Profiler::lookupClass, ObjectSampler, LivenessTracker) also take it
   // shared and use CAS-based inserts that are safe against concurrent shared
-  // readers; the exclusive _class_map.clear() in Profiler::dump runs only
+  // readers; the exclusive classMap()->clear() in Profiler::dump runs only
   // after writeClasses() returns and is blocked here.
   {
     SharedLockGuard guard(Profiler::instance()->classMapLock());

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1152,9 +1152,10 @@ void Recording::writeCpool(Buffer *buf) {
   // constant pool count - bump each time a new pool is added
   buf->put8(12);
 
-  // Profiler::instance()->classMap() provides access to non-locked _class_map
-  // instance The non-locked access is ok here as this code will never run
-  // concurrently to _class_map.clear()
+  // _class_map is shared across the dump (this thread) and the JVMTI shared-lock
+  // writers (Profiler::lookupClass and friends). writeClasses() takes
+  // _class_map_lock shared while reading; the exclusive _class_map.clear() in
+  // Profiler::dump runs only after this method returns.
   Lookup lookup(this, &_method_map, Profiler::instance()->classMap());
   writeFrameTypes(buf);
   writeThreadStates(buf);
@@ -1368,9 +1369,15 @@ void Recording::writeMethods(Buffer *buf, Lookup *lookup) {
 
 void Recording::writeClasses(Buffer *buf, Lookup *lookup) {
   std::map<u32, const char *> classes;
-  // no need to lock _classes as this code will never run concurrently with
-  // resetting that dictionary
-  lookup->_classes->collect(classes);
+  // Hold _class_map_lock shared while reading. JVMTI writers
+  // (Profiler::lookupClass, ObjectSampler, LivenessTracker) also take it
+  // shared and use CAS-based inserts that are safe against concurrent shared
+  // readers; the exclusive _class_map.clear() in Profiler::dump runs only
+  // after writeClasses() returns and is blocked here.
+  {
+    SharedLockGuard guard(Profiler::instance()->classMapLock());
+    lookup->_classes->collect(classes);
+  }
 
   buf->putVar64(T_CLASS);
   buf->putVar64(classes.size());

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1153,9 +1153,9 @@ void Recording::writeCpool(Buffer *buf) {
   buf->put8(12);
 
   // classMap() is shared across the dump (this thread) and the JVMTI shared-lock
-  // writers (Profiler::lookupClass and friends). writeClasses() takes
-  // classMapLock() shared while reading; the exclusive classMap()->clear() in
-  // Profiler::dump runs only after this method returns.
+  // writers (Profiler::lookupClass and friends). writeClasses() holds
+  // classMapSharedGuard() for its full duration; the exclusive classMap()->clear()
+  // in Profiler::dump runs only after this method returns.
   Lookup lookup(this, &_method_map, Profiler::instance()->classMap());
   writeFrameTypes(buf);
   writeThreadStates(buf);
@@ -1369,15 +1369,12 @@ void Recording::writeMethods(Buffer *buf, Lookup *lookup) {
 
 void Recording::writeClasses(Buffer *buf, Lookup *lookup) {
   std::map<u32, const char *> classes;
-  // Hold classMapLock() shared while reading. JVMTI writers
-  // (Profiler::lookupClass, ObjectSampler, LivenessTracker) also take it
-  // shared and use CAS-based inserts that are safe against concurrent shared
-  // readers; the exclusive classMap()->clear() in Profiler::dump runs only
-  // after writeClasses() returns and is blocked here.
-  {
-    SharedLockGuard guard(Profiler::instance()->classMapLock());
-    lookup->_classes->collect(classes);
-  }
+  // Hold classMapSharedGuard() for the full function. The const char* pointers
+  // stored in classes point into dictionary row storage; clear() frees that
+  // storage under the exclusive lock, so we must not release the shared lock
+  // until we have finished iterating.
+  auto guard = Profiler::instance()->classMapSharedGuard();
+  lookup->_classes->collect(classes);
 
   buf->putVar64(T_CLASS);
   buf->putVar64(classes.size());

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
@@ -531,15 +531,22 @@ __attribute__((no_sanitize("address"))) int HotspotSupport::walkVM(void* ucontex
                     uintptr_t receiver = frame.jarg0();
                     if (receiver != 0) {
                         VMSymbol* symbol = VMKlass::fromOop(receiver)->name();
-                        // walkVM runs in a signal handler; the inserting lookup() calls
-                        // malloc/calloc and is async-signal-unsafe. Use bounded_lookup
-                        // with size_limit=0 so we never grow the dictionary here. On
-                        // miss (sentinel INT_MAX) drop the synthetic frame — the JVMTI
-                        // path will populate the entry from a non-signal context.
-                        u32 class_id = profiler->classMap()->bounded_lookup(
-                            symbol->body(), symbol->length(), 0);
-                        if (class_id != INT_MAX) {
-                            fillFrame(frames[depth++], BCI_ALLOC, class_id);
+                        // walkVM runs in a signal handler. _class_map is mutated
+                        // under _class_map_lock (shared by Profiler::lookupClass
+                        // inserters, exclusive by _class_map.clear() in the dump
+                        // path between unlockAll() and lock()). bounded_lookup
+                        // with size_limit=0 never inserts (no malloc), but it
+                        // still traverses row->next and reads row->keys, which
+                        // clear() concurrently frees. Take the lock shared via
+                        // try-lock; if an exclusive clear() is in progress, drop
+                        // the synthetic frame rather than read freed memory.
+                        OptionalSharedLockGuard guard(profiler->classMapLock());
+                        if (guard.ownsLock()) {
+                            u32 class_id = profiler->classMap()->bounded_lookup(
+                                symbol->body(), symbol->length(), 0);
+                            if (class_id != INT_MAX) {
+                                fillFrame(frames[depth++], BCI_ALLOC, class_id);
+                            }
                         }
                     }
                 }

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <climits>
 #include <cstdlib>
 #include <setjmp.h>
 #include "asyncSampleMutex.h"
@@ -530,8 +531,16 @@ __attribute__((no_sanitize("address"))) int HotspotSupport::walkVM(void* ucontex
                     uintptr_t receiver = frame.jarg0();
                     if (receiver != 0) {
                         VMSymbol* symbol = VMKlass::fromOop(receiver)->name();
-                        u32 class_id = profiler->classMap()->lookup(symbol->body(), symbol->length());
-                        fillFrame(frames[depth++], BCI_ALLOC, class_id);
+                        // walkVM runs in a signal handler; the inserting lookup() calls
+                        // malloc/calloc and is async-signal-unsafe. Use bounded_lookup
+                        // with size_limit=0 so we never grow the dictionary here. On
+                        // miss (sentinel INT_MAX) drop the synthetic frame — the JVMTI
+                        // path will populate the entry from a non-signal context.
+                        u32 class_id = profiler->classMap()->bounded_lookup(
+                            symbol->body(), symbol->length(), 0);
+                        if (class_id != INT_MAX) {
+                            fillFrame(frames[depth++], BCI_ALLOC, class_id);
+                        }
                     }
                 }
 

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
@@ -540,7 +540,7 @@ __attribute__((no_sanitize("address"))) int HotspotSupport::walkVM(void* ucontex
                         // clear() concurrently frees. Take the lock shared via
                         // try-lock; if an exclusive clear() is in progress, drop
                         // the synthetic frame rather than read freed memory.
-                        OptionalSharedLockGuard guard(profiler->classMapLock());
+                        auto guard = profiler->classMapTrySharedGuard();
                         if (guard.ownsLock()) {
                             u32 class_id = profiler->classMap()->bounded_lookup(
                                 symbol->body(), symbol->length(), 0);

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -204,6 +204,7 @@ public:
   Engine *wallEngine() { return _wall_engine; }
 
   Dictionary *classMap() { return &_class_map; }
+  SpinLock *classMapLock() { return &_class_map_lock; }
   Dictionary *stringLabelMap() { return &_string_label_map; }
   Dictionary *contextValueMap() { return &_context_value_map; }
   u32 numContextAttributes() { return _num_context_attributes; }

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -204,7 +204,8 @@ public:
   Engine *wallEngine() { return _wall_engine; }
 
   Dictionary *classMap() { return &_class_map; }
-  SpinLock *classMapLock() { return &_class_map_lock; }
+  SharedLockGuard classMapSharedGuard() { return SharedLockGuard(&_class_map_lock); }
+  BoundedOptionalSharedLockGuard classMapTrySharedGuard() { return BoundedOptionalSharedLockGuard(&_class_map_lock); }
   Dictionary *stringLabelMap() { return &_string_label_map; }
   Dictionary *contextValueMap() { return &_context_value_map; }
   u32 numContextAttributes() { return _num_context_attributes; }

--- a/ddprof-lib/src/main/cpp/spinLock.h
+++ b/ddprof-lib/src/main/cpp/spinLock.h
@@ -47,8 +47,27 @@ public:
   void unlock() { __sync_fetch_and_sub(&_lock, 1); }
 
   bool tryLockShared() {
+    // Spins while no exclusive lock is held and the CAS to acquire a shared
+    // lock fails (due to concurrent reader contention). Returns false ONLY when
+    // an exclusive lock is observed (_lock > 0); never returns false spuriously.
     int value;
     while ((value = __atomic_load_n(&_lock, __ATOMIC_ACQUIRE)) <= 0) {
+      if (__sync_bool_compare_and_swap(&_lock, value, value - 1)) {
+        return true;
+      }
+      spinPause();
+    }
+    return false;
+  }
+
+  // Signal-safe variant: returns false after at most 5 CAS attempts.
+  // Use only in signal-handler paths where spinning indefinitely is unsafe.
+  bool tryLockSharedBounded() {
+    for (int attempts = 0; attempts < 5; ++attempts) {
+      int value = __atomic_load_n(&_lock, __ATOMIC_ACQUIRE);
+      if (value > 0) {
+        return false;
+      }
       if (__sync_bool_compare_and_swap(&_lock, value, value - 1)) {
         return true;
       }
@@ -88,9 +107,9 @@ public:
 class OptionalSharedLockGuard {
   SpinLock* _lock;
 public:
-  OptionalSharedLockGuard(SpinLock* lock) : _lock(lock) {
+  explicit OptionalSharedLockGuard(SpinLock* lock) : _lock(lock) {
     if (!_lock->tryLockShared()) {
-      // Locking failed, no need to unlock.
+      // Exclusive lock is held; no unlock needed. Only fails when an exclusive lock is observed.
       _lock = nullptr;
     }
   }
@@ -106,6 +125,33 @@ public:
   OptionalSharedLockGuard& operator=(const OptionalSharedLockGuard&) = delete;
   OptionalSharedLockGuard(OptionalSharedLockGuard&&) = delete;
   OptionalSharedLockGuard& operator=(OptionalSharedLockGuard&&) = delete;
+};
+
+// Signal-safe variant of OptionalSharedLockGuard: uses bounded CAS retries
+// and may fail spuriously when racing other shared lockers. Use ONLY in
+// signal-handler paths where spinning indefinitely is unsafe; do NOT use
+// in hot recording paths where silent acquisition failures would drop events.
+class BoundedOptionalSharedLockGuard {
+  SpinLock* _lock;
+public:
+  explicit BoundedOptionalSharedLockGuard(SpinLock* lock) : _lock(lock) {
+    if (!_lock->tryLockSharedBounded()) {
+      // Locking failed (bounded retries exhausted or exclusive lock held); no unlock needed.
+      _lock = nullptr;
+    }
+  }
+  ~BoundedOptionalSharedLockGuard() {
+    if (_lock != nullptr) {
+      _lock->unlockShared();
+    }
+  }
+  bool ownsLock() { return _lock != nullptr; }
+
+  // Non-copyable and non-movable
+  BoundedOptionalSharedLockGuard(const BoundedOptionalSharedLockGuard&) = delete;
+  BoundedOptionalSharedLockGuard& operator=(const BoundedOptionalSharedLockGuard&) = delete;
+  BoundedOptionalSharedLockGuard(BoundedOptionalSharedLockGuard&&) = delete;
+  BoundedOptionalSharedLockGuard& operator=(BoundedOptionalSharedLockGuard&&) = delete;
 };
 
 class ExclusiveLockGuard {

--- a/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
+++ b/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
@@ -167,3 +167,86 @@ TEST(DictionaryConcurrent, ConcurrentInsertCollectClearWithExternalLock) {
     EXPECT_GT(total_collects.load(), 0L);
     EXPECT_GT(total_clears.load(), 0L);
 }
+
+// (3) Regression for PROF-14550: the walkVM vtable-target lookup path uses
+// OptionalSharedLockGuard (tryLockShared) + bounded_lookup(0). This must not
+// race a concurrent exclusive dict.clear() (Profiler::dump path).
+//
+// Without the guard, bounded_lookup reads row->keys and row->next while clear()
+// concurrently frees them — use-after-free / SIGSEGV. With the guard, clear()
+// holds the exclusive lock and signal-side readers either finish before clear
+// or fail tryLockShared and skip the lookup entirely.
+TEST(DictionaryConcurrent, SignalHandlerBoundedLookupVsDumpClear) {
+    Dictionary dict(/*id=*/0);
+    SpinLock lock;
+
+    // Pre-populate so bounded_lookup has real rows to traverse.
+    constexpr int kPreload = 64;
+    for (int i = 0; i < kPreload; ++i) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "Lcom/example/Preloaded%d;", i);
+        lock.lock();
+        dict.lookup(buf, strlen(buf));
+        lock.unlock();
+    }
+
+    constexpr int kSignalThreads = 4;
+    const auto kDuration = std::chrono::milliseconds(500);
+
+    std::atomic<bool> stop{false};
+    std::atomic<long> total_reads{0};
+    std::atomic<long> total_skips{0};
+    std::atomic<long> total_clears{0};
+
+    // Simulate walkVM signal-handler threads: tryLockShared → bounded_lookup(0)
+    // → unlockShared. Mirrors the OptionalSharedLockGuard + ownsLock() guard in
+    // hotspotSupport.cpp.
+    std::vector<std::thread> signal_threads;
+    signal_threads.reserve(kSignalThreads);
+    for (int w = 0; w < kSignalThreads; ++w) {
+        signal_threads.emplace_back([&, w]() {
+            char buf[64];
+            int counter = 0;
+            while (!stop.load(std::memory_order_relaxed)) {
+                snprintf(buf, sizeof(buf), "Lcom/example/Preloaded%d;",
+                         counter % kPreload);
+                size_t len = strlen(buf);
+                OptionalSharedLockGuard guard(&lock);
+                if (guard.ownsLock()) {
+                    // Read-only; no malloc, no CAS — safe in signal context.
+                    unsigned int id = dict.bounded_lookup(buf, len, 0);
+                    // INT_MAX is fine: key was cleared by a concurrent dump.
+                    (void)id;
+                    total_reads.fetch_add(1, std::memory_order_relaxed);
+                } else {
+                    // Exclusive clear() holds the lock; drop the frame.
+                    total_skips.fetch_add(1, std::memory_order_relaxed);
+                }
+                ++counter;
+            }
+        });
+    }
+
+    // Simulate Profiler::dump: exclusive lock → _class_map.clear() → unlock.
+    std::thread dump_thread([&]() {
+        while (!stop.load(std::memory_order_relaxed)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            lock.lock();
+            dict.clear();
+            lock.unlock();
+            total_clears.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    std::this_thread::sleep_for(kDuration);
+    stop.store(true, std::memory_order_relaxed);
+
+    for (auto& t : signal_threads) {
+        t.join();
+    }
+    dump_thread.join();
+
+    // Both roles must have made progress.
+    EXPECT_GT(total_reads.load() + total_skips.load(), 0L);
+    EXPECT_GT(total_clears.load(), 0L);
+}

--- a/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
+++ b/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
@@ -18,7 +18,7 @@
 #include "spinLock.h"
 #include "../../main/cpp/gtest_crash_handler.h"
 
-// PROF-14549 regression tests.
+// Regression tests for the dictionary concurrency contracts.
 //
 // These tests pin down two contracts:
 //   (1) bounded_lookup(key, length, 0) is read-only (no malloc/calloc) and

--- a/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
+++ b/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
@@ -22,8 +22,9 @@
 //
 // These tests pin down two contracts:
 //   (1) bounded_lookup(key, length, 0) is read-only (no malloc/calloc) and
-//       returns INT_MAX on miss. This is the contract walkVM relies on at
-//       hotspotSupport.cpp:388 to be async-signal-safe.
+//       returns INT_MAX on miss. This is the contract
+//       HotspotSupport::walkVM relies on in its vtable-target lookup block to
+//       be async-signal-safe.
 //   (2) Dictionary::collect, when externally guarded by a SpinLock taken
 //       shared, can run concurrently with shared-lock inserters and is
 //       serialized against an exclusive-lock Dictionary::clear() — matching

--- a/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
+++ b/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <climits>
+#include <cstdio>
+#include <map>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "dictionary.h"
+#include "spinLock.h"
+#include "../../main/cpp/gtest_crash_handler.h"
+
+// PROF-14549 regression tests.
+//
+// These tests pin down two contracts:
+//   (1) bounded_lookup(key, length, 0) is read-only (no malloc/calloc) and
+//       returns INT_MAX on miss. This is the contract walkVM relies on at
+//       hotspotSupport.cpp:388 to be async-signal-safe.
+//   (2) Dictionary::collect, when externally guarded by a SpinLock taken
+//       shared, can run concurrently with shared-lock inserters and is
+//       serialized against an exclusive-lock Dictionary::clear() — matching
+//       the protocol Recording::writeClasses now uses around _class_map_lock.
+//
+// Test name for crash handler
+static constexpr char DICTIONARY_CONCURRENT_TEST_NAME[] = "DictionaryConcurrent";
+
+namespace {
+
+class DictionaryConcurrentSetup {
+public:
+    DictionaryConcurrentSetup() {
+        installGtestCrashHandler<DICTIONARY_CONCURRENT_TEST_NAME>();
+    }
+    ~DictionaryConcurrentSetup() {
+        restoreDefaultSignalHandlers();
+    }
+};
+
+static DictionaryConcurrentSetup dictionary_concurrent_global_setup;
+
+}  // namespace
+
+// (1a) bounded_lookup with size_limit=0 must not insert on miss.
+TEST(DictionaryConcurrent, BoundedLookupMissReturnsSentinelAndDoesNotInsert) {
+    Dictionary dict(/*id=*/0);
+
+    std::map<unsigned int, const char*> before;
+    dict.collect(before);
+    ASSERT_TRUE(before.empty());
+
+    const char* key = "Lorg/example/Cold;";
+    unsigned int id = dict.bounded_lookup(key, strlen(key), 0);
+    EXPECT_EQ(static_cast<unsigned int>(INT_MAX), id);
+
+    std::map<unsigned int, const char*> after;
+    dict.collect(after);
+    EXPECT_TRUE(after.empty());
+
+    // A second miss on a different key must also leave the dictionary empty.
+    const char* key2 = "Lorg/example/Other;";
+    unsigned int id2 = dict.bounded_lookup(key2, strlen(key2), 0);
+    EXPECT_EQ(static_cast<unsigned int>(INT_MAX), id2);
+
+    std::map<unsigned int, const char*> after2;
+    dict.collect(after2);
+    EXPECT_TRUE(after2.empty());
+}
+
+// (1b) bounded_lookup with size_limit=0 must return the existing id when the
+// key is already present (e.g. previously inserted from a non-signal context).
+TEST(DictionaryConcurrent, BoundedLookupHitReturnsExistingId) {
+    Dictionary dict(/*id=*/0);
+
+    const char* key = "Ljava/util/HashMap;";
+    unsigned int inserted_id = dict.lookup(key, strlen(key));
+    ASSERT_NE(0u, inserted_id);
+    ASSERT_NE(static_cast<unsigned int>(INT_MAX), inserted_id);
+
+    unsigned int looked_up_id = dict.bounded_lookup(key, strlen(key), 0);
+    EXPECT_EQ(inserted_id, looked_up_id);
+}
+
+// (2) Stress test: shared-lock inserters + exclusive-lock clear + shared-lock
+// collect, all driven from separate threads. This mirrors the discipline that
+// Recording::writeClasses (shared-lock collect) and Profiler::dump (exclusive-lock
+// clear) follow around _class_map_lock. Without the lock, this pattern races
+// (and SIGSEGVs on dictionary corruption); with the lock it is well-formed and
+// the test passes cleanly under TSan/ASan.
+TEST(DictionaryConcurrent, ConcurrentInsertCollectClearWithExternalLock) {
+    Dictionary dict(/*id=*/0);
+    SpinLock lock;
+
+    constexpr int kWriters = 4;
+    constexpr int kKeysPerWriter = 256;
+    const auto kDuration = std::chrono::milliseconds(500);
+
+    std::atomic<bool> stop{false};
+    std::atomic<long> total_inserts{0};
+    std::atomic<long> total_collects{0};
+    std::atomic<long> total_clears{0};
+
+    std::vector<std::thread> writers;
+    writers.reserve(kWriters);
+    for (int w = 0; w < kWriters; ++w) {
+        writers.emplace_back([&, w]() {
+            char buf[64];
+            int counter = 0;
+            while (!stop.load(std::memory_order_relaxed)) {
+                snprintf(buf, sizeof(buf), "Lcom/example/W%d/K%d;",
+                         w, counter % kKeysPerWriter);
+                size_t len = strlen(buf);
+                lock.lockShared();
+                unsigned int id = dict.lookup(buf, len);
+                lock.unlockShared();
+                EXPECT_NE(static_cast<unsigned int>(INT_MAX), id);
+                total_inserts.fetch_add(1, std::memory_order_relaxed);
+                ++counter;
+            }
+        });
+    }
+
+    std::thread collector([&]() {
+        while (!stop.load(std::memory_order_relaxed)) {
+            std::map<unsigned int, const char*> snapshot;
+            lock.lockShared();
+            dict.collect(snapshot);
+            lock.unlockShared();
+            // The map may be empty if a clear() just ran; either way it must
+            // be a well-formed map of (id, key) pairs that we can iterate.
+            for (auto it = snapshot.begin(); it != snapshot.end(); ++it) {
+                ASSERT_NE(nullptr, it->second);
+            }
+            total_collects.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    std::thread clearer([&]() {
+        while (!stop.load(std::memory_order_relaxed)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            lock.lock();
+            dict.clear();
+            lock.unlock();
+            total_clears.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    std::this_thread::sleep_for(kDuration);
+    stop.store(true, std::memory_order_relaxed);
+
+    for (auto& t : writers) {
+        t.join();
+    }
+    collector.join();
+    clearer.join();
+
+    // Sanity: each role made progress.
+    EXPECT_GT(total_inserts.load(), 0L);
+    EXPECT_GT(total_collects.load(), 0L);
+    EXPECT_GT(total_clears.load(), 0L);
+}

--- a/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
+++ b/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <climits>
 #include <cstdio>
+#include <cstring>
 #include <map>
 #include <string>
 #include <thread>

--- a/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
+++ b/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
@@ -199,8 +199,7 @@ TEST(DictionaryConcurrent, SignalHandlerBoundedLookupVsDumpClear) {
     std::atomic<long> total_clears{0};
 
     // Simulate walkVM signal-handler threads: tryLockShared → bounded_lookup(0)
-    // → unlockShared. Mirrors the OptionalSharedLockGuard + ownsLock() guard in
-    // hotspotSupport.cpp.
+    // → unlockShared. Mirrors the OptionalSharedLockGuard + ownsLock() guard.
     std::vector<std::thread> signal_threads;
     signal_threads.reserve(kSignalThreads);
     for (int w = 0; w < kSignalThreads; ++w) {
@@ -247,6 +246,77 @@ TEST(DictionaryConcurrent, SignalHandlerBoundedLookupVsDumpClear) {
     dump_thread.join();
 
     // Both roles must have made progress.
+    EXPECT_GT(total_reads.load() + total_skips.load(), 0L);
+    EXPECT_GT(total_clears.load(), 0L);
+}
+
+// (4) Same race as (3) but using BoundedOptionalSharedLockGuard, which is the
+// guard classMapTrySharedGuard() now returns in hotspotSupport.cpp. The bounded
+// variant may fail spuriously under reader pressure (≤5 CAS attempts); this
+// verifies it still prevents use-after-free without deadlocking.
+TEST(DictionaryConcurrent, SignalHandlerBoundedOptionalLookupVsDumpClear) {
+    Dictionary dict(/*id=*/0);
+    SpinLock lock;
+
+    constexpr int kPreload = 64;
+    for (int i = 0; i < kPreload; ++i) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "Lcom/example/Preloaded%d;", i);
+        lock.lock();
+        dict.lookup(buf, strlen(buf));
+        lock.unlock();
+    }
+
+    constexpr int kSignalThreads = 4;
+    const auto kDuration = std::chrono::milliseconds(500);
+
+    std::atomic<bool> stop{false};
+    std::atomic<long> total_reads{0};
+    std::atomic<long> total_skips{0};
+    std::atomic<long> total_clears{0};
+
+    // Simulate hotspotSupport.cpp: BoundedOptionalSharedLockGuard + bounded_lookup(0).
+    std::vector<std::thread> signal_threads;
+    signal_threads.reserve(kSignalThreads);
+    for (int w = 0; w < kSignalThreads; ++w) {
+        signal_threads.emplace_back([&, w]() {
+            char buf[64];
+            int counter = 0;
+            while (!stop.load(std::memory_order_relaxed)) {
+                snprintf(buf, sizeof(buf), "Lcom/example/Preloaded%d;",
+                         counter % kPreload);
+                size_t len = strlen(buf);
+                BoundedOptionalSharedLockGuard guard(&lock);
+                if (guard.ownsLock()) {
+                    unsigned int id = dict.bounded_lookup(buf, len, 0);
+                    (void)id;
+                    total_reads.fetch_add(1, std::memory_order_relaxed);
+                } else {
+                    total_skips.fetch_add(1, std::memory_order_relaxed);
+                }
+                ++counter;
+            }
+        });
+    }
+
+    std::thread dump_thread([&]() {
+        while (!stop.load(std::memory_order_relaxed)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            lock.lock();
+            dict.clear();
+            lock.unlock();
+            total_clears.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    std::this_thread::sleep_for(kDuration);
+    stop.store(true, std::memory_order_relaxed);
+
+    for (auto& t : signal_threads) {
+        t.join();
+    }
+    dump_thread.join();
+
     EXPECT_GT(total_reads.load() + total_skips.load(), 0L);
     EXPECT_GT(total_clears.load(), 0L);
 }

--- a/ddprof-lib/src/test/cpp/spinlock_bounded_ut.cpp
+++ b/ddprof-lib/src/test/cpp/spinlock_bounded_ut.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include "spinLock.h"
+#include "../../main/cpp/gtest_crash_handler.h"
+
+// Unit tests for tryLockSharedBounded() and BoundedOptionalSharedLockGuard —
+// the signal-safe locking API introduced to replace unbounded spinning in
+// hotspotSupport.cpp (classMapTrySharedGuard()).
+
+static constexpr char SPINLOCK_BOUNDED_TEST_NAME[] = "SpinLockBounded";
+
+namespace {
+
+class SpinLockBoundedSetup {
+public:
+    SpinLockBoundedSetup() {
+        installGtestCrashHandler<SPINLOCK_BOUNDED_TEST_NAME>();
+    }
+    ~SpinLockBoundedSetup() {
+        restoreDefaultSignalHandlers();
+    }
+};
+
+static SpinLockBoundedSetup spinlock_bounded_global_setup;
+
+} // namespace
+
+TEST(SpinLockBounded, BoundedTryLockSucceedsOnFreeLock) {
+    SpinLock lock;
+    EXPECT_TRUE(lock.tryLockSharedBounded());
+    lock.unlockShared();
+}
+
+TEST(SpinLockBounded, BoundedTryLockFailsWhenExclusiveLockHeld) {
+    SpinLock lock;
+    lock.lock();
+    EXPECT_FALSE(lock.tryLockSharedBounded());
+    lock.unlock();
+}
+
+// Multiple shared holders must coexist — bounded acquire must not treat a
+// concurrent reader's negative _lock value as an exclusive lock.
+TEST(SpinLockBounded, BoundedTryLockAllowsMultipleSharedHolders) {
+    SpinLock lock;
+    ASSERT_TRUE(lock.tryLockSharedBounded());
+    EXPECT_TRUE(lock.tryLockSharedBounded());
+    lock.unlockShared();
+    lock.unlockShared();
+}
+
+TEST(SpinLockBounded, BoundedGuardOwnsLockWhenFree) {
+    SpinLock lock;
+    BoundedOptionalSharedLockGuard guard(&lock);
+    EXPECT_TRUE(guard.ownsLock());
+}
+
+// When the exclusive lock is held the guard must not own the lock, and its
+// destructor must not accidentally release the exclusive lock.
+TEST(SpinLockBounded, BoundedGuardFailsWhenExclusiveLockHeld) {
+    SpinLock lock;
+    lock.lock();
+    {
+        BoundedOptionalSharedLockGuard guard(&lock);
+        EXPECT_FALSE(guard.ownsLock());
+    }
+    // Exclusive lock must still be held — unlock() must succeed exactly once.
+    lock.unlock();
+}
+
+// After the guard goes out of scope the lock must be fully released so that an
+// exclusive acquire succeeds.
+TEST(SpinLockBounded, BoundedGuardReleasesLockOnDestruction) {
+    SpinLock lock;
+    {
+        BoundedOptionalSharedLockGuard guard(&lock);
+        ASSERT_TRUE(guard.ownsLock());
+    }
+    EXPECT_TRUE(lock.tryLock());
+    lock.unlock();
+}
+
+// Stress: concurrent BoundedOptionalSharedLockGuard readers vs an exclusive
+// locker. Mirrors the classMapTrySharedGuard() signal-handler path vs the
+// Profiler::dump path, using the RAII type that hotspotSupport.cpp now uses.
+TEST(SpinLockBounded, BoundedGuardConcurrentWithExclusiveLock) {
+    SpinLock lock;
+    constexpr int kReaders = 4;
+    const auto kDuration = std::chrono::milliseconds(300);
+
+    std::atomic<bool> stop{false};
+    std::atomic<long> total_acquired{0};
+    std::atomic<long> total_skipped{0};
+    std::atomic<long> total_exclusive{0};
+
+    std::vector<std::thread> readers;
+    readers.reserve(kReaders);
+    for (int i = 0; i < kReaders; ++i) {
+        readers.emplace_back([&]() {
+            while (!stop.load(std::memory_order_relaxed)) {
+                BoundedOptionalSharedLockGuard guard(&lock);
+                if (guard.ownsLock()) {
+                    total_acquired.fetch_add(1, std::memory_order_relaxed);
+                } else {
+                    total_skipped.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+
+    std::thread exclusive_thread([&]() {
+        while (!stop.load(std::memory_order_relaxed)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            lock.lock();
+            lock.unlock();
+            total_exclusive.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    std::this_thread::sleep_for(kDuration);
+    stop.store(true, std::memory_order_relaxed);
+    for (auto& t : readers) t.join();
+    exclusive_thread.join();
+
+    EXPECT_GT(total_acquired.load(), 0L);
+    EXPECT_GT(total_exclusive.load(), 0L);
+}


### PR DESCRIPTION
**What does this PR do?**:

Fixes a SIGSEGV in `Dictionary::clear` reached via `Profiler::dump` by closing two correctness holes around `Profiler::_class_map`. Also covers the crash signature from PROF-14550 (same root cause, dump-path variant).

- `walkVM` at `hotspotSupport.cpp:388` previously called the inserting 2-arg `Dictionary::lookup` from a signal handler, which calls `malloc`/`calloc` (`dictionary.cpp:25,114`). That is async-signal-unsafe and could tear the malloc arena. Switched to the existing read-only `bounded_lookup(..., 0)` guarded by `OptionalSharedLockGuard` (tryLockShared); on miss or contention the synthetic vtable-target frame is skipped — the JVMTI / Java-API path will populate the entry from a non-signal context.
- `Recording::writeClasses` previously called `_classes->collect(map)` with no lock while JVMTI shared-lock writers (`Profiler::lookupClass`, `ObjectSampler`, `LivenessTracker`) could mutate the dictionary, and the dump path's exclusive `_class_map.clear()` ran shortly after. Now wrapped in `SharedLockGuard guard(Profiler::instance()->classMapLock())`. Multiple shared-lock holders coexist with CAS-based inserters; the exclusive `clear()` waits until `writeClasses` returns.
- Added a public `Profiler::classMapLock()` accessor next to the existing `classMap()` accessor.
- Documented the signal-safety hazard on the inserting `Dictionary::lookup` overloads.
- Corrected the misleading comments in `writeCpool` and `writeClasses` that previously claimed concurrent access was already safe.

**Motivation**:

PROF-14549 reports a SIGSEGV in `Dictionary::collect` reached via `Recording::writeClasses` during `Profiler::dump`. PROF-14550 reports the same SIGSEGV in `Dictionary::clear` reached via `Profiler::dump` directly. Both trace to the same root cause:

1. `walkVM` calling inserting `lookup` from a signal handler — malloc-arena tearing under signal preemption.
2. `writeClasses` reading the `Dictionary` chain unsynchronised against the dump-path `clear()`.

The `vtable_target` feature is on by default, so the buggy site is reachable on every CPU/wall/native-alloc sample whose top frame is a vtable stub.

**Additional Notes**:

- The `BCI_ALLOC` reuse at `hotspotSupport.cpp:388` is semantic overloading (frame marker, not allocation event). It was downported from upstream async-profiler and is preserved as-is here — only the signal-safety of the lookup is changed.
- The same hazard exists in upstream `src/stackWalker.cpp:399-405`. Filing the equivalent fix upstream is a follow-up.
- Trade-off: first-occurrence vtable-target annotations for cold classes are temporarily lost until the JVMTI / Java-API path inserts the class via `Profiler::lookupClass`. Eliminating the SIGSEGV outweighs the cosmetic loss.

**How to test the change?**:

- New unit/stress tests at `ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp` cover:
  1. `bounded_lookup(..., 0)` on a miss returns `INT_MAX` and does not insert.
  2. `bounded_lookup(..., 0)` on a hit returns the same id that the inserting `lookup` produced.
  3. ~500ms concurrent run with 4 shared-lock inserter threads, one shared-lock collector thread, and one exclusive-lock clear thread — regression gate for the lock discipline (PROF-14549).
  4. ~500ms concurrent run with 4 `OptionalSharedLockGuard` + `bounded_lookup(0)` "signal-handler" threads vs one exclusive-lock clear thread — regression gate for the PROF-14550 dump-path crash signature.
- Existing CPU / wall / native-alloc / JVMTI alloc / liveness profile tests continue to pass.

**For Datadog employees**:

- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-14549](https://datadoghq.atlassian.net/browse/PROF-14549), [PROF-14550](https://datadoghq.atlassian.net/browse/PROF-14550)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PROF-14549]: https://datadoghq.atlassian.net/browse/PROF-14549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ