### PR TITLE
fix: route plugin and build-logic deps through mavenRepositoryProxy

### DIFF
--- a/build-logic/conventions/build.gradle.kts
+++ b/build-logic/conventions/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
 }
 
 repositories {
+    val mavenRepositoryProxy = providers.gradleProperty("mavenRepositoryProxy").orNull
+    if (mavenRepositoryProxy != null) {
+        maven { url = uri(mavenRepositoryProxy) }
+    }
     gradlePluginPortal()
     mavenCentral()
 }

--- a/build-logic/settings.gradle
+++ b/build-logic/settings.gradle
@@ -1,3 +1,14 @@
+pluginManagement {
+    def mavenRepositoryProxy = providers.gradleProperty('mavenRepositoryProxy').orNull
+    repositories {
+        if (mavenRepositoryProxy != null) {
+            maven { url = uri(mavenRepositoryProxy) }
+        }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'build-logic'
 
 include 'conventions'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,10 @@
 pluginManagement {
   includeBuild("build-logic")
+  val mavenRepositoryProxy = providers.gradleProperty("mavenRepositoryProxy").orNull
   repositories {
+    if (mavenRepositoryProxy != null) {
+      maven { url = uri(mavenRepositoryProxy) }
+    }
     gradlePluginPortal()
     mavenCentral()
   }


### PR DESCRIPTION
## Summary

- The `mavenRepositoryProxy` Gradle property was only consulted in the root `dependencyResolutionManagement`. Plugin classpath resolution and the `build-logic` included build still hit `gradlePluginPortal()`/`mavenCentral()` directly, so on CI runners that restrict egress to the Depot mirror those fetches fail with `403 Forbidden`.
- This caused `:build-logic:conventions:compileKotlin` to fail downloading `kotlin-build-tools-impl-2.3.0.jar` and `kotlin-reflect-1.6.10.jar` (sample failure: [job 1664033372](https://gitlab.ddbuild.io/DataDog/java-profiler/-/jobs/1664033372)).
- Wires the proxy into three places so plugin and `build-logic` resolution also flow through Depot when the property is set:
  - root `pluginManagement` in `settings.gradle.kts`
  - `build-logic/settings.gradle` `pluginManagement` (the included build had none)
  - `repositories {}` in `build-logic/conventions/build.gradle.kts` (the actual failing config: `kotlinBuildToolsApiClasspath`)

The proxy is only added when the property is set, so local builds without `-PmavenRepositoryProxy=...` continue to behave as before. CI exports `ORG_GRADLE_PROJECT_mavenRepositoryProxy` already, so no `.gitlab-ci.yml` changes are needed.

## Test plan

- [ ] CI pipeline on this branch reaches `:build-logic:conventions:compileKotlin` and resolves `kotlin-build-tools-impl` / `kotlin-reflect` through `depot-read-api-java.us1.ddbuild.io` (no 403s in the build log).
- [ ] Local `./gradlew tasks` (without the property set) still succeeds — proxy block is no-op when the property is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)