### PR TITLE
fix(profiler): probe JVMTI strings before strncmp in fillJavaMethodInfo

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -190,7 +190,7 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
       // so a single bad pointer does not leak its siblings. Best-effort only:
       // a concurrent munmap between probe and use can still fault; the SIGSEGV
       // handler is the second line of defence.
-      auto probe = [&](const char*& ptr) -> bool {
+      auto probe = [&](char*& ptr) -> bool {
         if (ptr == nullptr || !SafeAccess::isReadableRange(ptr, probe_len)) {
           ptr = nullptr;
           return false;

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -164,6 +164,7 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
   if ((phase & (JVMTI_PHASE_START | JVMTI_PHASE_LIVE)) != 0) {
     bool entry = false;
     bool readable = false;
+    const size_t probe_len = 256;
     if (VMMethod::check_jmethodID(method) &&
         jvmti->GetMethodDeclaringClass(method, &method_class) == 0 &&
         // GetMethodDeclaringClass may return a jclass wrapping a stale/garbage oop when the class was
@@ -189,20 +190,14 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
       // so a single bad pointer does not leak its siblings. Best-effort only:
       // a concurrent munmap between probe and use can still fault; the SIGSEGV
       // handler is the second line of defence.
-      const uintptr_t probe_len = 256;
-      bool class_name_ok = class_name != nullptr &&
-                           reinterpret_cast<uintptr_t>(class_name) <= UINTPTR_MAX - (probe_len - 1) &&
-                           SafeAccess::isReadableRange(class_name, probe_len);
-      bool method_name_ok = method_name != nullptr &&
-                            reinterpret_cast<uintptr_t>(method_name) <= UINTPTR_MAX - (probe_len - 1) &&
-                            SafeAccess::isReadableRange(method_name, probe_len);
-      bool method_sig_ok = method_sig != nullptr &&
-                           reinterpret_cast<uintptr_t>(method_sig) <= UINTPTR_MAX - (probe_len - 1) &&
-                           SafeAccess::isReadableRange(method_sig, probe_len);
-      if (!class_name_ok) class_name = nullptr;
-      if (!method_name_ok) method_name = nullptr;
-      if (!method_sig_ok) method_sig = nullptr;
-      readable = class_name_ok && method_name_ok && method_sig_ok;
+      auto probe = [&](const char*& ptr) -> bool {
+        if (ptr == nullptr || !SafeAccess::isReadableRange(ptr, probe_len)) {
+          ptr = nullptr;
+          return false;
+        }
+        return true;
+      };
+      readable = probe(class_name) & probe(method_name) & probe(method_sig);
     }
     if (readable) {
 
@@ -301,13 +296,13 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         } else {
           // don't recognise the suffix, so don't normalise
           class_name_id =
-              _classes->lookup(class_name + 1, strlen(class_name) - 2);
+              _classes->lookup(class_name + 1, strnlen(class_name, 65536) - 2);
         }
         method_name_id = _symbols.lookup(method_name);
         method_sig_id = _symbols.lookup(method_sig);
       } else {
         class_name_id =
-            _classes->lookup(class_name + 1, strlen(class_name) - 2);
+            _classes->lookup(class_name + 1, strnlen(class_name, 65536) - 2);
         method_name_id = _symbols.lookup(method_name);
         method_sig_id = _symbols.lookup(method_sig);
       }

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -20,6 +20,7 @@
 #include "os.h"
 #include "profiler.h"
 #include "rustDemangler.h"
+#include "safeAccess.h"
 #include "spinLock.h"
 #include "unwindStats.h"
 #include "symbols.h"
@@ -176,7 +177,13 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         // The check below mitigates these crashes on J9.
         (!VM::isOpenJ9() || method_class != reinterpret_cast<jclass>(-1)) &&
         jvmti->GetClassSignature(method_class, &class_name, NULL) == 0 &&
-        jvmti->GetMethodName(method, &method_name, &method_sig, NULL) == 0) {
+        jvmti->GetMethodName(method, &method_name, &method_sig, NULL) == 0 &&
+        // PROF-14623: the JVMTI strings should be non-null and mapped, but crash
+        // telemetry shows strncmp dereferences on unmapped memory anyway. Page-level
+        // probe of each pointer; on failure fall through to JMETHODID_SKIPPED.
+        class_name != nullptr && SafeAccess::isReadable(class_name) &&
+        method_name != nullptr && SafeAccess::isReadable(method_name) &&
+        method_sig != nullptr && SafeAccess::isReadable(method_sig)) {
 
       if (first_time) {
         jvmtiError line_table_error = jvmti->GetLineNumberTable(method, &line_number_table_size,

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -163,6 +163,7 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
   jvmti->GetPhase(&phase);
   if ((phase & (JVMTI_PHASE_START | JVMTI_PHASE_LIVE)) != 0) {
     bool entry = false;
+    bool readable = false;
     if (VMMethod::check_jmethodID(method) &&
         jvmti->GetMethodDeclaringClass(method, &method_class) == 0 &&
         // GetMethodDeclaringClass may return a jclass wrapping a stale/garbage oop when the class was
@@ -177,17 +178,26 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         // The check below mitigates these crashes on J9.
         (!VM::isOpenJ9() || method_class != reinterpret_cast<jclass>(-1)) &&
         jvmti->GetClassSignature(method_class, &class_name, NULL) == 0 &&
-        jvmti->GetMethodName(method, &method_name, &method_sig, NULL) == 0 &&
-        // PROF-14623: the JVMTI strings should be non-null and mapped, but crash
-        // telemetry shows strncmp dereferences on unmapped memory anyway. Probe a
-        // range covering the longest prefix compared below ("Ljdk/internal/reflect/
-        // GeneratedConstructorAccessor", ~50 bytes) plus headroom for strlen() at
-        // line 282. Best-effort only: a concurrent munmap between the probe and the
-        // string reads can still fault; the SIGSEGV handler is the second line of
-        // defence. On any failure fall through to JMETHODID_SKIPPED.
-        class_name != nullptr && SafeAccess::isReadableRange(class_name, 256) &&
-        method_name != nullptr && SafeAccess::isReadableRange(method_name, 256) &&
-        method_sig != nullptr && SafeAccess::isReadableRange(method_sig, 256)) {
+        jvmti->GetMethodName(method, &method_name, &method_sig, NULL) == 0) {
+      // PROF-14623: the JVMTI strings should be non-null and mapped per spec,
+      // but crash telemetry shows both `strncmp` and `jvmti_Deallocate` faulting
+      // on them. Probe each pointer over a range covering the longest prefix
+      // compared below (~50 bytes) plus headroom for strlen, and NULL any that
+      // fails so the unconditional Deallocate block at end of this function
+      // skips it (os::free faults on an unmapped pointer just like strncmp).
+      // Accept a small leak on the corruption path. Probes run independently
+      // so a single bad pointer does not leak its siblings. Best-effort only:
+      // a concurrent munmap between probe and use can still fault; the SIGSEGV
+      // handler is the second line of defence.
+      bool class_name_ok = class_name != nullptr && SafeAccess::isReadableRange(class_name, 256);
+      bool method_name_ok = method_name != nullptr && SafeAccess::isReadableRange(method_name, 256);
+      bool method_sig_ok = method_sig != nullptr && SafeAccess::isReadableRange(method_sig, 256);
+      if (!class_name_ok) class_name = nullptr;
+      if (!method_name_ok) method_name = nullptr;
+      if (!method_sig_ok) method_sig = nullptr;
+      readable = class_name_ok && method_name_ok && method_sig_ok;
+    }
+    if (readable) {
 
       if (first_time) {
         jvmtiError line_table_error = jvmti->GetLineNumberTable(method, &line_number_table_size,

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -189,9 +189,16 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
       // so a single bad pointer does not leak its siblings. Best-effort only:
       // a concurrent munmap between probe and use can still fault; the SIGSEGV
       // handler is the second line of defence.
-      bool class_name_ok = class_name != nullptr && SafeAccess::isReadableRange(class_name, 256);
-      bool method_name_ok = method_name != nullptr && SafeAccess::isReadableRange(method_name, 256);
-      bool method_sig_ok = method_sig != nullptr && SafeAccess::isReadableRange(method_sig, 256);
+      const uintptr_t probe_len = 256;
+      bool class_name_ok = class_name != nullptr &&
+                           reinterpret_cast<uintptr_t>(class_name) <= UINTPTR_MAX - (probe_len - 1) &&
+                           SafeAccess::isReadableRange(class_name, probe_len);
+      bool method_name_ok = method_name != nullptr &&
+                            reinterpret_cast<uintptr_t>(method_name) <= UINTPTR_MAX - (probe_len - 1) &&
+                            SafeAccess::isReadableRange(method_name, probe_len);
+      bool method_sig_ok = method_sig != nullptr &&
+                           reinterpret_cast<uintptr_t>(method_sig) <= UINTPTR_MAX - (probe_len - 1) &&
+                           SafeAccess::isReadableRange(method_sig, probe_len);
       if (!class_name_ok) class_name = nullptr;
       if (!method_name_ok) method_name = nullptr;
       if (!method_sig_ok) method_sig = nullptr;

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -179,11 +179,15 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         jvmti->GetClassSignature(method_class, &class_name, NULL) == 0 &&
         jvmti->GetMethodName(method, &method_name, &method_sig, NULL) == 0 &&
         // PROF-14623: the JVMTI strings should be non-null and mapped, but crash
-        // telemetry shows strncmp dereferences on unmapped memory anyway. Page-level
-        // probe of each pointer; on failure fall through to JMETHODID_SKIPPED.
-        class_name != nullptr && SafeAccess::isReadable(class_name) &&
-        method_name != nullptr && SafeAccess::isReadable(method_name) &&
-        method_sig != nullptr && SafeAccess::isReadable(method_sig)) {
+        // telemetry shows strncmp dereferences on unmapped memory anyway. Probe a
+        // range covering the longest prefix compared below ("Ljdk/internal/reflect/
+        // GeneratedConstructorAccessor", ~50 bytes) plus headroom for strlen() at
+        // line 282. Best-effort only: a concurrent munmap between the probe and the
+        // string reads can still fault; the SIGSEGV handler is the second line of
+        // defence. On any failure fall through to JMETHODID_SKIPPED.
+        class_name != nullptr && SafeAccess::isReadableRange(class_name, 256) &&
+        method_name != nullptr && SafeAccess::isReadableRange(method_name, 256) &&
+        method_sig != nullptr && SafeAccess::isReadableRange(method_sig, 256)) {
 
       if (first_time) {
         jvmtiError line_table_error = jvmti->GetLineNumberTable(method, &line_number_table_size,

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -179,9 +179,9 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         (!VM::isOpenJ9() || method_class != reinterpret_cast<jclass>(-1)) &&
         jvmti->GetClassSignature(method_class, &class_name, NULL) == 0 &&
         jvmti->GetMethodName(method, &method_name, &method_sig, NULL) == 0) {
-      // PROF-14623: the JVMTI strings should be non-null and mapped per spec,
-      // but crash telemetry shows both `strncmp` and `jvmti_Deallocate` faulting
-      // on them. Probe each pointer over a range covering the longest prefix
+      // The JVMTI strings should be non-null and mapped per spec, but crash
+      // telemetry shows both `strncmp` and `jvmti_Deallocate` faulting on them.
+      // Probe each pointer over a range covering the longest prefix
       // compared below (~50 bytes) plus headroom for strlen, and NULL any that
       // fails so the unconditional Deallocate block at end of this function
       // skips it (os::free faults on an unmapped pointer just like strncmp).

--- a/ddprof-lib/src/main/cpp/safeAccess.h
+++ b/ddprof-lib/src/main/cpp/safeAccess.h
@@ -83,16 +83,21 @@ public:
 
   static inline bool isReadableRange(const void* start, size_t size) {
     assert(size > 0);
+    // Reject addresses where start + size - 1 would wrap around UINTPTR_MAX,
+    // which would produce a bogus end_page below start_page.
+    if (reinterpret_cast<uintptr_t>(start) > UINTPTR_MAX - (size - 1)) {
+      return false;
+    }
     void* start_page = (void*)align_down((uintptr_t)start, OS::page_size);
     void* end_page = (void*)align_down((uintptr_t)start + size - 1, OS::page_size);
-    // Memory readability is determined at the page level, so we check each page in the range for readability. 
-    // This is more efficient than checking each byte.
-    for (void* page = start_page; page <= end_page; page = (void*)((uintptr_t)page + OS::page_size)) {
+    // Check readability page by page. The loop only increments when page != end_page,
+    // so (uintptr_t)page + OS::page_size never wraps even when end_page is near UINTPTR_MAX.
+    for (void* page = start_page; page != end_page; page = (void*)((uintptr_t)page + OS::page_size)) {
       if (!isReadable(page)) {
         return false;
       }
     }
-    return true;
+    return isReadable(end_page);
   }
 };
 


### PR DESCRIPTION
**What does this PR do?**:

Adds a page-range readability probe (`SafeAccess::isReadableRange(ptr, 256)`) for the `class_name`, `method_name`, and `method_sig` pointers returned by JVMTI inside `Lookup::fillJavaMethodInfo`. If any probe fails, the method routes to the existing `JMETHODID_SKIPPED` placeholder instead of crashing in the subsequent `strncmp` / `has_prefix` calls.

**Motivation**:

We have reports of SIGSEGV crashes whose top frame is `strncmp` directly under `Lookup::fillJavaMethodInfo` on JDK 25 + tracer 1.62.0 (4 events / 2 orgs in 3 days). The JVMTI 1.2 spec guarantees these pointers are non-null on success, and JDK 25 source review (`jvmtiEnv.cpp:3214` `GetMethodName`, `:2644` `GetClassSignature`) confirms no path produces `JVMTI_ERROR_NONE` with a NULL output. The crash is therefore either a HotSpot bug not visible from code review or external memory corruption — in either case a page-range probe converts the crash into observable degraded behavior via the existing `JMETHODID_SKIPPED` counter.

The structural fix is the in-flight jmethodID-removal plan (`doc/plans/2026-04-01-remove-jmethodid-*.md`); this is an interim guard.

**Additional Notes**:

- Probe range: 256 bytes per pointer — covers the longest prefix compared in the function (`"Ljdk/internal/reflect/GeneratedConstructorAccessor"`, ~50 bytes) plus headroom for `strlen(class_name)` at line 282. Page-level check, so typically one page per pointer; two only when the string straddles a page boundary.
- Catches: pointer to an unmapped page anywhere in the 256-byte window — the observed crash signature.
- Does NOT catch: freed-but-still-mapped buffers in the libc arena (would not produce the observed SIGSEGV), or a string whose body extends past 256 bytes into an unmapped page (rare; typical class signatures are well under 256).
- Hot path cost: three `isReadableRange` calls per `fillJavaMethodInfo` — each is one or two signal-trapped page loads.
- Cleanup at `flightRecorder.cpp:325-333` is unchanged — the existing `if (ptr) Deallocate(ptr)` guards run unconditionally after the success/fallback branch, so probe rejections do not leak JVMTI strings.
- TOCTOU: a concurrent `munmap` between probe and use can still fault. Inherent to probe-before-use; the existing SIGSEGV handler is the second line of defence. Acknowledged in the inline comment.

**How to test the change?**:

Without a reproducer for the JDK 25 crash, the guard is only exercised on the production crash path that we cannot trigger synthetically — `JMETHODID_SKIPPED` increments in JFR counter telemetry on affected hosts would confirm it fires. No unit test added because the production JVMTI path has no test-only hook to inject an unmapped pointer, and adding one would carry more risk than the guard itself. `buildDebug` passes locally.

**For Datadog employees**:

- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-14623](https://datadoghq.atlassian.net/browse/PROF-14623)

[PROF-14623]: https://datadoghq.atlassian.net/browse/PROF-14623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ