### PR TITLE
Fix missing OTel thread context initialization

### DIFF
--- a/ddprof-lib/src/main/cpp/context_api.cpp
+++ b/ddprof-lib/src/main/cpp/context_api.cpp
@@ -113,3 +113,13 @@ void ContextApi::registerAttributeKeys(const char** keys, int count) {
     }
 #endif
 }
+
+void ContextApi::registerAttributeKeys(const std::vector<std::string>& keys) {
+    // Clip to DD_TAGS_CAPACITY before materializing C string pointers.
+    size_t n = keys.size() < DD_TAGS_CAPACITY ? keys.size() : DD_TAGS_CAPACITY;
+    const char* key_ptrs[DD_TAGS_CAPACITY];
+    for (size_t i = 0; i < n; i++) {
+        key_ptrs[i] = keys[i].c_str();
+    }
+    registerAttributeKeys(key_ptrs, (int)n);
+}

--- a/ddprof-lib/src/main/cpp/context_api.h
+++ b/ddprof-lib/src/main/cpp/context_api.h
@@ -20,6 +20,8 @@
 #include "arch.h"
 #include "context.h"
 #include <cstdint>
+#include <string>
+#include <vector>
 
 class ProfiledThread;
 
@@ -78,6 +80,12 @@ public:
      */
     static void registerAttributeKeys(const char** keys, int count);
 
+    /**
+     * std::vector overload of registerAttributeKeys, used from the C++ start
+     * path so that the attributes=... CLI argument auto-publishes the OTEP
+     * attribute_key_map without requiring an explicit Java-side call.
+     */
+    static void registerAttributeKeys(const std::vector<std::string>& keys);
 };
 
 #endif /* _CONTEXT_API_H */

--- a/ddprof-lib/src/main/cpp/javaApi.cpp
+++ b/ddprof-lib/src/main/cpp/javaApi.cpp
@@ -504,6 +504,22 @@ Java_com_datadoghq_profiler_OTelContext_readProcessCtx0(JNIEnv *env, jclass unus
     }
   }
 
+  // Extract attribute_key_map from thread_ctx_config (NULL if no config was published)
+  jobjectArray jAttributeKeyMap = nullptr;
+  if (result.data.thread_ctx_config != NULL && result.data.thread_ctx_config->attribute_key_map != NULL) {
+    int n = 0;
+    while (result.data.thread_ctx_config->attribute_key_map[n] != NULL) n++;
+    jclass stringClass = env->FindClass("java/lang/String");
+    if (stringClass != nullptr) {
+      jAttributeKeyMap = env->NewObjectArray(n, stringClass, nullptr);
+      for (int i = 0; i < n; i++) {
+        jstring jKey = env->NewStringUTF(result.data.thread_ctx_config->attribute_key_map[i]);
+        env->SetObjectArrayElement(jAttributeKeyMap, i, jKey);
+        env->DeleteLocalRef(jKey);
+      }
+    }
+  }
+
   otel_process_ctx_read_drop(&result);
 
   // Find the ProcessContext class
@@ -514,14 +530,14 @@ Java_com_datadoghq_profiler_OTelContext_readProcessCtx0(JNIEnv *env, jclass unus
 
   // Find the constructor
   jmethodID constructor = env->GetMethodID(processContextClass, "<init>",
-    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)V");
   if (!constructor) {
     return nullptr;
   }
 
   // Create the ProcessContext object
   jobject processContext = env->NewObject(processContextClass, constructor,
-    jDeploymentEnvironmentName, jHostName, jServiceInstanceId, jServiceName, jServiceVersion, jTelemetrySdkLanguage, jTelemetrySdkVersion, jTelemetrySdkName);
+    jDeploymentEnvironmentName, jHostName, jServiceInstanceId, jServiceName, jServiceVersion, jTelemetrySdkLanguage, jTelemetrySdkVersion, jTelemetrySdkName, jAttributeKeyMap);
 
   return processContext;
 #else

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1181,6 +1181,9 @@ Error Profiler::start(Arguments &args, bool reset) {
   JfrMetadata::reset();
   JfrMetadata::initialize(args._context_attributes);
   _num_context_attributes = args._context_attributes.size();
+  // Initialize the OTel thread context so external profilers can decode
+  // the per-thread context, including custom attributes
+  ContextApi::registerAttributeKeys(args._context_attributes);
   error = _jfr.start(args, reset);
   if (error) {
     disableEngines();

--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/OTelContext.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/OTelContext.java
@@ -52,8 +52,16 @@ public final class OTelContext {
         public final String telemetrySdkLanguage;
         public final String telemetrySdkVersion;
         public final String telemetrySdkName;
+        /**
+         * The threadlocal.attribute_key_map published in the process context's
+         * thread_ctx_config, or null if no thread context configuration was
+         * published. The first entry is always the reserved
+         * {@code datadog.local_root_span_id} slot; user-registered keys follow
+         * in registration order.
+         */
+        public final String[] attributeKeyMap;
 
-        public ProcessContext(String deploymentEnvironmentName, String hostName, String serviceInstanceId, String serviceName, String serviceVersion, String telemetrySdkLanguage, String telemetrySdkVersion, String telemetrySdkName) {
+        public ProcessContext(String deploymentEnvironmentName, String hostName, String serviceInstanceId, String serviceName, String serviceVersion, String telemetrySdkLanguage, String telemetrySdkVersion, String telemetrySdkName, String[] attributeKeyMap) {
             this.deploymentEnvironmentName = deploymentEnvironmentName;
             this.hostName = hostName;
             this.serviceInstanceId = serviceInstanceId;
@@ -62,12 +70,13 @@ public final class OTelContext {
             this.telemetrySdkLanguage = telemetrySdkLanguage;
             this.telemetrySdkVersion = telemetrySdkVersion;
             this.telemetrySdkName = telemetrySdkName;
+            this.attributeKeyMap = attributeKeyMap;
         }
 
         @Override
         public String toString() {
-            return String.format("ProcessContext{deploymentEnvironmentName='%s', hostName='%s', serviceInstanceId='%s', serviceName='%s', serviceVersion='%s', telemetrySdkLanguage='%s', telemetrySdkVersion='%s', telemetrySdkName='%s'}",
-                deploymentEnvironmentName, hostName, serviceInstanceId, serviceName, serviceVersion, telemetrySdkLanguage, telemetrySdkVersion, telemetrySdkName);
+            return String.format("ProcessContext{deploymentEnvironmentName='%s', hostName='%s', serviceInstanceId='%s', serviceName='%s', serviceVersion='%s', telemetrySdkLanguage='%s', telemetrySdkVersion='%s', telemetrySdkName='%s', attributeKeyMap=%s}",
+                deploymentEnvironmentName, hostName, serviceInstanceId, serviceName, serviceVersion, telemetrySdkLanguage, telemetrySdkVersion, telemetrySdkName, java.util.Arrays.toString(attributeKeyMap));
         }
     }
     
@@ -229,6 +238,22 @@ public final class OTelContext {
      * thread_ctx_config. In OTEL mode, attribute values set via
      * {@link ThreadContext#setContextAttribute(int, String)} are encoded
      * with the key index corresponding to position in this array.
+     *
+     * <p>Calling this method explicitly is <b>optional</b> when the profiler
+     * is started with the {@code attributes=...} argument (e.g.
+     * {@code execute("start,attributes=http.route;db.system,...")}); the
+     * native start path auto-registers those keys.
+     *
+     * <p>This method reads the currently published process context and
+     * republishes it with thread_ctx_config attached. It must therefore be
+     * called <b>after</b>
+     * {@link #setProcessContext(String, String, String, String, String, String)};
+     * if no process context has been published yet, the registration is a
+     * no-op for the process-level attribute_key_map (per-thread
+     * setContextAttribute writes still work). Conversely, calling
+     * setProcessContext after this method drops the previously published
+     * thread_ctx_config — re-register the keys after each setProcessContext
+     * if you need them to persist.
      *
      * <p>Must be called before any calls to setContextAttribute.
      *

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/context/ProcessContextTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/context/ProcessContextTest.java
@@ -1,5 +1,6 @@
 package com.datadoghq.profiler.context;
 
+import com.datadoghq.profiler.JavaProfiler;
 import com.datadoghq.profiler.OTelContext;
 import com.datadoghq.profiler.Platform;
 import org.junit.jupiter.api.Assumptions;
@@ -141,5 +142,42 @@ public class ProcessContextTest {
         assertEquals("java", readContext.telemetrySdkLanguage, "Tracer language must survive registerAttributeKeys");
         assertEquals(tracerVersion, readContext.telemetrySdkVersion, "Tracer version must survive registerAttributeKeys");
         assertEquals("dd-trace-java", readContext.telemetrySdkName, "Tracer name must survive registerAttributeKeys");
+        assertArrayEquals(
+            new String[] {"datadog.local_root_span_id", "http.route", "db.system"},
+            readContext.attributeKeyMap,
+            "attribute_key_map should expose the reserved LRS slot followed by registered keys");
     }
+
+    /**
+     * Verifies that starting the profiler with attributes=... auto-publishes the
+     * OTEP attribute_key_map without an explicit OTelContext.registerAttributeKeys()
+     * call. This is the gap fixed in the ivoanjo/fix-otel-thread-ctx branch.
+     */
+    @Test
+    public void testStartAttributesAutoRegistersKeys() throws IOException {
+        Assumptions.assumeTrue(Platform.isLinux());
+
+        OTelContext context = OTelContext.getInstance();
+        // Publish a process context first so readProcessContext() returns non-null.
+        context.setProcessContext("auto-env", "auto-host", "auto-instance", "auto-service", "1.0.0", "auto-tracer-1.0.0");
+
+        JavaProfiler profiler = JavaProfiler.getInstance();
+        Path jfrFile = Files.createTempFile("auto-attrs", ".jfr");
+        try {
+            profiler.execute(String.format("start,cpu=1ms,attributes=http.route;db.system,jfr,file=%s", jfrFile.toAbsolutePath()));
+            try {
+                OTelContext.ProcessContext readContext = context.readProcessContext();
+                assertNotNull(readContext, "Process context must be readable");
+                assertArrayEquals(
+                    new String[] {"datadog.local_root_span_id", "http.route", "db.system"},
+                    readContext.attributeKeyMap,
+                    "attributes=... in start command should auto-publish attribute_key_map");
+            } finally {
+                profiler.stop();
+            }
+        } finally {
+            Files.deleteIfExists(jfrFile);
+        }
+    }
+
 }


### PR DESCRIPTION
**What does this PR do?**

In PR https://github.com/DataDog/java-profiler/pull/347 we changed the per-thread context kept by the profiler to follow the OpenTelemetry format from
https://github.com/open-telemetry/opentelemetry-specification/pull/4947

But, a crucial part was missing -- calling
`ContextApi::registerAttributeKeys`. Because this was not wired up, we did not announce the availability of the thread context, and thus external readers could not pick it up.

This PR fixes this gap by automatically calling
`registerAttributeKeys` during profiler initialization.

**Motivation:**

Make external readers (such as the OTel eBPF Profiler) be able to read the per-thread context information.

**Additional Notes:**

Right now the call to `registerAttributeKeys` relies on a previous call to `OTelContext::setProcessContext`. I believe that should be fine as:

1. dd-trace-java does call that before starting the profiler
2. It calls it by default as of https://github.com/DataDog/dd-trace-java/pull/11288

A separate note is that now that `ContextApi::registerAttributeKeys` is implicitly/automatically called from `Profiler::start`, we _could_ get rid of the Java-level APIs. Yet they seem kinda useful for testing? So I didn't remove them -- thoughts welcome on this.

**How to test the change?**

With these changes, I was able to start an example app and use https://github.com/scottgerring/ctx-sharing-demo/tree/main/context-reader to check that the trace id/span id/local root span id/custom attribute could be read and were correct.

Here's my test app:

```java
package com.example;

import datadog.trace.api.CorrelationIdentifier;
import datadog.trace.api.Trace;
import datadog.trace.api.profiling.Profiling;

public class App {

    @Trace(operationName = "my.traced.method")
    public void tracedMethod(boolean sleepForever) {
        try (var scope = Profiling.get().newScope()) {
            scope.setContextValue("customer_name", "test customer name");
            System.out.println("Process PID: " + ProcessHandle.current().pid());
            System.out.println("Trace ID: " + CorrelationIdentifier.getTraceId());
            System.out.println("Span ID: " + CorrelationIdentifier.getSpanId());
            if (sleepForever) {
                System.out.println("Sleeping forever...");
                while (true) {
                    try {
                        Thread.sleep(Long.MAX_VALUE);
                    } catch (InterruptedException e) {
                        // continue sleeping
                    }
                }
            }
         }
    }

    public static void main(String[] args) {
        boolean sleep = args.length > 0 && args[0].equals("-s");
        App app = new App();
        app.tracedMethod(sleep);
        System.out.println("Done.");
    }
}
```

and I ran it with:

```bash
java -javaagent:dd-java-agent.jar \
     -Ddd.service=my-test-app \
     -Ddd.profiling.enabled=true \
     -Ddd.profiling.experimental.process_context.enabled=true \
     -Ddd.profiling.context.attributes=customer_name \
     -cp out:dd-trace-api.jar \
     com.example.App "$@"
```

and here's what I saw:

```
// From Java app:
Process PID: 366422
Trace ID: 69fca1f2000000000fbf0550eb5ad8ee
Span ID: 6518782658524195367
Sleeping forever...

// From reader:
2026-05-07T14:30:25.128376Z  INFO tail: Monitoring process 366422 (java)
2026-05-07T14:30:25.201870Z  INFO custom_labels::process_context::reader: Found named OTEL_CTX mapping addr="0x7d8ced3a0000"
2026-05-07T14:30:25.201893Z  INFO custom_labels::process_context::reader: Read process-context header monotonic_published_at_ns=25813536699856 version=2 payload_size=449
2026-05-07T14:30:25.201907Z  INFO tail: V1 reader not available: No binary found with v1 custom labels symbols
2026-05-07T14:30:25.201912Z  INFO context_reader::v2_reader: V2 reader: parsed key table from process-context num_keys=3
2026-05-07T14:30:25.201915Z  INFO context_reader::v2_reader: V2 reader: found otel_thread_ctx_v1 in /tmp/ddprof_ivo_anjo/pid_366422/scratch/libjavaProfiler-dd-tmp13251873446977520577.so
2026-05-07T14:30:25.202895Z  INFO context_reader::tls_symbols::process: TLS for otel_thread_ctx_v1: DTV only [module_id=4, tls_offset=0xffffffffffffffff]
2026-05-07T14:30:25.202952Z  INFO tail: V2 reader initialized successfully
2026-05-07T14:30:25.202955Z  INFO tail: Initialized 1 TLS reader(s)
2026-05-07T14:30:25.208772Z  INFO context_reader::output: [v2] iteration = 1, thread = 366423, labels = [trace_id=69fca1f2000000000fbf0550eb5ad8ee, span_id=5a775e4a394faa27, datadog.local_root_span_id=5a775e4a394faa27, _dd.trace.operation=my.traced.method, customer_name=test customer name]
```

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: No ticket