### PR TITLE
fix(profiler): eliminate SIGSEGV race on _class_map.clear() in signal handler and dump path

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1153,9 +1153,9 @@ void Recording::writeCpool(Buffer *buf) {
   buf->put8(12);
 
   // classMap() is shared across the dump (this thread) and the JVMTI shared-lock
-  // writers (Profiler::lookupClass and friends). writeClasses() takes
-  // classMapLock() shared while reading; the exclusive classMap()->clear() in
-  // Profiler::dump runs only after this method returns.
+  // writers (Profiler::lookupClass and friends). writeClasses() holds
+  // classMapSharedGuard() for its full duration; the exclusive classMap()->clear()
+  // in Profiler::dump runs only after this method returns.
   Lookup lookup(this, &_method_map, Profiler::instance()->classMap());
   writeFrameTypes(buf);
   writeThreadStates(buf);
@@ -1369,15 +1369,12 @@ void Recording::writeMethods(Buffer *buf, Lookup *lookup) {
 
 void Recording::writeClasses(Buffer *buf, Lookup *lookup) {
   std::map<u32, const char *> classes;
-  // Hold classMapLock() shared while reading. JVMTI writers
-  // (Profiler::lookupClass, ObjectSampler, LivenessTracker) also take it
-  // shared and use CAS-based inserts that are safe against concurrent shared
-  // readers; the exclusive classMap()->clear() in Profiler::dump runs only
-  // after writeClasses() returns and is blocked here.
-  {
-    SharedLockGuard guard(Profiler::instance()->classMapLock());
-    lookup->_classes->collect(classes);
-  }
+  // Hold classMapSharedGuard() for the full function. The const char* pointers
+  // stored in classes point into dictionary row storage; clear() frees that
+  // storage under the exclusive lock, so we must not release the shared lock
+  // until we have finished iterating.
+  auto guard = Profiler::instance()->classMapSharedGuard();
+  lookup->_classes->collect(classes);
 
   buf->putVar64(T_CLASS);
   buf->putVar64(classes.size());

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
@@ -540,7 +540,7 @@ __attribute__((no_sanitize("address"))) int HotspotSupport::walkVM(void* ucontex
                         // clear() concurrently frees. Take the lock shared via
                         // try-lock; if an exclusive clear() is in progress, drop
                         // the synthetic frame rather than read freed memory.
-                        OptionalSharedLockGuard guard(profiler->classMapLock());
+                        auto guard = profiler->classMapTrySharedGuard();
                         if (guard.ownsLock()) {
                             u32 class_id = profiler->classMap()->bounded_lookup(
                                 symbol->body(), symbol->length(), 0);

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -204,7 +204,8 @@ public:
   Engine *wallEngine() { return _wall_engine; }
 
   Dictionary *classMap() { return &_class_map; }
-  SpinLock *classMapLock() { return &_class_map_lock; }
+  SharedLockGuard classMapSharedGuard() { return SharedLockGuard(&_class_map_lock); }
+  OptionalSharedLockGuard classMapTrySharedGuard() { return OptionalSharedLockGuard(&_class_map_lock); }
   Dictionary *stringLabelMap() { return &_string_label_map; }
   Dictionary *contextValueMap() { return &_context_value_map; }
   u32 numContextAttributes() { return _num_context_attributes; }

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -205,7 +205,7 @@ public:
 
   Dictionary *classMap() { return &_class_map; }
   SharedLockGuard classMapSharedGuard() { return SharedLockGuard(&_class_map_lock); }
-  OptionalSharedLockGuard classMapTrySharedGuard() { return OptionalSharedLockGuard(&_class_map_lock); }
+  BoundedOptionalSharedLockGuard classMapTrySharedGuard() { return BoundedOptionalSharedLockGuard(&_class_map_lock); }
   Dictionary *stringLabelMap() { return &_string_label_map; }
   Dictionary *contextValueMap() { return &_context_value_map; }
   u32 numContextAttributes() { return _num_context_attributes; }

--- a/ddprof-lib/src/main/cpp/spinLock.h
+++ b/ddprof-lib/src/main/cpp/spinLock.h
@@ -47,8 +47,14 @@ public:
   void unlock() { __sync_fetch_and_sub(&_lock, 1); }
 
   bool tryLockShared() {
-    int value;
-    while ((value = __atomic_load_n(&_lock, __ATOMIC_ACQUIRE)) <= 0) {
+    // Retry up to 5 times to handle transient CAS failures from concurrent
+    // shared acquirers. Returns false immediately if exclusive lock is held
+    // (value > 0) or after 5 failed CAS attempts.
+    for (int attempts = 0; attempts < 5; ++attempts) {
+      int value = __atomic_load_n(&_lock, __ATOMIC_ACQUIRE);
+      if (value > 0) {
+        return false;
+      }
       if (__sync_bool_compare_and_swap(&_lock, value, value - 1)) {
         return true;
       }
@@ -76,12 +82,16 @@ public:
     _lock->lockShared();
   }
   ~SharedLockGuard() {
-    _lock->unlockShared();
+    if (_lock != nullptr) {
+      _lock->unlockShared();
+    }
   }
-  // Non-copyable and non-movable
+  SharedLockGuard(SharedLockGuard&& other) : _lock(other._lock) {
+    other._lock = nullptr;
+  }
+  // Non-copyable, non-move-assignable
   SharedLockGuard(const SharedLockGuard&) = delete;
   SharedLockGuard& operator=(const SharedLockGuard&) = delete;
-  SharedLockGuard(SharedLockGuard&&) = delete;
   SharedLockGuard& operator=(SharedLockGuard&&) = delete;
 };
 
@@ -101,10 +111,12 @@ public:
   }
   bool ownsLock() { return _lock != nullptr; }
 
-  // Non-copyable and non-movable
+  OptionalSharedLockGuard(OptionalSharedLockGuard&& other) : _lock(other._lock) {
+    other._lock = nullptr;
+  }
+  // Non-copyable, non-move-assignable
   OptionalSharedLockGuard(const OptionalSharedLockGuard&) = delete;
   OptionalSharedLockGuard& operator=(const OptionalSharedLockGuard&) = delete;
-  OptionalSharedLockGuard(OptionalSharedLockGuard&&) = delete;
   OptionalSharedLockGuard& operator=(OptionalSharedLockGuard&&) = delete;
 };
 

--- a/ddprof-lib/src/main/cpp/spinLock.h
+++ b/ddprof-lib/src/main/cpp/spinLock.h
@@ -95,16 +95,12 @@ public:
     _lock->lockShared();
   }
   ~SharedLockGuard() {
-    if (_lock != nullptr) {
-      _lock->unlockShared();
-    }
+    _lock->unlockShared();
   }
-  SharedLockGuard(SharedLockGuard&& other) : _lock(other._lock) {
-    other._lock = nullptr;
-  }
-  // Non-copyable, non-move-assignable
+  // Non-copyable and non-movable
   SharedLockGuard(const SharedLockGuard&) = delete;
   SharedLockGuard& operator=(const SharedLockGuard&) = delete;
+  SharedLockGuard(SharedLockGuard&&) = delete;
   SharedLockGuard& operator=(SharedLockGuard&&) = delete;
 };
 
@@ -124,12 +120,10 @@ public:
   }
   bool ownsLock() { return _lock != nullptr; }
 
-  OptionalSharedLockGuard(OptionalSharedLockGuard&& other) : _lock(other._lock) {
-    other._lock = nullptr;
-  }
-  // Non-copyable, non-move-assignable
+  // Non-copyable and non-movable
   OptionalSharedLockGuard(const OptionalSharedLockGuard&) = delete;
   OptionalSharedLockGuard& operator=(const OptionalSharedLockGuard&) = delete;
+  OptionalSharedLockGuard(OptionalSharedLockGuard&&) = delete;
   OptionalSharedLockGuard& operator=(OptionalSharedLockGuard&&) = delete;
 };
 

--- a/ddprof-lib/src/main/cpp/spinLock.h
+++ b/ddprof-lib/src/main/cpp/spinLock.h
@@ -112,8 +112,8 @@ class OptionalSharedLockGuard {
   SpinLock* _lock;
 public:
   OptionalSharedLockGuard(SpinLock* lock) : _lock(lock) {
-    if (!_lock->tryLockShared()) {
-      // Locking failed, no need to unlock.
+    if (!_lock->tryLockSharedBounded()) {
+      // Locking failed (bounded retries exhausted or exclusive lock held); no unlock needed.
       _lock = nullptr;
     }
   }

--- a/ddprof-lib/src/main/cpp/spinLock.h
+++ b/ddprof-lib/src/main/cpp/spinLock.h
@@ -111,9 +111,9 @@ public:
 class OptionalSharedLockGuard {
   SpinLock* _lock;
 public:
-  OptionalSharedLockGuard(SpinLock* lock) : _lock(lock) {
-    if (!_lock->tryLockSharedBounded()) {
-      // Locking failed (bounded retries exhausted or exclusive lock held); no unlock needed.
+  explicit OptionalSharedLockGuard(SpinLock* lock) : _lock(lock) {
+    if (!_lock->tryLockShared()) {
+      // Exclusive lock is held; no unlock needed. Only fails when an exclusive lock is observed.
       _lock = nullptr;
     }
   }
@@ -131,6 +131,33 @@ public:
   OptionalSharedLockGuard(const OptionalSharedLockGuard&) = delete;
   OptionalSharedLockGuard& operator=(const OptionalSharedLockGuard&) = delete;
   OptionalSharedLockGuard& operator=(OptionalSharedLockGuard&&) = delete;
+};
+
+// Signal-safe variant of OptionalSharedLockGuard: uses bounded CAS retries
+// and may fail spuriously when racing other shared lockers. Use ONLY in
+// signal-handler paths where spinning indefinitely is unsafe; do NOT use
+// in hot recording paths where silent acquisition failures would drop events.
+class BoundedOptionalSharedLockGuard {
+  SpinLock* _lock;
+public:
+  explicit BoundedOptionalSharedLockGuard(SpinLock* lock) : _lock(lock) {
+    if (!_lock->tryLockSharedBounded()) {
+      // Locking failed (bounded retries exhausted or exclusive lock held); no unlock needed.
+      _lock = nullptr;
+    }
+  }
+  ~BoundedOptionalSharedLockGuard() {
+    if (_lock != nullptr) {
+      _lock->unlockShared();
+    }
+  }
+  bool ownsLock() { return _lock != nullptr; }
+
+  // Non-copyable and non-movable
+  BoundedOptionalSharedLockGuard(const BoundedOptionalSharedLockGuard&) = delete;
+  BoundedOptionalSharedLockGuard& operator=(const BoundedOptionalSharedLockGuard&) = delete;
+  BoundedOptionalSharedLockGuard(BoundedOptionalSharedLockGuard&&) = delete;
+  BoundedOptionalSharedLockGuard& operator=(BoundedOptionalSharedLockGuard&&) = delete;
 };
 
 class ExclusiveLockGuard {

--- a/ddprof-lib/src/main/cpp/spinLock.h
+++ b/ddprof-lib/src/main/cpp/spinLock.h
@@ -47,9 +47,22 @@ public:
   void unlock() { __sync_fetch_and_sub(&_lock, 1); }
 
   bool tryLockShared() {
-    // Retry up to 5 times to handle transient CAS failures from concurrent
-    // shared acquirers. Returns false immediately if exclusive lock is held
-    // (value > 0) or after 5 failed CAS attempts.
+    // Spins until the exclusive lock is released, then acquires a shared lock.
+    // Returns false ONLY when an exclusive lock is observed (_lock > 0); never
+    // returns false spuriously. Callers must be prepared for this to block.
+    int value;
+    while ((value = __atomic_load_n(&_lock, __ATOMIC_ACQUIRE)) <= 0) {
+      if (__sync_bool_compare_and_swap(&_lock, value, value - 1)) {
+        return true;
+      }
+      spinPause();
+    }
+    return false;
+  }
+
+  // Signal-safe variant: returns false after at most 5 CAS attempts.
+  // Use only in signal-handler paths where spinning indefinitely is unsafe.
+  bool tryLockSharedBounded() {
     for (int attempts = 0; attempts < 5; ++attempts) {
       int value = __atomic_load_n(&_lock, __ATOMIC_ACQUIRE);
       if (value > 0) {

--- a/ddprof-lib/src/main/cpp/spinLock.h
+++ b/ddprof-lib/src/main/cpp/spinLock.h
@@ -47,9 +47,9 @@ public:
   void unlock() { __sync_fetch_and_sub(&_lock, 1); }
 
   bool tryLockShared() {
-    // Spins until the exclusive lock is released, then acquires a shared lock.
-    // Returns false ONLY when an exclusive lock is observed (_lock > 0); never
-    // returns false spuriously. Callers must be prepared for this to block.
+    // Spins while no exclusive lock is held and the CAS to acquire a shared
+    // lock fails (due to concurrent reader contention). Returns false ONLY when
+    // an exclusive lock is observed (_lock > 0); never returns false spuriously.
     int value;
     while ((value = __atomic_load_n(&_lock, __ATOMIC_ACQUIRE)) <= 0) {
       if (__sync_bool_compare_and_swap(&_lock, value, value - 1)) {

--- a/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
+++ b/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
@@ -198,9 +198,9 @@ TEST(DictionaryConcurrent, SignalHandlerBoundedLookupVsDumpClear) {
     std::atomic<long> total_skips{0};
     std::atomic<long> total_clears{0};
 
-    // Simulate walkVM signal-handler threads: tryLockShared → bounded_lookup(0)
-    // → unlockShared. Mirrors the OptionalSharedLockGuard + ownsLock() guard in
-    // hotspotSupport.cpp.
+    // Simulate walkVM signal-handler threads: tryLockSharedBounded → bounded_lookup(0)
+    // → unlockShared. Mirrors the BoundedOptionalSharedLockGuard + ownsLock() guard in
+    // hotspotSupport.cpp (classMapTrySharedGuard()).
     std::vector<std::thread> signal_threads;
     signal_threads.reserve(kSignalThreads);
     for (int w = 0; w < kSignalThreads; ++w) {
@@ -211,7 +211,7 @@ TEST(DictionaryConcurrent, SignalHandlerBoundedLookupVsDumpClear) {
                 snprintf(buf, sizeof(buf), "Lcom/example/Preloaded%d;",
                          counter % kPreload);
                 size_t len = strlen(buf);
-                OptionalSharedLockGuard guard(&lock);
+                BoundedOptionalSharedLockGuard guard(&lock);
                 if (guard.ownsLock()) {
                     // Read-only; no malloc, no CAS — safe in signal context.
                     unsigned int id = dict.bounded_lookup(buf, len, 0);

--- a/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
+++ b/ddprof-lib/src/test/cpp/dictionary_concurrent_ut.cpp
@@ -198,9 +198,8 @@ TEST(DictionaryConcurrent, SignalHandlerBoundedLookupVsDumpClear) {
     std::atomic<long> total_skips{0};
     std::atomic<long> total_clears{0};
 
-    // Simulate walkVM signal-handler threads: tryLockSharedBounded → bounded_lookup(0)
-    // → unlockShared. Mirrors the BoundedOptionalSharedLockGuard + ownsLock() guard in
-    // hotspotSupport.cpp (classMapTrySharedGuard()).
+    // Simulate walkVM signal-handler threads: tryLockShared → bounded_lookup(0)
+    // → unlockShared. Mirrors the OptionalSharedLockGuard + ownsLock() guard.
     std::vector<std::thread> signal_threads;
     signal_threads.reserve(kSignalThreads);
     for (int w = 0; w < kSignalThreads; ++w) {
@@ -211,7 +210,7 @@ TEST(DictionaryConcurrent, SignalHandlerBoundedLookupVsDumpClear) {
                 snprintf(buf, sizeof(buf), "Lcom/example/Preloaded%d;",
                          counter % kPreload);
                 size_t len = strlen(buf);
-                BoundedOptionalSharedLockGuard guard(&lock);
+                OptionalSharedLockGuard guard(&lock);
                 if (guard.ownsLock()) {
                     // Read-only; no malloc, no CAS — safe in signal context.
                     unsigned int id = dict.bounded_lookup(buf, len, 0);
@@ -247,6 +246,77 @@ TEST(DictionaryConcurrent, SignalHandlerBoundedLookupVsDumpClear) {
     dump_thread.join();
 
     // Both roles must have made progress.
+    EXPECT_GT(total_reads.load() + total_skips.load(), 0L);
+    EXPECT_GT(total_clears.load(), 0L);
+}
+
+// (4) Same race as (3) but using BoundedOptionalSharedLockGuard, which is the
+// guard classMapTrySharedGuard() now returns in hotspotSupport.cpp. The bounded
+// variant may fail spuriously under reader pressure (≤5 CAS attempts); this
+// verifies it still prevents use-after-free without deadlocking.
+TEST(DictionaryConcurrent, SignalHandlerBoundedOptionalLookupVsDumpClear) {
+    Dictionary dict(/*id=*/0);
+    SpinLock lock;
+
+    constexpr int kPreload = 64;
+    for (int i = 0; i < kPreload; ++i) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "Lcom/example/Preloaded%d;", i);
+        lock.lock();
+        dict.lookup(buf, strlen(buf));
+        lock.unlock();
+    }
+
+    constexpr int kSignalThreads = 4;
+    const auto kDuration = std::chrono::milliseconds(500);
+
+    std::atomic<bool> stop{false};
+    std::atomic<long> total_reads{0};
+    std::atomic<long> total_skips{0};
+    std::atomic<long> total_clears{0};
+
+    // Simulate hotspotSupport.cpp: BoundedOptionalSharedLockGuard + bounded_lookup(0).
+    std::vector<std::thread> signal_threads;
+    signal_threads.reserve(kSignalThreads);
+    for (int w = 0; w < kSignalThreads; ++w) {
+        signal_threads.emplace_back([&, w]() {
+            char buf[64];
+            int counter = 0;
+            while (!stop.load(std::memory_order_relaxed)) {
+                snprintf(buf, sizeof(buf), "Lcom/example/Preloaded%d;",
+                         counter % kPreload);
+                size_t len = strlen(buf);
+                BoundedOptionalSharedLockGuard guard(&lock);
+                if (guard.ownsLock()) {
+                    unsigned int id = dict.bounded_lookup(buf, len, 0);
+                    (void)id;
+                    total_reads.fetch_add(1, std::memory_order_relaxed);
+                } else {
+                    total_skips.fetch_add(1, std::memory_order_relaxed);
+                }
+                ++counter;
+            }
+        });
+    }
+
+    std::thread dump_thread([&]() {
+        while (!stop.load(std::memory_order_relaxed)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            lock.lock();
+            dict.clear();
+            lock.unlock();
+            total_clears.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    std::this_thread::sleep_for(kDuration);
+    stop.store(true, std::memory_order_relaxed);
+
+    for (auto& t : signal_threads) {
+        t.join();
+    }
+    dump_thread.join();
+
     EXPECT_GT(total_reads.load() + total_skips.load(), 0L);
     EXPECT_GT(total_clears.load(), 0L);
 }

--- a/ddprof-lib/src/test/cpp/spinlock_bounded_ut.cpp
+++ b/ddprof-lib/src/test/cpp/spinlock_bounded_ut.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include "spinLock.h"
+#include "../../main/cpp/gtest_crash_handler.h"
+
+// Unit tests for tryLockSharedBounded() and BoundedOptionalSharedLockGuard —
+// the signal-safe locking API introduced to replace unbounded spinning in
+// hotspotSupport.cpp (classMapTrySharedGuard()).
+
+static constexpr char SPINLOCK_BOUNDED_TEST_NAME[] = "SpinLockBounded";
+
+namespace {
+
+class SpinLockBoundedSetup {
+public:
+    SpinLockBoundedSetup() {
+        installGtestCrashHandler<SPINLOCK_BOUNDED_TEST_NAME>();
+    }
+    ~SpinLockBoundedSetup() {
+        restoreDefaultSignalHandlers();
+    }
+};
+
+static SpinLockBoundedSetup spinlock_bounded_global_setup;
+
+} // namespace
+
+TEST(SpinLockBounded, BoundedTryLockSucceedsOnFreeLock) {
+    SpinLock lock;
+    EXPECT_TRUE(lock.tryLockSharedBounded());
+    lock.unlockShared();
+}
+
+TEST(SpinLockBounded, BoundedTryLockFailsWhenExclusiveLockHeld) {
+    SpinLock lock;
+    lock.lock();
+    EXPECT_FALSE(lock.tryLockSharedBounded());
+    lock.unlock();
+}
+
+// Multiple shared holders must coexist — bounded acquire must not treat a
+// concurrent reader's negative _lock value as an exclusive lock.
+TEST(SpinLockBounded, BoundedTryLockAllowsMultipleSharedHolders) {
+    SpinLock lock;
+    ASSERT_TRUE(lock.tryLockSharedBounded());
+    EXPECT_TRUE(lock.tryLockSharedBounded());
+    lock.unlockShared();
+    lock.unlockShared();
+}
+
+TEST(SpinLockBounded, BoundedGuardOwnsLockWhenFree) {
+    SpinLock lock;
+    BoundedOptionalSharedLockGuard guard(&lock);
+    EXPECT_TRUE(guard.ownsLock());
+}
+
+// When the exclusive lock is held the guard must not own the lock, and its
+// destructor must not accidentally release the exclusive lock.
+TEST(SpinLockBounded, BoundedGuardFailsWhenExclusiveLockHeld) {
+    SpinLock lock;
+    lock.lock();
+    {
+        BoundedOptionalSharedLockGuard guard(&lock);
+        EXPECT_FALSE(guard.ownsLock());
+    }
+    // Exclusive lock must still be held — unlock() must succeed exactly once.
+    lock.unlock();
+}
+
+// After the guard goes out of scope the lock must be fully released so that an
+// exclusive acquire succeeds.
+TEST(SpinLockBounded, BoundedGuardReleasesLockOnDestruction) {
+    SpinLock lock;
+    {
+        BoundedOptionalSharedLockGuard guard(&lock);
+        ASSERT_TRUE(guard.ownsLock());
+    }
+    EXPECT_TRUE(lock.tryLock());
+    lock.unlock();
+}
+
+// Stress: concurrent BoundedOptionalSharedLockGuard readers vs an exclusive
+// locker. Mirrors the classMapTrySharedGuard() signal-handler path vs the
+// Profiler::dump path, using the RAII type that hotspotSupport.cpp now uses.
+TEST(SpinLockBounded, BoundedGuardConcurrentWithExclusiveLock) {
+    SpinLock lock;
+    constexpr int kReaders = 4;
+    const auto kDuration = std::chrono::milliseconds(300);
+
+    std::atomic<bool> stop{false};
+    std::atomic<long> total_acquired{0};
+    std::atomic<long> total_skipped{0};
+    std::atomic<long> total_exclusive{0};
+
+    std::vector<std::thread> readers;
+    readers.reserve(kReaders);
+    for (int i = 0; i < kReaders; ++i) {
+        readers.emplace_back([&]() {
+            while (!stop.load(std::memory_order_relaxed)) {
+                BoundedOptionalSharedLockGuard guard(&lock);
+                if (guard.ownsLock()) {
+                    total_acquired.fetch_add(1, std::memory_order_relaxed);
+                } else {
+                    total_skipped.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+
+    std::thread exclusive_thread([&]() {
+        while (!stop.load(std::memory_order_relaxed)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            lock.lock();
+            lock.unlock();
+            total_exclusive.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    std::this_thread::sleep_for(kDuration);
+    stop.store(true, std::memory_order_relaxed);
+    for (auto& t : readers) t.join();
+    exclusive_thread.join();
+
+    EXPECT_GT(total_acquired.load(), 0L);
+    EXPECT_GT(total_exclusive.load(), 0L);
+}


### PR DESCRIPTION
**What does this PR do?**:
Fixes a SIGSEGV in \`Profiler::dump\` caused by a three-way race on \`_class_map\`:

1. \`HotspotSupport::walkVM\` (signal handler) called the inserting \`Dictionary::lookup()\`, which calls \`malloc\`/\`calloc\` — async-signal-unsafe — and raced \`clear()\` which frees \`row->keys\` and \`row->next\`.
2. \`Recording::writeClasses\` called \`Dictionary::collect()\` without holding \`_class_map_lock\`, then iterated \`const char*\` pointers from the collected map after the lock was released — use-after-free if \`clear()\` ran between collect and iteration.
3. \`Profiler::dump\` calls \`_class_map.clear()\` under exclusive lock, but neither of the above callers respected the lock.

**Motivation**:
Crash reports showing SIGSEGV with frames \`Dictionary::clear\` ← \`Profiler::dump\` ← \`JavaProfiler.dump0\`.

**Changes**:
- **\`spinLock.h\`**: added \`tryLockSharedBounded()\` — a signal-safe variant that returns false after at most 5 CAS attempts. \`SharedLockGuard\` and \`OptionalSharedLockGuard\` gain move constructors + null-check in \`SharedLockGuard\` dtor, enabling RAII factory methods. New \`BoundedOptionalSharedLockGuard\` wraps \`tryLockSharedBounded()\` for signal-handler paths.
- **\`profiler.h\`**: replaced raw \`SpinLock *classMapLock()\` with \`SharedLockGuard classMapSharedGuard()\` and \`BoundedOptionalSharedLockGuard classMapTrySharedGuard()\` factory methods. Callers never hold a raw lock pointer.
- **\`flightRecorder.cpp\`**: \`writeClasses()\` holds the shared guard for the full function scope (not just during \`collect()\`), preventing use-after-free during iteration.
- **\`hotspotSupport.cpp\`**: signal-handler path uses \`classMapTrySharedGuard()\` (non-blocking, bounded retries) + \`bounded_lookup(size_limit=0)\` (read-only, no malloc). If \`clear()\` holds the exclusive lock, \`ownsLock()\` is false and the vtable-target frame is silently dropped — never reading freed memory.
- **\`dictionary_concurrent_ut.cpp\`**: 4 gtest cases covering the \`bounded_lookup\` contract and a direct regression for the PROF-14550 race pattern (passes cleanly under TSan/ASan).
- **\`spinlock_bounded_ut.cpp\`**: 6 gtest cases covering \`tryLockSharedBounded()\` and \`BoundedOptionalSharedLockGuard\` in isolation and under concurrent stress.

**Additional Notes**:
- The \`dictionary_concurrent_ut.cpp\` and \`spinlock_bounded_ut.cpp\` tests require Google Test. On macOS the test binary is skipped at build time; they will run in CI on Linux.
- \`_class_map_lock\` internal usages in \`profiler.cpp\` (explicit \`lock()\`/\`unlock()\` at the dump path) are unchanged — those are in-class accesses that don't need to go through the factory methods.

**How to test the change?**:
- \`./gradlew :ddprof-lib:buildDebug :ddprof-lib:buildRelease\` — both must compile cleanly.
- On Linux with Google Test: \`./gradlew :ddprof-lib:gtestDebug\` — all \`DictionaryConcurrent\` and \`SpinLockBounded\` tests must pass, including \`SignalHandlerBoundedLookupVsDumpClear\` which reproduces the PROF-14550 race.
- Run under TSan: the concurrent test suite detects data races if any locking is omitted.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from \`@DataDog/security-design-and-guidance\`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-14550](https://datadoghq.atlassian.net/browse/PROF-14550)

<!-- muse-session:impl-20260508-134157 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code) via muse implement

[PROF-14550]: https://datadoghq.atlassian.net/browse/PROF-14550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ