### PR TITLE
test: reduce BoundMethodHandle workload on aarch64+asan

### DIFF
--- a/ddprof-test/src/test/java/com/datadoghq/profiler/metadata/BoundMethodHandleMetadataSizeTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/metadata/BoundMethodHandleMetadataSizeTest.java
@@ -26,7 +26,9 @@ public class BoundMethodHandleMetadataSizeTest extends AbstractProfilerTest {
         assumeFalse(Platform.isJ9() && Platform.isJavaVersion(17)); // JVMTI::GetClassSignature() is reliably crashing on a valid 'class' instance
         assumeFalse(Platform.isAarch64() && Platform.isMusl() && !Platform.isJavaVersionAtLeast(11)); // aarch64 + musl + jdk 8 will crash very often
         registerCurrentThreadForWallClockProfiling();
-        int numBoundMethodHandles = 10_000;
+        // Reduce workload on aarch64+asan: ASAN slows each invocation enough that the test
+        // takes 3+ minutes, generating a 56MB JFR that OOMs the 512MB test-runner heap.
+        int numBoundMethodHandles = isAsan() && Platform.isAarch64() ? 1_000 : 10_000;
         int x = generateBoundMethodHandles(numBoundMethodHandles);
         assertTrue(x != 0);
         stopProfiler();


### PR DESCRIPTION
**What does this PR do?**:
Reduces `numBoundMethodHandles` from 10,000 to 1,000 in `BoundMethodHandleMetadataSizeTest` when running under ASAN on aarch64.

**Motivation**:
`BoundMethodHandleMetadataSizeTest` has been failing nightly on `aarch64 glibc asan` for at least 3 days (JDK 21, 25, 25-graal). The root cause:

1. ASAN memory instrumentation slows each method handle invocation significantly on aarch64.
2. The test workload (10,000 BoundMethodHandles × 1,024 invocations) runs for ~3 minutes under aarch64+asan (vs ~30s on amd64).
3. At `wall=100us` sampling, 3 minutes generates a ~56MB JFR recording.
4. When `checkConfig()` calls `JfrLoaderToolkit.loadEvents()` on the 56MB JFR, the 512MB test-runner heap is exhausted (`OutOfMemoryError: Java heap space`).

amd64 is unaffected because the workload completes in ~30 seconds, producing a small JFR.

Reducing to 1,000 on aarch64+asan brings runtime to ~18 seconds and JFR size to ~6MB — well within the heap limit — while still exercising the metadata-size behavior the test was designed for.

**Additional Notes**:
This follows the established precedent in `NativeLibrariesTest` which already reduces iteration counts for aarch64+asan.

The test's metadata size assertion (the `// assert about the size of metadata here` TODO) is not yet implemented, so this fix keeps the existing behaviour-correctness checks intact.

**How to test the change?**:
- [x] CI nightly sanitized run on aarch64 should now pass `BoundMethodHandleMetadataSizeTest` on all JDK versions.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.