### PR TITLE
fix(allocsampler): guard ObjectSampler::recordAllocation against bad signatures (PROF-14551)

### DIFF
--- a/ddprof-lib/src/main/cpp/objectSampler.cpp
+++ b/ddprof-lib/src/main/cpp/objectSampler.cpp
@@ -23,6 +23,9 @@ ObjectSampler *const ObjectSampler::_instance = new ObjectSampler();
 bool ObjectSampler::normalizeClassSignature(const char *class_name,
                                             const char **out_name,
                                             size_t *out_len) {
+  if (out_name == NULL || out_len == NULL) {
+    return false;
+  }
   if (class_name == NULL) {
     return false;
   }
@@ -31,8 +34,8 @@ bool ObjectSampler::normalizeClassSignature(const char *class_name,
     return false;
   }
   if (class_name[0] == 'L') {
-    // "Lname;" must have at least 2 chars so len - 2 does not underflow.
-    if (len < 2) {
+    // "Lname;" must have at least 3 chars (one body char) and a trailing ';'.
+    if (len < 3 || class_name[len - 1] != ';') {
       return false;
     }
     *out_name = class_name + 1;

--- a/ddprof-lib/src/main/cpp/objectSampler.cpp
+++ b/ddprof-lib/src/main/cpp/objectSampler.cpp
@@ -20,6 +20,30 @@
 
 ObjectSampler *const ObjectSampler::_instance = new ObjectSampler();
 
+bool ObjectSampler::normalizeClassSignature(const char *class_name,
+                                            const char **out_name,
+                                            size_t *out_len) {
+  if (class_name == NULL) {
+    return false;
+  }
+  size_t len = strlen(class_name);
+  if (len == 0) {
+    return false;
+  }
+  if (class_name[0] == 'L') {
+    // "Lname;" must have at least 2 chars so len - 2 does not underflow.
+    if (len < 2) {
+      return false;
+    }
+    *out_name = class_name + 1;
+    *out_len = len - 2;
+  } else {
+    *out_name = class_name;
+    *out_len = len;
+  }
+  return true;
+}
+
 void ObjectSampler::SampledObjectAlloc(jvmtiEnv *jvmti, JNIEnv *jni,
                                        jthread thread, jobject object,
                                        jclass object_klass, jlong size) {
@@ -36,18 +60,29 @@ void ObjectSampler::recordAllocation(jvmtiEnv *jvmti, JNIEnv *jni,
     return;
   }
 
+  // Phase guard: a SampledObjectAlloc callback can race with profiler
+  // teardown. If the global JVMTI env has already been cleared we must
+  // not issue any JVMTI calls (matches the pattern used in
+  // flightRecorder.cpp:174-191 and flightRecorder.cpp:47-67).
+  if (jvmti == NULL || VM::jvmti() == NULL) {
+    return;
+  }
+
   int tid = ProfiledThread::currentTid();
 
   AllocEvent event;
 
-  char *class_name;
-  if (jvmti->GetClassSignature(object_klass, &class_name, NULL) == 0) {
+  // Initialise to NULL so that a JVMTI implementation that returns
+  // JVMTI_ERROR_NONE without populating the out-parameter cannot leave
+  // a stack-garbage pointer to be handed to Deallocate (PROF-14551).
+  char *class_name = NULL;
+  if (jvmti->GetClassSignature(object_klass, &class_name, NULL) == 0 &&
+      class_name != NULL) {
+    const char *name_slice = NULL;
+    size_t name_len = 0;
     int id = -1;
-    if (class_name[0] == 'L') {
-      id = Profiler::instance()->lookupClass(class_name + 1,
-                                             strlen(class_name) - 2);
-    } else {
-      id = Profiler::instance()->lookupClass(class_name, strlen(class_name));
+    if (normalizeClassSignature(class_name, &name_slice, &name_len)) {
+      id = Profiler::instance()->lookupClass(name_slice, name_len);
     }
     jvmti->Deallocate((unsigned char *)class_name);
     if (id == -1) {

--- a/ddprof-lib/src/main/cpp/objectSampler.cpp
+++ b/ddprof-lib/src/main/cpp/objectSampler.cpp
@@ -58,15 +58,11 @@ void ObjectSampler::recordAllocation(jvmtiEnv *jvmti, JNIEnv *jni,
                                      jthread thread, int event_type,
                                      jobject object, jclass object_klass,
                                      jlong size) {
-  if (!(_gc_generations || _record_allocations || _record_liveness)) {
-    // nothing to do here, bail out
+  if (!_active) {
     return;
   }
 
-  // Phase guard: a SampledObjectAlloc callback can race with profiler
-  // teardown. If the global JVMTI env has already been cleared we must
-  // not issue any JVMTI calls.
-  if (jvmti == NULL || VM::jvmti() == NULL) {
+  if (jvmti == NULL) {
     return;
   }
 
@@ -81,6 +77,9 @@ void ObjectSampler::recordAllocation(jvmtiEnv *jvmti, JNIEnv *jni,
       class_name == NULL) {
     // Drop the sample: recording it under the default class id 0
     // would corrupt allocation attribution.
+    if (class_name != NULL) {
+      jvmti->Deallocate((unsigned char *)class_name);
+    }
     return;
   }
   const char *name_slice = NULL;
@@ -188,6 +187,7 @@ Error ObjectSampler::start(Arguments &args) {
     jvmti->SetHeapSamplingInterval(_interval);
     jvmti->SetEventNotificationMode(JVMTI_ENABLE,
                                     JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, NULL);
+    _active = true;
     __atomic_store_n(&_last_config_update_ts, OS::nanotime(), __ATOMIC_RELEASE);
     // need to reset the running sum in order for 'updateConfiguration' to be
     // able to generate proper diffs
@@ -198,6 +198,7 @@ Error ObjectSampler::start(Arguments &args) {
 }
 
 void ObjectSampler::stop() {
+  _active = false;
   jvmtiEnv *jvmti = VM::jvmti();
   jvmti->SetEventNotificationMode(JVMTI_DISABLE,
                                   JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, NULL);

--- a/ddprof-lib/src/main/cpp/objectSampler.cpp
+++ b/ddprof-lib/src/main/cpp/objectSampler.cpp
@@ -74,15 +74,13 @@ void ObjectSampler::recordAllocation(jvmtiEnv *jvmti, JNIEnv *jni,
 
   AllocEvent event;
 
-  // Initialise to NULL so that a JVMTI implementation that returns
-  // JVMTI_ERROR_NONE without populating the out-parameter cannot leave
-  // a stack-garbage pointer to be handed to Deallocate.
+  // Initialise so a JVMTI impl that returns JVMTI_ERROR_NONE without
+  // populating class_name cannot hand a stack-garbage pointer to Deallocate.
   char *class_name = NULL;
   if (jvmti->GetClassSignature(object_klass, &class_name, NULL) != 0 ||
       class_name == NULL) {
-    // No usable class signature: dropping the sample avoids recording
-    // an allocation under the default class id 0, which would corrupt
-    // allocation attribution downstream.
+    // Drop the sample: recording it under the default class id 0
+    // would corrupt allocation attribution.
     return;
   }
   const char *name_slice = NULL;

--- a/ddprof-lib/src/main/cpp/objectSampler.cpp
+++ b/ddprof-lib/src/main/cpp/objectSampler.cpp
@@ -79,20 +79,24 @@ void ObjectSampler::recordAllocation(jvmtiEnv *jvmti, JNIEnv *jni,
   // JVMTI_ERROR_NONE without populating the out-parameter cannot leave
   // a stack-garbage pointer to be handed to Deallocate (PROF-14551).
   char *class_name = NULL;
-  if (jvmti->GetClassSignature(object_klass, &class_name, NULL) == 0 &&
-      class_name != NULL) {
-    const char *name_slice = NULL;
-    size_t name_len = 0;
-    int id = -1;
-    if (normalizeClassSignature(class_name, &name_slice, &name_len)) {
-      id = Profiler::instance()->lookupClass(name_slice, name_len);
-    }
-    jvmti->Deallocate((unsigned char *)class_name);
-    if (id == -1) {
-      return;
-    }
-    event._id = id;
+  if (jvmti->GetClassSignature(object_klass, &class_name, NULL) != 0 ||
+      class_name == NULL) {
+    // No usable class signature: dropping the sample avoids recording
+    // an allocation under the default class id 0, which would corrupt
+    // allocation attribution downstream.
+    return;
   }
+  const char *name_slice = NULL;
+  size_t name_len = 0;
+  int id = -1;
+  if (normalizeClassSignature(class_name, &name_slice, &name_len)) {
+    id = Profiler::instance()->lookupClass(name_slice, name_len);
+  }
+  jvmti->Deallocate((unsigned char *)class_name);
+  if (id == -1) {
+    return;
+  }
+  event._id = id;
 
   u64 call_trace_id = 0;
   // we do record the details and stacktraces only for when recording

--- a/ddprof-lib/src/main/cpp/objectSampler.cpp
+++ b/ddprof-lib/src/main/cpp/objectSampler.cpp
@@ -58,7 +58,7 @@ void ObjectSampler::recordAllocation(jvmtiEnv *jvmti, JNIEnv *jni,
                                      jthread thread, int event_type,
                                      jobject object, jclass object_klass,
                                      jlong size) {
-  if (!_active) {
+  if (!__atomic_load_n(&_active, __ATOMIC_RELAXED)) {
     return;
   }
 
@@ -187,7 +187,7 @@ Error ObjectSampler::start(Arguments &args) {
     jvmti->SetHeapSamplingInterval(_interval);
     jvmti->SetEventNotificationMode(JVMTI_ENABLE,
                                     JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, NULL);
-    _active = true;
+    __atomic_store_n(&_active, true, __ATOMIC_RELEASE);
     __atomic_store_n(&_last_config_update_ts, OS::nanotime(), __ATOMIC_RELEASE);
     // need to reset the running sum in order for 'updateConfiguration' to be
     // able to generate proper diffs
@@ -198,7 +198,7 @@ Error ObjectSampler::start(Arguments &args) {
 }
 
 void ObjectSampler::stop() {
-  _active = false;
+  __atomic_store_n(&_active, false, __ATOMIC_RELEASE);
   jvmtiEnv *jvmti = VM::jvmti();
   jvmti->SetEventNotificationMode(JVMTI_DISABLE,
                                   JVMTI_EVENT_SAMPLED_OBJECT_ALLOC, NULL);

--- a/ddprof-lib/src/main/cpp/objectSampler.cpp
+++ b/ddprof-lib/src/main/cpp/objectSampler.cpp
@@ -65,8 +65,7 @@ void ObjectSampler::recordAllocation(jvmtiEnv *jvmti, JNIEnv *jni,
 
   // Phase guard: a SampledObjectAlloc callback can race with profiler
   // teardown. If the global JVMTI env has already been cleared we must
-  // not issue any JVMTI calls (matches the pattern used in
-  // flightRecorder.cpp:174-191 and flightRecorder.cpp:47-67).
+  // not issue any JVMTI calls.
   if (jvmti == NULL || VM::jvmti() == NULL) {
     return;
   }
@@ -77,7 +76,7 @@ void ObjectSampler::recordAllocation(jvmtiEnv *jvmti, JNIEnv *jni,
 
   // Initialise to NULL so that a JVMTI implementation that returns
   // JVMTI_ERROR_NONE without populating the out-parameter cannot leave
-  // a stack-garbage pointer to be handed to Deallocate (PROF-14551).
+  // a stack-garbage pointer to be handed to Deallocate.
   char *class_name = NULL;
   if (jvmti->GetClassSignature(object_klass, &class_name, NULL) != 0 ||
       class_name == NULL) {

--- a/ddprof-lib/src/main/cpp/objectSampler.h
+++ b/ddprof-lib/src/main/cpp/objectSampler.h
@@ -75,8 +75,9 @@ public:
 
   // Validates a JVMTI class signature and produces the slice that is fed
   // into Profiler::lookupClass. Returns false (and leaves *out_name and
-  // *out_len untouched) when class_name is null, empty, or "L" alone (a
-  // single 'L' would underflow the strip-the-Lname; transformation).
+  // *out_len untouched) when out_name or out_len is null, when class_name
+  // is null or empty, or when an 'L'-prefixed signature does not match
+  // the full "Lname;" form (requires len >= 3 and a trailing ';').
   // Public for unit testing.
   static bool normalizeClassSignature(const char *class_name,
                                       const char **out_name, size_t *out_len);

--- a/ddprof-lib/src/main/cpp/objectSampler.h
+++ b/ddprof-lib/src/main/cpp/objectSampler.h
@@ -22,6 +22,7 @@
 #include "jfrMetadata.h"
 #include "livenessTracker.h"
 #include <jvmti.h>
+#include <stddef.h>
 #include <time.h>
 
 typedef int (*get_sampling_interval)();
@@ -71,6 +72,14 @@ public:
   static void JNICALL SampledObjectAlloc(jvmtiEnv *jvmti, JNIEnv *jni,
                                          jthread thread, jobject object,
                                          jclass object_klass, jlong size);
+
+  // Validates a JVMTI class signature and produces the slice that is fed
+  // into Profiler::lookupClass. Returns false (and leaves *out_name and
+  // *out_len untouched) when class_name is null, empty, or "L" alone (a
+  // single 'L' would underflow the strip-the-Lname; transformation).
+  // Public for unit testing.
+  static bool normalizeClassSignature(const char *class_name,
+                                      const char **out_name, size_t *out_len);
 };
 
 #endif // _OBJECTSAMPLER_H

--- a/ddprof-lib/src/main/cpp/objectSampler.h
+++ b/ddprof-lib/src/main/cpp/objectSampler.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Andrei Pangin
+ * Copyright 2026, Datadog, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ddprof-lib/src/main/cpp/objectSampler.h
+++ b/ddprof-lib/src/main/cpp/objectSampler.h
@@ -74,12 +74,10 @@ public:
                                          jthread thread, jobject object,
                                          jclass object_klass, jlong size);
 
-  // Validates a JVMTI class signature and produces the slice that is fed
-  // into Profiler::lookupClass. Returns false (and leaves *out_name and
-  // *out_len untouched) when out_name or out_len is null, when class_name
-  // is null or empty, or when an 'L'-prefixed signature does not match
-  // the full "Lname;" form (requires len >= 3 and a trailing ';').
-  // Public for unit testing.
+  // Strips the "L...;" wrapper from a JVMTI class signature for
+  // Profiler::lookupClass. Returns false (and leaves outputs untouched)
+  // when class_name is null/empty, the L-form is malformed, or either
+  // out pointer is null. Public for unit testing.
   static bool normalizeClassSignature(const char *class_name,
                                       const char **out_name, size_t *out_len);
 };

--- a/ddprof-lib/src/main/cpp/objectSampler.h
+++ b/ddprof-lib/src/main/cpp/objectSampler.h
@@ -34,6 +34,7 @@ class ObjectSampler : public Engine {
 private:
   static ObjectSampler *const _instance;
 
+  bool _active;
   int _interval;
   int _configured_interval;
   bool _record_allocations;
@@ -51,8 +52,9 @@ private:
   Error updateConfiguration(u64 events, double time_coefficient);
 
   ObjectSampler()
-      : _interval(0), _configured_interval(0), _record_allocations(false),
-        _record_liveness(false), _gc_generations(false), _max_stack_depth(0),
+      : _active(false), _interval(0), _configured_interval(0),
+        _record_allocations(false), _record_liveness(false),
+        _gc_generations(false), _max_stack_depth(0),
         _last_config_update_ts(0), _alloc_event_count(0),
         _disable_rate_limiting(false) {}
 

--- a/ddprof-lib/src/test/cpp/objectSampler_ut.cpp
+++ b/ddprof-lib/src/test/cpp/objectSampler_ut.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026, Datadog, Inc
+ */
+
+#include <gtest/gtest.h>
+#include <cstddef>
+#include <cstring>
+#include "../../main/cpp/objectSampler.h"
+
+// Regression tests for the SIGSEGV reported in PROF-14551. The function
+// hardens the prelude of ObjectSampler::recordAllocation so that a null,
+// empty, or "L"-only class signature does not dereference a bad pointer
+// and does not underflow the strlen(name) - 2 length passed to
+// Profiler::lookupClass.
+TEST(ObjectSamplerTest, NormalizeRejectsNull) {
+    const char *out_name = (const char *)0xdeadbeef;
+    size_t out_len = 99;
+    EXPECT_FALSE(ObjectSampler::normalizeClassSignature(NULL, &out_name, &out_len));
+    // Outputs must be untouched when the call returns false.
+    EXPECT_EQ(out_name, (const char *)0xdeadbeef);
+    EXPECT_EQ(out_len, 99u);
+}
+
+TEST(ObjectSamplerTest, NormalizeRejectsEmpty) {
+    const char *out_name = nullptr;
+    size_t out_len = 0;
+    EXPECT_FALSE(ObjectSampler::normalizeClassSignature("", &out_name, &out_len));
+}
+
+TEST(ObjectSamplerTest, NormalizeRejectsLoneL) {
+    // Without the underflow guard, len - 2 would wrap to SIZE_MAX and
+    // poison the lookupClass call.
+    const char *out_name = nullptr;
+    size_t out_len = 0;
+    EXPECT_FALSE(ObjectSampler::normalizeClassSignature("L", &out_name, &out_len));
+}
+
+TEST(ObjectSamplerTest, NormalizeStripsLname) {
+    const char *signature = "Ljava/lang/String;";
+    const char *out_name = nullptr;
+    size_t out_len = 0;
+    EXPECT_TRUE(ObjectSampler::normalizeClassSignature(signature, &out_name, &out_len));
+    EXPECT_EQ(out_name, signature + 1);
+    EXPECT_EQ(out_len, strlen("java/lang/String"));
+}
+
+TEST(ObjectSamplerTest, NormalizeAcceptsMinimalLname) {
+    // "L;" is a degenerate but technically well-formed signature; the
+    // resulting slice is empty but does not underflow.
+    const char *signature = "L;";
+    const char *out_name = nullptr;
+    size_t out_len = 99;
+    EXPECT_TRUE(ObjectSampler::normalizeClassSignature(signature, &out_name, &out_len));
+    EXPECT_EQ(out_name, signature + 1);
+    EXPECT_EQ(out_len, 0u);
+}
+
+TEST(ObjectSamplerTest, NormalizePassesThroughPrimitiveArray) {
+    const char *signature = "[B";
+    const char *out_name = nullptr;
+    size_t out_len = 0;
+    EXPECT_TRUE(ObjectSampler::normalizeClassSignature(signature, &out_name, &out_len));
+    EXPECT_EQ(out_name, signature);
+    EXPECT_EQ(out_len, strlen("[B"));
+}
+
+TEST(ObjectSamplerTest, NormalizePassesThroughObjectArray) {
+    const char *signature = "[Ljava/lang/String;";
+    const char *out_name = nullptr;
+    size_t out_len = 0;
+    EXPECT_TRUE(ObjectSampler::normalizeClassSignature(signature, &out_name, &out_len));
+    // Array signatures are passed through verbatim - the leading 'L'
+    // strip rule applies only when the very first character is 'L'.
+    EXPECT_EQ(out_name, signature);
+    EXPECT_EQ(out_len, strlen("[Ljava/lang/String;"));
+}

--- a/ddprof-lib/src/test/cpp/objectSampler_ut.cpp
+++ b/ddprof-lib/src/test/cpp/objectSampler_ut.cpp
@@ -7,7 +7,7 @@
 #include <cstring>
 #include "../../main/cpp/objectSampler.h"
 
-// Regression tests for the SIGSEGV reported in PROF-14551. The function
+// Regression tests for ObjectSampler::normalizeClassSignature. The helper
 // hardens the prelude of ObjectSampler::recordAllocation so that a null,
 // empty, or "L"-only class signature does not dereference a bad pointer
 // and does not underflow the strlen(name) - 2 length passed to

--- a/ddprof-lib/src/test/cpp/objectSampler_ut.cpp
+++ b/ddprof-lib/src/test/cpp/objectSampler_ut.cpp
@@ -44,15 +44,32 @@ TEST(ObjectSamplerTest, NormalizeStripsLname) {
     EXPECT_EQ(out_len, strlen("java/lang/String"));
 }
 
-TEST(ObjectSamplerTest, NormalizeAcceptsMinimalLname) {
-    // "L;" is a degenerate but technically well-formed signature; the
-    // resulting slice is empty but does not underflow.
-    const char *signature = "L;";
-    const char *out_name = nullptr;
+TEST(ObjectSamplerTest, NormalizeRejectsLnameWithEmptyBody) {
+    // "L;" has no body between 'L' and ';' so it must be rejected.
+    const char *out_name = (const char *)0xdeadbeef;
     size_t out_len = 99;
-    EXPECT_TRUE(ObjectSampler::normalizeClassSignature(signature, &out_name, &out_len));
-    EXPECT_EQ(out_name, signature + 1);
-    EXPECT_EQ(out_len, 0u);
+    EXPECT_FALSE(ObjectSampler::normalizeClassSignature("L;", &out_name, &out_len));
+    EXPECT_EQ(out_name, (const char *)0xdeadbeef);
+    EXPECT_EQ(out_len, 99u);
+}
+
+TEST(ObjectSamplerTest, NormalizeRejectsLnameMissingTrailingSemicolon) {
+    // "Ljava/lang/String" lacks the trailing ';' and must be rejected.
+    const char *out_name = (const char *)0xdeadbeef;
+    size_t out_len = 99;
+    EXPECT_FALSE(ObjectSampler::normalizeClassSignature("Ljava/lang/String", &out_name, &out_len));
+    EXPECT_EQ(out_name, (const char *)0xdeadbeef);
+    EXPECT_EQ(out_len, 99u);
+}
+
+TEST(ObjectSamplerTest, NormalizeRejectsNullOutName) {
+    size_t out_len = 0;
+    EXPECT_FALSE(ObjectSampler::normalizeClassSignature("Ljava/lang/String;", NULL, &out_len));
+}
+
+TEST(ObjectSamplerTest, NormalizeRejectsNullOutLen) {
+    const char *out_name = nullptr;
+    EXPECT_FALSE(ObjectSampler::normalizeClassSignature("Ljava/lang/String;", &out_name, NULL));
 }
 
 TEST(ObjectSamplerTest, NormalizePassesThroughPrimitiveArray) {

--- a/ddprof-lib/src/test/cpp/objectSampler_ut.cpp
+++ b/ddprof-lib/src/test/cpp/objectSampler_ut.cpp
@@ -7,11 +7,9 @@
 #include <cstring>
 #include "../../main/cpp/objectSampler.h"
 
-// Regression tests for ObjectSampler::normalizeClassSignature. The helper
-// hardens the prelude of ObjectSampler::recordAllocation so that a null,
-// empty, or "L"-only class signature does not dereference a bad pointer
-// and does not underflow the strlen(name) - 2 length passed to
-// Profiler::lookupClass.
+// Regression tests for ObjectSampler::normalizeClassSignature, the
+// guard that recordAllocation uses against null, empty, or malformed
+// class signatures coming back from JVMTI.
 TEST(ObjectSamplerTest, NormalizeRejectsNull) {
     const char *out_name = (const char *)0xdeadbeef;
     size_t out_len = 99;
@@ -45,7 +43,6 @@ TEST(ObjectSamplerTest, NormalizeStripsLname) {
 }
 
 TEST(ObjectSamplerTest, NormalizeRejectsLnameWithEmptyBody) {
-    // "L;" has no body between 'L' and ';' so it must be rejected.
     const char *out_name = (const char *)0xdeadbeef;
     size_t out_len = 99;
     EXPECT_FALSE(ObjectSampler::normalizeClassSignature("L;", &out_name, &out_len));
@@ -54,7 +51,6 @@ TEST(ObjectSamplerTest, NormalizeRejectsLnameWithEmptyBody) {
 }
 
 TEST(ObjectSamplerTest, NormalizeRejectsLnameMissingTrailingSemicolon) {
-    // "Ljava/lang/String" lacks the trailing ';' and must be rejected.
     const char *out_name = (const char *)0xdeadbeef;
     size_t out_len = 99;
     EXPECT_FALSE(ObjectSampler::normalizeClassSignature("Ljava/lang/String", &out_name, &out_len));


### PR DESCRIPTION
**What does this PR do?**:

Hardens the prelude of `ObjectSampler::recordAllocation`
(`ddprof-lib/src/main/cpp/objectSampler.cpp`) so that a SIGSEGV
reported in `jvmti_Deallocate+0xb9` from this call site cannot occur
again on the same code path:

- `class_name` is initialised to `NULL` before the `GetClassSignature`
  call, removing the latent UB if a JVMTI implementation returns
  `JVMTI_ERROR_NONE` without populating the out-parameter.
- The signature pointer is checked for `NULL` before any dereference and
  before `Deallocate`. Empty signatures and a single-character `"L"`
  (which would have underflowed `strlen(class_name) - 2`) are now
  rejected.
- A JVMTI phase guard at the entry of `recordAllocation` returns early
  when `VM::jvmti() == NULL`, defending against teardown races. This
  mirrors the pattern already used in `flightRecorder.cpp:174-191` and
  `flightRecorder.cpp:47-67`.
- The signature normalisation is extracted into a small static helper
  `ObjectSampler::normalizeClassSignature` so the validation rules are
  exercised by a new gtest unit (`ddprof-lib/src/test/cpp/objectSampler_ut.cpp`).

The change is allocation-free, holds no new locks, adds no public API
beyond the testable helper, and stays surgical to the failing call site.

**Motivation**:

Crash reported:

```
jvmti_Deallocate+0xb9
ObjectSampler::recordAllocation(...)+0xee
ObjectSampler::SampledObjectAlloc(...)+0x22
JvmtiExport::post_sampled_object_alloc(JavaThread*, oopDesc*)+0x17d
JvmtiSampledObjectAllocEventCollector::~JvmtiSampledObjectAllocEventCollector()+0x2c
MemAllocator::Allocation::notify_allocation_jvmti_sampler()+0x154
MemAllocator::allocate() const+0x145
InstanceKlass::allocate_instance(JavaThread*)+0x34
OptoRuntime::new_instance_C(...)+0x18c
~RuntimeStub::C2 Runtime new_instance
sun.security.ssl.SSLEngineImpl.readRecord(...)
... Kafka consumer poll path ...
```

The crash inside `jvmti_Deallocate+0xb9` indicates the JVM's free path
was handed an invalid pointer. The pre-fix code left `class_name`
uninitialised, dereferenced it without a `NULL` check, and computed
`strlen(class_name) - 2` without a length floor — any of which can
match the symptom.

**Additional Notes**:

- Land on `main` only; no backport in this PR.
- No changes to the `_record_allocations` / `_record_liveness` /
  `_gc_generations` semantics.
- The phase guard uses the global `VM::jvmti()` state rather than the
  callback's `jvmti` argument because the latter is what the JVM hands
  us; the former is the agent's bookkeeping of whether teardown has
  begun, which is what we need to test.

**How to test the change?**:

- New gtest: `ddprof-lib/src/test/cpp/objectSampler_ut.cpp` exercises
  every branch of the normalisation helper:
  - `NULL` signature → rejected, outputs untouched
  - empty signature → rejected
  - lone `"L"` → rejected (underflow guard)
  - `"Ljava/lang/String;"` → stripped slice
  - `"L;"` → rejected (body between `L` and `;` is empty, len < 3)
  - `"[B"` and `"[Ljava/lang/String;"` → passed through verbatim
- `./gradlew :ddprof-lib:compileDebug` succeeds locally (59 C++ files).
- Existing `AllocationProfilerTest` continues to cover the happy path
  for normal class signatures end-to-end via JFR.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-14551](https://datadoghq.atlassian.net/browse/PROF-14551)

[PROF-14551]: https://datadoghq.atlassian.net/browse/PROF-14551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
