### PR TITLE
fix(profiler): prevent SIGSEGV in updateThreadName on thread death (PROF-14548)

### DIFF
--- a/ddprof-lib/src/main/cpp/hotspot/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/vmStructs.cpp
@@ -665,7 +665,9 @@ void* VMThread::initialize(jthread thread) {
     }
 
     void* vm_thread = fromJavaThread(env, thread);
-    assert(vm_thread != nullptr);
+    if (vm_thread == nullptr) {
+        return nullptr;
+    }
     _has_native_thread_id = _thread_osthread_offset >= 0 && _osthread_id_offset >= 0;
     _env_offset = (intptr_t)env - (intptr_t)vm_thread;
     memcpy(_java_thread_vtbl, VMThread::cast(vm_thread)->vtable(), sizeof(_java_thread_vtbl));
@@ -752,7 +754,7 @@ OSThreadState VMThread::getOSThreadState() {
 }
 
 int VMThread::osThreadId() {
-    const char* osthread = *(const char**) at(_thread_osthread_offset);
+    const char* osthread = (const char*) SafeAccess::load((void**) at(_thread_osthread_offset));
     if (osthread != NULL) {
         // Java thread may be in the middle of termination, and its osthread structure just released
         return SafeAccess::load32((int32_t*)(osthread + _osthread_id_offset), -1);
@@ -1034,7 +1036,7 @@ bool VMMethod::check_jmethodID_J9(jmethodID id) {
 
 OSThreadState VMThread::osThreadState() {
     if (VMStructs::thread_osthread_offset() >= 0 && VMStructs::osthread_state_offset() >= 0) {
-        const char *osthread = *(char **)at(VMStructs::thread_osthread_offset());
+        const char *osthread = (const char*) SafeAccess::load((void**) at(VMStructs::thread_osthread_offset()));
         if (osthread != nullptr) {
             // If the location is not accessible, the thread must have been terminated
             int value = SafeAccess::safeFetch32((int*)(osthread + VMStructs::osthread_state_offset()),

--- a/ddprof-lib/src/main/cpp/hotspot/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/vmStructs.cpp
@@ -665,9 +665,7 @@ void* VMThread::initialize(jthread thread) {
     }
 
     void* vm_thread = fromJavaThread(env, thread);
-    if (vm_thread == nullptr) {
-        return nullptr;
-    }
+    assert(vm_thread != nullptr);
     _has_native_thread_id = _thread_osthread_offset >= 0 && _osthread_id_offset >= 0;
     _env_offset = (intptr_t)env - (intptr_t)vm_thread;
     memcpy(_java_thread_vtbl, VMThread::cast(vm_thread)->vtable(), sizeof(_java_thread_vtbl));

--- a/ddprof-lib/src/main/cpp/hotspot/vmStructs.inline.h
+++ b/ddprof-lib/src/main/cpp/hotspot/vmStructs.inline.h
@@ -17,7 +17,11 @@ VMThread* VMThread::current() {
 VMThread* VMThread::fromJavaThread(JNIEnv* env, jthread thread) {
     assert(_eetop != nullptr);
     if (_eetop != nullptr) {
-        return VMThread::cast((void*)env->GetLongField(thread, _eetop));
+        jlong eetop = env->GetLongField(thread, _eetop);
+        if (env->ExceptionCheck()) {
+            env->ExceptionClear();
+        }
+        return eetop != 0 ? VMThread::cast((void*)eetop) : nullptr;
     } else {
         return nullptr;
     }

--- a/ddprof-lib/src/main/cpp/hotspot/vmStructs.inline.h
+++ b/ddprof-lib/src/main/cpp/hotspot/vmStructs.inline.h
@@ -20,6 +20,7 @@ VMThread* VMThread::fromJavaThread(JNIEnv* env, jthread thread) {
         jlong eetop = env->GetLongField(thread, _eetop);
         if (env->ExceptionCheck()) {
             env->ExceptionClear();
+            return nullptr;
         }
         return eetop != 0 ? VMThread::cast((void*)eetop) : nullptr;
     } else {

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -881,6 +881,9 @@ void Profiler::updateThreadName(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread,
     assert(native_thread_id != -1);
   } else {
     native_thread_id = JVMThread::nativeThreadId(jni, thread);
+    if (jni->ExceptionCheck()) {
+      jni->ExceptionClear();
+    }
   }
 
   if (native_thread_id >= 0 &&
@@ -901,6 +904,9 @@ void Profiler::updateJavaThreadNames() {
 
   JNIEnv *jni = VM::jni();
   for (int i = 0; i < thread_count; i++) {
+    if (thread_objects[i] == nullptr) {
+      continue;
+    }
     updateThreadName(jvmti, jni, thread_objects[i]);
     jni->DeleteLocalRef(thread_objects[i]);
   }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/DumpWhileChurningThreadsTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/DumpWhileChurningThreadsTest.java
@@ -1,0 +1,102 @@
+package com.datadoghq.profiler.jfr;
+
+import com.datadoghq.profiler.CStackAwareAbstractProfilerTest;
+import com.datadoghq.profiler.Platform;
+import com.datadoghq.profiler.junit.CStack;
+import com.datadoghq.profiler.junit.RetryTest;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for PROF-14548: SIGSEGV in Profiler::updateThreadName when a thread
+ * terminates between GetAllThreads and the eetop dereference during dump().
+ *
+ * Exercises the race by churning short-lived threads while calling dump() repeatedly.
+ * A SIGSEGV would abort the JVM and fail the test with a non-zero exit code.
+ */
+public class DumpWhileChurningThreadsTest extends CStackAwareAbstractProfilerTest {
+
+    private static final int TEST_DURATION_SECS = 10;
+    private static final int CHURN_THREADS = 50;
+
+    public DumpWhileChurningThreadsTest(@CStack String cstack) {
+        super(cstack);
+    }
+
+    @Override
+    protected boolean isPlatformSupported() {
+        return !Platform.isJ9() && Platform.isJavaVersionAtLeast(11);
+    }
+
+    @Override
+    protected String getProfilerCommand() {
+        return "wall=5ms";
+    }
+
+    @RetryTest(2)
+    @Timeout(value = 60)
+    @TestTemplate
+    @ValueSource(strings = {"vm"})
+    public void dumpWhileChurning(@CStack String cstack) throws Exception {
+        Assumptions.assumeTrue(!Platform.isZing(), "Zing forces cstack=no, skipping");
+
+        AtomicInteger dumpCount = new AtomicInteger(0);
+        AtomicInteger threadStartCount = new AtomicInteger(0);
+        CountDownLatch churnStarted = new CountDownLatch(1);
+
+        ExecutorService executor = Executors.newFixedThreadPool(CHURN_THREADS);
+        long deadline = System.currentTimeMillis() + TEST_DURATION_SECS * 1000L;
+
+        // Start the churn task; each pool thread spawns short-lived tasks until deadline
+        for (int i = 0; i < CHURN_THREADS; i++) {
+            executor.submit(() -> {
+                churnStarted.countDown();
+                while (System.currentTimeMillis() < deadline) {
+                    Thread t = new Thread(() -> threadStartCount.incrementAndGet());
+                    t.start();
+                    try {
+                        t.join(5);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+            });
+        }
+
+        // Wait for at least one churn thread to be running before starting dumps
+        churnStarted.await(5, TimeUnit.SECONDS);
+
+        // Dump repeatedly while churn runs
+        while (System.currentTimeMillis() < deadline) {
+            Path recording = Files.createTempFile("dump-churn-", ".jfr");
+            try {
+                dump(recording);
+                dumpCount.incrementAndGet();
+            } finally {
+                Files.deleteIfExists(recording);
+            }
+            Thread.sleep(200);
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+
+        assertTrue(dumpCount.get() >= 10,
+            "Expected at least 10 dumps during churn, got " + dumpCount.get()
+            + " (threadStarts=" + threadStartCount.get() + ")");
+    }
+}

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/DumpWhileChurningThreadsTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/jfr/DumpWhileChurningThreadsTest.java
@@ -78,22 +78,27 @@ public class DumpWhileChurningThreadsTest extends CStackAwareAbstractProfilerTes
         }
 
         // Wait for at least one churn thread to be running before starting dumps
-        churnStarted.await(5, TimeUnit.SECONDS);
+        assertTrue(churnStarted.await(5, TimeUnit.SECONDS),
+            "Churn tasks did not start within 5 seconds");
 
         // Dump repeatedly while churn runs
-        while (System.currentTimeMillis() < deadline) {
-            Path recording = Files.createTempFile("dump-churn-", ".jfr");
-            try {
-                dump(recording);
-                dumpCount.incrementAndGet();
-            } finally {
-                Files.deleteIfExists(recording);
+        try {
+            while (System.currentTimeMillis() < deadline) {
+                Path recording = Files.createTempFile("dump-churn-", ".jfr");
+                try {
+                    dump(recording);
+                    dumpCount.incrementAndGet();
+                } finally {
+                    Files.deleteIfExists(recording);
+                }
+                Thread.sleep(200);
             }
-            Thread.sleep(200);
+        } finally {
+            executor.shutdown();
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
         }
-
-        executor.shutdown();
-        executor.awaitTermination(5, TimeUnit.SECONDS);
 
         assertTrue(dumpCount.get() >= 10,
             "Expected at least 10 dumps during churn, got " + dumpCount.get()


### PR DESCRIPTION
**What does this PR do?**:
Guards the osthread pointer dereferences in `VMThread::osThreadId()` and `VMThread::osThreadState()` with `SafeAccess::load` to survive stale VMThread pointers from threads that terminated between `GetAllThreads` and the dump loop. Adds a zero-eetop check in `fromJavaThread` and a null-guard in `VMThread::initialize`. Clears pending JNI exceptions after `nativeThreadId()` and skips NULL entries in `updateJavaThreadNames`.

**Motivation**:
Production SIGSEGV crash at `Profiler::updateThreadName+0x9d`. Stack trace shows the crash originates from the unguarded `*(const char**) at(_thread_osthread_offset)` dereference in `VMThread::osThreadId()` when `fromJavaThread` returns a stale VMThread* pointer for a thread that died between `GetAllThreads` and the dump loop.

**Additional Notes**:
- `SafeAccess::load` is already used analogously in `vmStructs.cpp` for other two-level pointer chases (e.g., `_method_constmethod_offset`)
- The `osThreadState()` function had an identical unguarded dereference pattern (C-05)
- `VMThread::initialize()` assert replaced with a null-guard since `fromJavaThread` can now legitimately return nullptr
- JNI exception from `GetLongField` is cleared conditionally (ExceptionCheck guard) after `nativeThreadId()`

**How to test the change?**:
New regression test `DumpWhileChurningThreadsTest` in `ddprof-test`:
- Starts wall-clock profiler at 5ms
- Uses `CountDownLatch` to synchronize churn start with first `dump()` call
- Churns 50 threads × short-lived tasks for 10 seconds
- Asserts `dumpCount >= 10` (confirms dumps ran during thread churn)
- Guards `cstack=vm` via `CStackInjector` (auto-skips unsafe platforms)
- Run via: `./gradlew :ddprof-test:testRelease --tests '*.DumpWhileChurningThreadsTest'`

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-14548](https://datadoghq.atlassian.net/browse/PROF-14548)

<!-- muse-session:impl-20260508-184031 -->

[PROF-14548]: https://datadoghq.atlassian.net/browse/PROF-14548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ