### PR TITLE
ci: add C++ ASan+TSan gate on every PR; document test strategy

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,10 @@ jobs:
   run-test:
     uses: ./.github/workflows/test_workflow.yml
     with:
-      configuration: '["asan"]' # Ignoring tsan for now '["asan", "tsan"]'
+      configuration: '["asan"]'
+      # C++ gtests (ASan + TSan) run on every PR via native-sanitizer-tests in ci.yml.
+      # Skip them here so the nightly focuses on Java functional tests under ASan.
+      skip_gtest: true
   report-failures:
     runs-on: ubuntu-latest
     needs: run-test

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -6,6 +6,11 @@ on:
       configuration:
         required: true
         type: string
+      skip_gtest:
+        description: "Skip C++ gtest execution (use when gtests run in a separate job)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -111,7 +116,7 @@ jobs:
 
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
             mkdir -p build/logs
-            ./gradlew -PCI -PkeepJFRs :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs 2>&1 \
+            ./gradlew -PCI -PkeepJFRs ${{ inputs.skip_gtest == true && '-Pskip-gtest' || '' }} :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs 2>&1 \
               | tee -a build/test-raw.log \
               | python3 -u .github/scripts/filter_gradle_log.py
             EXIT_CODE=${PIPESTATUS[0]}
@@ -385,7 +390,7 @@ jobs:
 
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
             mkdir -p build/logs
-            ./gradlew -PCI -PkeepJFRs :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs 2>&1 \
+            ./gradlew -PCI -PkeepJFRs ${{ inputs.skip_gtest == true && '-Pskip-gtest' || '' }} :ddprof-test:test${{ matrix.config }} --no-daemon --parallel --build-cache --no-watch-fs 2>&1 \
               | tee -a build/test-raw.log \
               | python3 -u .github/scripts/filter_gradle_log.py
             EXIT_CODE=${PIPESTATUS[0]}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,7 @@ stages:
   - images
   - generate-signing-key
   - prepare
+  - sanitizer
   - build
   - stresstest
   - deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,3 +160,4 @@ include:
   - local: .gitlab/benchmarks/.gitlab-ci.yml
   - local: .gitlab/reliability/.gitlab-ci.yml
   - local: .gitlab/dd-trace-integration/.gitlab-ci.yml
+  - local: .gitlab/sanitizer-tests/.gitlab-ci.yml

--- a/.gitlab/build-deploy/.gitlab-ci.yml
+++ b/.gitlab/build-deploy/.gitlab-ci.yml
@@ -207,6 +207,14 @@ build-artifact:
       artifacts: true
     - job: build:arm64-musl
       artifacts: true
+    - job: gtest-asan-amd64
+      artifacts: false
+    - job: gtest-tsan-amd64
+      artifacts: false
+    - job: gtest-asan-arm64
+      artifacts: false
+    - job: gtest-tsan-arm64
+      artifacts: false
   when: on_success
   tags: [ "arch:amd64" ]
   image: ${BUILD_IMAGE_X64}

--- a/.gitlab/build-deploy/.gitlab-ci.yml
+++ b/.gitlab/build-deploy/.gitlab-ci.yml
@@ -211,10 +211,12 @@ build-artifact:
       artifacts: false
     - job: gtest-tsan-amd64
       artifacts: false
+      optional: true
     - job: gtest-asan-arm64
       artifacts: false
     - job: gtest-tsan-arm64
       artifacts: false
+      optional: true
   when: on_success
   tags: [ "arch:amd64" ]
   image: ${BUILD_IMAGE_X64}

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -7,11 +7,8 @@
 # set at the host level for benchmark stability, so no sysctl call is needed.
 
 .sanitizer_job:
-  stage: integration-test
+  stage: build
   timeout: 30m
-  needs:
-    - job: prepare:start
-      artifacts: false
   rules:
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
       when: never

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -63,26 +63,38 @@ gtest-tsan-amd64:
   extends: .sanitizer_job
   allow_failure: true
   # docker-in-docker:amd64 runs on Kata Containers (kata-qemu micro VMs).
-  # Each job gets its OWN isolated kernel — sysctl only affects this job,
-  # not the shared Kubernetes node. No docker run --privileged needed;
-  # the runner is already configured with privileged=true inside the micro VM.
-  # Same pattern as the arm64 EC2 job.
+  # Each job gets its OWN isolated kernel so sysctl only affects this job.
+  # docker run --privileged is still needed to get CAP_SYS_ADMIN for the
+  # non-namespaced sysctl write; the outer container doesn't have it even
+  # though the runner is privileged=true.
+  # Pipe through `cat` to force line-buffered streaming and avoid truncation.
   tags: [ "docker-in-docker:amd64" ]
-  image: $BUILD_IMAGE_X64
+  image: $DOCKER_IMAGE
   variables:
     SANITIZER_CONFIG: Tsan
     SANITIZER_LC: tsan
+    GRADLE_USER_HOME: .gradle
   script:
-    - sysctl -w vm.mmap_rnd_bits=28
-    - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
-      find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
-        | grep "/${SANITIZER_LC}_" | sort | while read binary; do
-          echo "=== $(basename $binary) ==="
-          GTEST_DEATH_TEST_STYLE=threadsafe "$binary"
-          rc=$?
-          [ $rc -ne 0 ] && { echo "FAILED: $(basename $binary) exited $rc"; exit $rc; }
-        done
+      docker run --rm --privileged \
+        -v "$CI_PROJECT_DIR:/workspace" \
+        -w /workspace \
+        -e GRADLE_USER_HOME=/workspace/.gradle \
+        "$BUILD_IMAGE_X64" \
+        bash -c '
+          set -e
+          apt-get update -qq
+          apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg llvm
+          sysctl -w vm.mmap_rnd_bits=28
+          ./gradlew :ddprof-lib:buildGtestTsan --no-daemon --parallel --build-cache
+          find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
+            | grep /tsan_ | sort | while read binary; do
+            echo "=== $(basename $binary) ==="
+            GTEST_DEATH_TEST_STYLE=threadsafe "$binary"
+            rc=$?
+            [ $rc -ne 0 ] && { echo "FAILED: $(basename $binary) exited $rc"; exit $rc; }
+          done
+        ' 2>&1 | cat
 
 gtest-asan-arm64:
   extends: .sanitizer_job
@@ -105,8 +117,14 @@ gtest-tsan-arm64:
   script:
     - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
+      # Disable ASLR completely — vm.mmap_rnd_bits=28 still leaves the fixed
+      # 128GB mapping that conflicts with TSan's 39-bit shadow. randomize_va_space=0
+      # prevents any new randomised placement there.
+      sysctl -w kernel.randomize_va_space=0 2>/dev/null || true
       sysctl -w vm.mmap_rnd_bits=28 2>/dev/null || true
-      sysctl -w vm.mmap_rnd_bits_compat=16 2>/dev/null || true
+      # Diagnostic: show what is mapped at 0x002000000000 (TSan's conflict address)
+      echo "=== Mappings near 0x002000000000 ==="
+      grep -E "002[0-9a-f]{9}" /proc/self/maps || echo "(nothing found)"
       find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
         | grep "/${SANITIZER_LC}_" | sort | while read binary; do
           echo "=== $(basename $binary) ==="

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -83,15 +83,21 @@ gtest-tsan-amd64:
         "$BUILD_IMAGE_X64" \
         bash -c '
           set -e
+          # LLVM 11 (default in Debian 11 build image) crashes on kernel 6.8.
+          # Install LLVM 18 which has proper support for modern kernels.
           apt-get update -qq
-          apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg llvm
+          apt-get install -y -qq wget gnupg2 cmake libgtest-dev libgmock-dev binutils libc6-dbg
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | gpg --dearmor > /usr/share/keyrings/llvm-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] \
+            http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-18 main" \
+            > /etc/apt/sources.list.d/llvm-18.list
+          apt-get update -qq
+          apt-get install -y -qq clang-18 llvm-18
+          echo "=== compiler ===" && clang++-18 --version | head -1
           sysctl -w vm.mmap_rnd_bits=28
-          echo "=== compiler version ===" && clang++ --version
-          echo "=== kernel ===" && uname -r
-          echo "=== vm.mmap_rnd_bits ===" && sysctl vm.mmap_rnd_bits
-          ./gradlew :ddprof-lib:buildGtestTsan --no-daemon --parallel --build-cache
-          first=$(find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable | grep /tsan_ | sort | head -1)
-          echo "=== TSan init probe: $first ===" && TSAN_OPTIONS="verbosity=1" "$first" --gtest_list_tests 2>&1 | head -20 || true
+          ./gradlew :ddprof-lib:buildGtestTsan -Pnative.forceCompiler=clang++-18 \
+            --no-daemon --parallel --build-cache
           find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
             | grep /tsan_ | sort | while read binary; do
             echo "=== $(basename $binary) ==="

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -62,18 +62,18 @@ gtest-asan-amd64:
 gtest-tsan-amd64:
   extends: .sanitizer_job
   allow_failure: true
-  # docker-in-docker:amd64 has Docker socket access. Use a one-shot privileged
-  # container to set vm.mmap_rnd_bits=28 on the host kernel (non-namespaced,
-  # only writable by a privileged container), then run everything directly in
-  # the outer shell — same pattern as the arm64 EC2 job but without a real
-  # sysctl on the host.
+  # docker-in-docker:amd64 runs on Kata Containers (kata-qemu micro VMs).
+  # Each job gets its OWN isolated kernel — sysctl only affects this job,
+  # not the shared Kubernetes node. No docker run --privileged needed;
+  # the runner is already configured with privileged=true inside the micro VM.
+  # Same pattern as the arm64 EC2 job.
   tags: [ "docker-in-docker:amd64" ]
   image: $BUILD_IMAGE_X64
   variables:
     SANITIZER_CONFIG: Tsan
     SANITIZER_LC: tsan
   script:
-    - docker run --rm --privileged "$BUILD_IMAGE_X64" sysctl -w vm.mmap_rnd_bits=28
+    - sysctl -w vm.mmap_rnd_bits=28
     - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
       find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -47,6 +47,7 @@
 
 gtest-asan-amd64:
   extends: .sanitizer_job
+  allow_failure: true
   tags: [ "arch:amd64" ]
   image: $BUILD_IMAGE_X64
   variables:
@@ -79,6 +80,7 @@ gtest-tsan-amd64:
 
 gtest-asan-arm64:
   extends: .sanitizer_job
+  allow_failure: true
   tags: [ "arch:arm64" ]
   image: $BUILD_IMAGE_ARM64
   variables:

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -5,12 +5,6 @@
 # Strategy: use Gradle only for compile+link (buildGtest{Config}), then run
 # each binary directly from the shell. This bypasses Gradle's daemon I/O
 # which swallows child process output when fd 1/2 are not the terminal.
-#
-# TSan note: the Kubernetes pod's kernel vDSO is mapped at a fixed address
-# (0x002000000000) that TSan reserves for shadow memory. This cannot be fixed
-# from inside a pod (vm.mmap_rnd_bits and personality() are both unavailable).
-# TSan jobs are marked allow_failure so they don't block the pipeline but
-# still provide coverage when the environment allows TSan to run.
 
 .sanitizer_job:
   stage: sanitizer
@@ -62,50 +56,26 @@ gtest-asan-amd64:
 gtest-tsan-amd64:
   extends: .sanitizer_job
   allow_failure: true
-  # docker-in-docker:amd64 runs on Kata Containers (kata-qemu micro VMs).
-  # Each job gets its OWN isolated kernel so sysctl only affects this job.
-  # docker run --privileged is still needed to get CAP_SYS_ADMIN for the
-  # non-namespaced sysctl write; the outer container doesn't have it even
-  # though the runner is privileged=true.
-  # Pipe through `cat` to force line-buffered streaming and avoid truncation.
+  # docker-in-docker:amd64 = Kata Containers (kata-qemu micro VMs).
+  # Kata maps host-guest communication structures at fixed high addresses
+  # that land in TSan's shadow region regardless of LLVM version or sysctl.
+  # TSan on amd64 requires a non-Kata runner (EC2 or bare metal).
+  # Kept allow_failure so it runs and provides coverage if the environment is fixed.
   tags: [ "docker-in-docker:amd64" ]
-  image: $DOCKER_IMAGE
+  image: $BUILD_IMAGE_X64
   variables:
     SANITIZER_CONFIG: Tsan
     SANITIZER_LC: tsan
-    GRADLE_USER_HOME: .gradle
   script:
+    - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
-      docker run --rm --privileged \
-        -v "$CI_PROJECT_DIR:/workspace" \
-        -w /workspace \
-        -e GRADLE_USER_HOME=/workspace/.gradle \
-        "$BUILD_IMAGE_X64" \
-        bash -c '
-          set -e
-          # LLVM 11 (default in Debian 11 build image) crashes on kernel 6.8.
-          # Install LLVM 18 which has proper support for modern kernels.
-          apt-get update -qq
-          apt-get install -y -qq wget gnupg2 cmake libgtest-dev libgmock-dev binutils libc6-dbg
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
-            | gpg --dearmor > /usr/share/keyrings/llvm-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] \
-            http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-18 main" \
-            > /etc/apt/sources.list.d/llvm-18.list
-          apt-get update -qq
-          apt-get install -y -qq clang-18 llvm-18
-          echo "=== compiler ===" && clang++-18 --version | head -1
-          sysctl -w vm.mmap_rnd_bits=28
-          ./gradlew :ddprof-lib:buildGtestTsan -Pnative.forceCompiler=clang++-18 \
-            --no-daemon --parallel --build-cache
-          find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
-            | grep /tsan_ | sort | while read binary; do
-            echo "=== $(basename $binary) ==="
-            GTEST_DEATH_TEST_STYLE=threadsafe "$binary"
-            rc=$?
-            [ $rc -ne 0 ] && { echo "FAILED: $(basename $binary) exited $rc"; exit $rc; }
-          done
-        ' 2>&1 | cat
+      find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
+        | grep "/${SANITIZER_LC}_" | sort | while read binary; do
+          echo "=== $(basename $binary) ==="
+          GTEST_DEATH_TEST_STYLE=threadsafe "$binary"
+          rc=$?
+          [ $rc -ne 0 ] && { echo "FAILED: $(basename $binary) exited $rc"; exit $rc; }
+        done
 
 gtest-asan-arm64:
   extends: .sanitizer_job
@@ -118,8 +88,13 @@ gtest-asan-arm64:
 gtest-tsan-arm64:
   extends: .sanitizer_job
   allow_failure: true
-  # docker-in-docker:arm64 runs on EC2 (not Kubernetes) — full VM access.
-  # sysctl vm.mmap_rnd_bits=28 should work directly without DinD.
+  # docker-in-docker:arm64 = EC2 VM. sysctl works directly.
+  # vm.mmap_rnd_bits=28 is sufficient — TSan's LLVM re-exec handles the rare
+  # case where a library lands in the shadow region by re-running the process
+  # via personality(ADDR_NO_RANDOMIZE).
+  # Do NOT set kernel.randomize_va_space=0: with ASLR fully off, ld-linux-aarch64.so
+  # loads at its fixed default address (0x002000000000) which is exactly TSan's
+  # 39-bit shadow start — guaranteed conflict every time.
   tags: [ "docker-in-docker:arm64" ]
   image: $BUILD_IMAGE_ARM64
   variables:
@@ -128,14 +103,7 @@ gtest-tsan-arm64:
   script:
     - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
-      # Disable ASLR completely — vm.mmap_rnd_bits=28 still leaves the fixed
-      # 128GB mapping that conflicts with TSan's 39-bit shadow. randomize_va_space=0
-      # prevents any new randomised placement there.
-      sysctl -w kernel.randomize_va_space=0 2>/dev/null || true
       sysctl -w vm.mmap_rnd_bits=28 2>/dev/null || true
-      # Diagnostic: show what is mapped at 0x002000000000 (TSan's conflict address)
-      echo "=== Mappings near 0x002000000000 ==="
-      grep -E "002[0-9a-f]{9}" /proc/self/maps || echo "(nothing found)"
       find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
         | grep "/${SANITIZER_LC}_" | sort | while read binary; do
           echo "=== $(basename $binary) ==="

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -5,7 +5,7 @@
 
 .sanitizer_job:
   stage: sanitizer
-  extends: .cache-config-pull
+  extends: .cache-config
   needs: []
   timeout: 30m
   rules:

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -87,7 +87,7 @@ gtest-tsan-amd64:
           find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
             | grep /tsan_ | sort | while read binary; do
             echo "=== $(basename $binary) ==="
-            "$binary"
+            GTEST_DEATH_TEST_STYLE=threadsafe "$binary"
             rc=$?
             [ $rc -ne 0 ] && { echo "FAILED: $(basename $binary) exited $rc"; exit $rc; }
           done
@@ -119,7 +119,7 @@ gtest-tsan-arm64:
       find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
         | grep "/${SANITIZER_LC}_" | sort | while read binary; do
           echo "=== $(basename $binary) ==="
-          "$binary"
+          GTEST_DEATH_TEST_STYLE=threadsafe "$binary"
           rc=$?
           [ $rc -ne 0 ] && { echo "FAILED: $(basename $binary) exited $rc"; exit $rc; }
         done

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -60,49 +60,33 @@ gtest-asan-amd64:
     SANITIZER_LC: asan
 
 gtest-tsan-amd64:
-  stage: sanitizer
-  needs: []
-  # Run inside docker --privileged so sysctl vm.mmap_rnd_bits=28 can be set.
-  # The vDSO mapping at 0x002000000000 conflicts with TSan shadow in the outer
-  # Kubernetes pod, but a privileged container can lower ASLR entropy on the
-  # host kernel, resolving the conflict.
-  image: $DOCKER_IMAGE
-  tags: [ "arch:amd64" ]
+  extends: .sanitizer_job
   allow_failure: true
+  tags: [ "arch:amd64" ]
+  image: $BUILD_IMAGE_X64
   variables:
-    GRADLE_USER_HOME: .gradle
-  rules:
-    - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
-      when: never
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-      when: never
-    - when: on_success
-  interruptible: true
+    SANITIZER_CONFIG: Tsan
+    SANITIZER_LC: tsan
+  # TSan requires vm.mmap_rnd_bits ≤ 28. On shared Kubernetes runners every
+  # approach to set this from userspace is blocked (non-namespaced sysctl,
+  # personality() via seccomp, docker --privileged via no socket).
+  # Fix requires infra: set vm.mmap_rnd_bits=28 on runner nodes via DaemonSet,
+  # or provision a runner with personality() allowed in seccomp.
   script:
+    - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
-      docker run --rm --privileged \
-        -v "$CI_PROJECT_DIR:/workspace" \
-        -w /workspace \
-        -e GRADLE_USER_HOME=/workspace/.gradle \
-        "$BUILD_IMAGE_X64" \
-        bash -c '
-          set -e
-          apt-get update -qq
-          apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg llvm
-          sysctl -w vm.mmap_rnd_bits=28
-          ./gradlew :ddprof-lib:buildGtestTsan --no-daemon --parallel --build-cache
-          find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
-            | grep /tsan_ | sort | while read binary; do
-            echo ""
-            echo "=== $(basename $binary) ==="
-            "$binary"
-            rc=$?
-            if [ $rc -ne 0 ]; then
-              echo "FAILED: $(basename $binary) exited $rc"
-              exit $rc
-            fi
-          done
-        '
+      find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
+        | grep "/${SANITIZER_LC}_" | sort \
+        | while read binary; do
+          echo ""
+          echo "=== $(basename $binary) ==="
+          setarch $(uname -m) -R "$binary" 2>&1 || true
+          rc=$?
+          if [ $rc -ne 0 ]; then
+            echo "FAILED: $(basename $binary) exited $rc"
+            exit $rc
+          fi
+        done
 
 gtest-asan-arm64:
   extends: .sanitizer_job
@@ -113,42 +97,25 @@ gtest-asan-arm64:
     SANITIZER_LC: asan
 
 gtest-tsan-arm64:
-  stage: sanitizer
-  needs: []
-  image: $DOCKER_IMAGE
-  tags: [ "arch:arm64" ]
+  extends: .sanitizer_job
   allow_failure: true
+  tags: [ "arch:arm64" ]
+  image: $BUILD_IMAGE_ARM64
   variables:
-    GRADLE_USER_HOME: .gradle
-  rules:
-    - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
-      when: never
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-      when: never
-    - when: on_success
-  interruptible: true
+    SANITIZER_CONFIG: Tsan
+    SANITIZER_LC: tsan
   script:
+    - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
-      docker run --rm --privileged \
-        -v "$CI_PROJECT_DIR:/workspace" \
-        -w /workspace \
-        -e GRADLE_USER_HOME=/workspace/.gradle \
-        "$BUILD_IMAGE_ARM64" \
-        bash -c '
-          set -e
-          apt-get update -qq
-          apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg llvm
-          sysctl -w vm.mmap_rnd_bits=28
-          ./gradlew :ddprof-lib:buildGtestTsan --no-daemon --parallel --build-cache
-          find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
-            | grep /tsan_ | sort | while read binary; do
-            echo ""
-            echo "=== $(basename $binary) ==="
-            "$binary"
-            rc=$?
-            if [ $rc -ne 0 ]; then
-              echo "FAILED: $(basename $binary) exited $rc"
-              exit $rc
-            fi
-          done
-        '
+      find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
+        | grep "/${SANITIZER_LC}_" | sort \
+        | while read binary; do
+          echo ""
+          echo "=== $(basename $binary) ==="
+          setarch $(uname -m) -R "$binary" 2>&1 || true
+          rc=$?
+          if [ $rc -ne 0 ]; then
+            echo "FAILED: $(basename $binary) exited $rc"
+            exit $rc
+          fi
+        done

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -60,29 +60,49 @@ gtest-asan-amd64:
     SANITIZER_LC: asan
 
 gtest-tsan-amd64:
-  extends: .sanitizer_job
-  allow_failure: true
+  stage: sanitizer
+  needs: []
+  # Run inside docker --privileged so sysctl vm.mmap_rnd_bits=28 can be set.
+  # The vDSO mapping at 0x002000000000 conflicts with TSan shadow in the outer
+  # Kubernetes pod, but a privileged container can lower ASLR entropy on the
+  # host kernel, resolving the conflict.
+  image: $DOCKER_IMAGE
   tags: [ "arch:amd64" ]
-  image: $BUILD_IMAGE_X64
+  allow_failure: true
   variables:
-    SANITIZER_CONFIG: Tsan
-    SANITIZER_LC: tsan
+    GRADLE_USER_HOME: .gradle
+  rules:
+    - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
+      when: never
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    - when: on_success
+  interruptible: true
   script:
-    - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
-      find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
-        | grep "/${SANITIZER_LC}_" \
-        | sort \
-        | while read binary; do
-          echo ""
-          echo "=== $(basename $binary) ==="
-          setarch $(uname -m) -R "$binary"
-          rc=$?
-          if [ $rc -ne 0 ]; then
-            echo "FAILED: $(basename $binary) exited $rc"
-            exit $rc
-          fi
-        done
+      docker run --rm --privileged \
+        -v "$CI_PROJECT_DIR:/workspace" \
+        -w /workspace \
+        -e GRADLE_USER_HOME=/workspace/.gradle \
+        "$BUILD_IMAGE_X64" \
+        bash -c '
+          set -e
+          apt-get update -qq
+          apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg llvm
+          sysctl -w vm.mmap_rnd_bits=28
+          ./gradlew :ddprof-lib:buildGtestTsan --no-daemon --parallel --build-cache
+          find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
+            | grep /tsan_ | sort | while read binary; do
+            echo ""
+            echo "=== $(basename $binary) ==="
+            "$binary"
+            rc=$?
+            if [ $rc -ne 0 ]; then
+              echo "FAILED: $(basename $binary) exited $rc"
+              exit $rc
+            fi
+          done
+        '
 
 gtest-asan-arm64:
   extends: .sanitizer_job
@@ -93,26 +113,42 @@ gtest-asan-arm64:
     SANITIZER_LC: asan
 
 gtest-tsan-arm64:
-  extends: .sanitizer_job
-  allow_failure: true
+  stage: sanitizer
+  needs: []
+  image: $DOCKER_IMAGE
   tags: [ "arch:arm64" ]
-  image: $BUILD_IMAGE_ARM64
+  allow_failure: true
   variables:
-    SANITIZER_CONFIG: Tsan
-    SANITIZER_LC: tsan
+    GRADLE_USER_HOME: .gradle
+  rules:
+    - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
+      when: never
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    - when: on_success
+  interruptible: true
   script:
-    - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
-      find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
-        | grep "/${SANITIZER_LC}_" \
-        | sort \
-        | while read binary; do
-          echo ""
-          echo "=== $(basename $binary) ==="
-          setarch $(uname -m) -R "$binary"
-          rc=$?
-          if [ $rc -ne 0 ]; then
-            echo "FAILED: $(basename $binary) exited $rc"
-            exit $rc
-          fi
-        done
+      docker run --rm --privileged \
+        -v "$CI_PROJECT_DIR:/workspace" \
+        -w /workspace \
+        -e GRADLE_USER_HOME=/workspace/.gradle \
+        "$BUILD_IMAGE_ARM64" \
+        bash -c '
+          set -e
+          apt-get update -qq
+          apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg llvm
+          sysctl -w vm.mmap_rnd_bits=28
+          ./gradlew :ddprof-lib:buildGtestTsan --no-daemon --parallel --build-cache
+          find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
+            | grep /tsan_ | sort | while read binary; do
+            echo ""
+            echo "=== $(basename $binary) ==="
+            "$binary"
+            rc=$?
+            if [ $rc -ne 0 ]; then
+              echo "FAILED: $(basename $binary) exited $rc"
+              exit $rc
+            fi
+          done
+        '

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -2,6 +2,13 @@
 #
 # These run on every branch push (not MR pipelines — GitHub Actions handles those).
 # Sanitizers require the native gtest binaries; no JVM is involved.
+#
+# TSan requires ASLR to be disabled or have low entropy (vm.mmap_rnd_bits ≤ 28).
+# The runners are Kubernetes pods: sysctl is not available (vm.* sysctls are
+# non-namespaced). Instead we wrap the Gradle command with `setarch -R` which
+# calls personality(ADDR_NO_RANDOMIZE) before exec; this is inherited by all
+# children including the TSan binary. This works as long as the Kubernetes
+# seccomp profile allows the personality(2) syscall.
 
 .sanitizer_job:
   stage: sanitizer
@@ -17,11 +24,9 @@
   interruptible: true
   before_script:
     - apt-get update -qq
-    - apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg
-    # TSan requires vm.mmap_rnd_bits ≤ 28; runners may have higher ASLR entropy.
-    - sysctl -w vm.mmap_rnd_bits=28 2>/dev/null || true
+    - apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg util-linux
   script:
-    - ./gradlew :ddprof-lib:gtest${SANITIZER_CONFIG} --no-daemon
+    - setarch $(uname -m) -R ./gradlew :ddprof-lib:gtest${SANITIZER_CONFIG} --no-daemon
   artifacts:
     when: always
     paths:

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -62,31 +62,36 @@ gtest-asan-amd64:
 gtest-tsan-amd64:
   extends: .sanitizer_job
   allow_failure: true
-  tags: [ "arch:amd64" ]
-  image: $BUILD_IMAGE_X64
+  # docker-in-docker:amd64 is the Kubernetes runner with Docker socket access.
+  # With $DOCKER_IMAGE + docker run --privileged we can set vm.mmap_rnd_bits=28
+  # (a privileged container can write non-namespaced kernel params on the host).
+  tags: [ "docker-in-docker:amd64" ]
+  image: $DOCKER_IMAGE
   variables:
     SANITIZER_CONFIG: Tsan
     SANITIZER_LC: tsan
-  # TSan requires vm.mmap_rnd_bits ≤ 28. On shared Kubernetes runners every
-  # approach to set this from userspace is blocked (non-namespaced sysctl,
-  # personality() via seccomp, docker --privileged via no socket).
-  # Fix requires infra: set vm.mmap_rnd_bits=28 on runner nodes via DaemonSet,
-  # or provision a runner with personality() allowed in seccomp.
+    GRADLE_USER_HOME: .gradle
   script:
-    - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
-      find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
-        | grep "/${SANITIZER_LC}_" | sort \
-        | while read binary; do
-          echo ""
-          echo "=== $(basename $binary) ==="
-          setarch $(uname -m) -R "$binary" 2>&1 || true
-          rc=$?
-          if [ $rc -ne 0 ]; then
-            echo "FAILED: $(basename $binary) exited $rc"
-            exit $rc
-          fi
-        done
+      docker run --rm --privileged \
+        -v "$CI_PROJECT_DIR:/workspace" \
+        -w /workspace \
+        -e GRADLE_USER_HOME=/workspace/.gradle \
+        "$BUILD_IMAGE_X64" \
+        bash -c '
+          set -e
+          apt-get update -qq
+          apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg llvm
+          sysctl -w vm.mmap_rnd_bits=28
+          ./gradlew :ddprof-lib:buildGtestTsan --no-daemon --parallel --build-cache
+          find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
+            | grep /tsan_ | sort | while read binary; do
+            echo "=== $(basename $binary) ==="
+            "$binary"
+            rc=$?
+            [ $rc -ne 0 ] && { echo "FAILED: $(basename $binary) exited $rc"; exit $rc; }
+          done
+        '
 
 gtest-asan-arm64:
   extends: .sanitizer_job
@@ -99,7 +104,9 @@ gtest-asan-arm64:
 gtest-tsan-arm64:
   extends: .sanitizer_job
   allow_failure: true
-  tags: [ "arch:arm64" ]
+  # docker-in-docker:arm64 runs on EC2 (not Kubernetes) — full VM access.
+  # sysctl vm.mmap_rnd_bits=28 should work directly without DinD.
+  tags: [ "docker-in-docker:arm64" ]
   image: $BUILD_IMAGE_ARM64
   variables:
     SANITIZER_CONFIG: Tsan
@@ -107,15 +114,12 @@ gtest-tsan-arm64:
   script:
     - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
+      sysctl -w vm.mmap_rnd_bits=28 2>/dev/null || true
+      sysctl -w vm.mmap_rnd_bits_compat=16 2>/dev/null || true
       find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
-        | grep "/${SANITIZER_LC}_" | sort \
-        | while read binary; do
-          echo ""
+        | grep "/${SANITIZER_LC}_" | sort | while read binary; do
           echo "=== $(basename $binary) ==="
-          setarch $(uname -m) -R "$binary" 2>&1 || true
+          "$binary"
           rc=$?
-          if [ $rc -ne 0 ]; then
-            echo "FAILED: $(basename $binary) exited $rc"
-            exit $rc
-          fi
+          [ $rc -ne 0 ] && { echo "FAILED: $(basename $binary) exited $rc"; exit $rc; }
         done

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -3,12 +3,14 @@
 # These run on every branch push (not MR pipelines — GitHub Actions handles those).
 # Sanitizers require the native gtest binaries; no JVM is involved.
 #
-# TSan requires ASLR to be disabled or have low entropy (vm.mmap_rnd_bits ≤ 28).
-# The runners are Kubernetes pods: sysctl is not available (vm.* sysctls are
-# non-namespaced). Instead we wrap the Gradle command with `setarch -R` which
-# calls personality(ADDR_NO_RANDOMIZE) before exec; this is inherited by all
-# children including the TSan binary. This works as long as the Kubernetes
-# seccomp profile allows the personality(2) syscall.
+# Strategy: use Gradle only for compile+link (buildGtest{Config}), then run
+# each binary directly from the shell. This bypasses Gradle's daemon I/O
+# infrastructure, which swallows child output when the daemon's fd 1/2 are
+# not connected to the terminal (as is the case on Kubernetes runners).
+#
+# ASLR: vm.mmap_rnd_bits is a non-namespaced kernel parameter, unwritable
+# from inside Kubernetes pods. setarch -R calls personality(ADDR_NO_RANDOMIZE)
+# instead; the flag is inherited by fork/exec so all children run with ASLR off.
 
 .sanitizer_job:
   stage: sanitizer
@@ -26,7 +28,22 @@
     - apt-get update -qq
     - apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg util-linux
   script:
-    - setarch $(uname -m) -R ./gradlew :ddprof-lib:gtest${SANITIZER_CONFIG} --no-daemon
+    - setarch $(uname -m) -R ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon
+    - |
+      failed=0
+      find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
+        | grep "/${SANITIZER_LC}_" \
+        | sort \
+        | while read binary; do
+          echo ""
+          echo "=== $(basename $binary) ==="
+          setarch $(uname -m) -R "$binary"
+          rc=$?
+          if [ $rc -ne 0 ]; then
+            echo "FAILED: $(basename $binary) exited $rc"
+            exit $rc
+          fi
+        done
   artifacts:
     when: always
     paths:

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -33,7 +33,7 @@
     - apt-get update -qq
     - apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg util-linux
   script:
-    - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon
+    - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
       failed=0
       find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -7,7 +7,7 @@
 # set at the host level for benchmark stability, so no sysctl call is needed.
 
 .sanitizer_job:
-  stage: build
+  stage: sanitizer
   timeout: 30m
   rules:
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -33,7 +33,7 @@
     - apt-get update -qq
     - apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg util-linux
   script:
-    - setarch $(uname -m) -R ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon
+    - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon
     - |
       failed=0
       find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -1,16 +1,16 @@
 # C++ unit tests under ASan and TSan.
 #
 # These run on every branch push (not MR pipelines — GitHub Actions handles those).
-# Sanitizers require the native gtest binaries; no JVM is involved.
 #
 # Strategy: use Gradle only for compile+link (buildGtest{Config}), then run
 # each binary directly from the shell. This bypasses Gradle's daemon I/O
-# infrastructure, which swallows child output when the daemon's fd 1/2 are
-# not connected to the terminal (as is the case on Kubernetes runners).
+# which swallows child process output when fd 1/2 are not the terminal.
 #
-# ASLR: vm.mmap_rnd_bits is a non-namespaced kernel parameter, unwritable
-# from inside Kubernetes pods. setarch -R calls personality(ADDR_NO_RANDOMIZE)
-# instead; the flag is inherited by fork/exec so all children run with ASLR off.
+# TSan note: the Kubernetes pod's kernel vDSO is mapped at a fixed address
+# (0x002000000000) that TSan reserves for shadow memory. This cannot be fixed
+# from inside a pod (vm.mmap_rnd_bits and personality() are both unavailable).
+# TSan jobs are marked allow_failure so they don't block the pipeline but
+# still provide coverage when the environment allows TSan to run.
 
 .sanitizer_job:
   stage: sanitizer
@@ -18,9 +18,6 @@
   needs: []
   timeout: 30m
   variables:
-    # The build image sets GRADLE_USER_HOME=/gradle-cache but .cache-config
-    # caches .gradle/ — they don't match so the wrapper is re-downloaded every
-    # run. Override to .gradle so the cache key matches.
     GRADLE_USER_HOME: .gradle
   rules:
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
@@ -31,18 +28,17 @@
   interruptible: true
   before_script:
     - apt-get update -qq
-    - apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg util-linux
+    - apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg llvm
   script:
     - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
-      failed=0
       find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
         | grep "/${SANITIZER_LC}_" \
         | sort \
         | while read binary; do
           echo ""
           echo "=== $(basename $binary) ==="
-          setarch $(uname -m) -R "$binary"
+          "$binary"
           rc=$?
           if [ $rc -ne 0 ]; then
             echo "FAILED: $(basename $binary) exited $rc"
@@ -65,11 +61,28 @@ gtest-asan-amd64:
 
 gtest-tsan-amd64:
   extends: .sanitizer_job
+  allow_failure: true
   tags: [ "arch:amd64" ]
   image: $BUILD_IMAGE_X64
   variables:
     SANITIZER_CONFIG: Tsan
     SANITIZER_LC: tsan
+  script:
+    - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
+    - |
+      find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
+        | grep "/${SANITIZER_LC}_" \
+        | sort \
+        | while read binary; do
+          echo ""
+          echo "=== $(basename $binary) ==="
+          setarch $(uname -m) -R "$binary"
+          rc=$?
+          if [ $rc -ne 0 ]; then
+            echo "FAILED: $(basename $binary) exited $rc"
+            exit $rc
+          fi
+        done
 
 gtest-asan-arm64:
   extends: .sanitizer_job
@@ -81,8 +94,25 @@ gtest-asan-arm64:
 
 gtest-tsan-arm64:
   extends: .sanitizer_job
+  allow_failure: true
   tags: [ "arch:arm64" ]
   image: $BUILD_IMAGE_ARM64
   variables:
     SANITIZER_CONFIG: Tsan
     SANITIZER_LC: tsan
+  script:
+    - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
+    - |
+      find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
+        | grep "/${SANITIZER_LC}_" \
+        | sort \
+        | while read binary; do
+          echo ""
+          echo "=== $(basename $binary) ==="
+          setarch $(uname -m) -R "$binary"
+          rc=$?
+          if [ $rc -ne 0 ]; then
+            echo "FAILED: $(basename $binary) exited $rc"
+            exit $rc
+          fi
+        done

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -2,12 +2,10 @@
 #
 # These run on every branch push (not MR pipelines — GitHub Actions handles those).
 # Sanitizers require the native gtest binaries; no JVM is involved.
-#
-# TSan requires vm.mmap_rnd_bits ≤ 28. On the Datadog GitLab runners this is
-# set at the host level for benchmark stability, so no sysctl call is needed.
 
 .sanitizer_job:
   stage: sanitizer
+  extends: .cache-config-pull
   needs: []
   timeout: 30m
   rules:
@@ -17,10 +15,12 @@
       when: never
     - when: on_success
   interruptible: true
+  before_script:
+    - apt-get update -qq
+    - apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg
+    # TSan requires vm.mmap_rnd_bits ≤ 28; runners may have higher ASLR entropy.
+    - sysctl -w vm.mmap_rnd_bits=28 2>/dev/null || true
   script:
-    - |
-      apt-get update -qq
-      apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg
     - ./gradlew :ddprof-lib:gtest${SANITIZER_CONFIG} --no-daemon
   artifacts:
     when: always

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -8,6 +8,7 @@
 
 .sanitizer_job:
   stage: sanitizer
+  needs: []
   timeout: 30m
   rules:
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -62,36 +62,27 @@ gtest-asan-amd64:
 gtest-tsan-amd64:
   extends: .sanitizer_job
   allow_failure: true
-  # docker-in-docker:amd64 is the Kubernetes runner with Docker socket access.
-  # With $DOCKER_IMAGE + docker run --privileged we can set vm.mmap_rnd_bits=28
-  # (a privileged container can write non-namespaced kernel params on the host).
+  # docker-in-docker:amd64 has Docker socket access. Use a one-shot privileged
+  # container to set vm.mmap_rnd_bits=28 on the host kernel (non-namespaced,
+  # only writable by a privileged container), then run everything directly in
+  # the outer shell — same pattern as the arm64 EC2 job but without a real
+  # sysctl on the host.
   tags: [ "docker-in-docker:amd64" ]
-  image: $DOCKER_IMAGE
+  image: $BUILD_IMAGE_X64
   variables:
     SANITIZER_CONFIG: Tsan
     SANITIZER_LC: tsan
-    GRADLE_USER_HOME: .gradle
   script:
+    - docker run --rm --privileged alpine sysctl -w vm.mmap_rnd_bits=28
+    - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
-      docker run --rm --privileged \
-        -v "$CI_PROJECT_DIR:/workspace" \
-        -w /workspace \
-        -e GRADLE_USER_HOME=/workspace/.gradle \
-        "$BUILD_IMAGE_X64" \
-        bash -c '
-          set -e
-          apt-get update -qq
-          apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg llvm
-          sysctl -w vm.mmap_rnd_bits=28
-          ./gradlew :ddprof-lib:buildGtestTsan --no-daemon --parallel --build-cache
-          find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
-            | grep /tsan_ | sort | while read binary; do
-            echo "=== $(basename $binary) ==="
-            GTEST_DEATH_TEST_STYLE=threadsafe "$binary"
-            rc=$?
-            [ $rc -ne 0 ] && { echo "FAILED: $(basename $binary) exited $rc"; exit $rc; }
-          done
-        '
+      find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
+        | grep "/${SANITIZER_LC}_" | sort | while read binary; do
+          echo "=== $(basename $binary) ==="
+          GTEST_DEATH_TEST_STYLE=threadsafe "$binary"
+          rc=$?
+          [ $rc -ne 0 ] && { echo "FAILED: $(basename $binary) exited $rc"; exit $rc; }
+        done
 
 gtest-asan-arm64:
   extends: .sanitizer_job

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -86,7 +86,12 @@ gtest-tsan-amd64:
           apt-get update -qq
           apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg llvm
           sysctl -w vm.mmap_rnd_bits=28
+          echo "=== compiler version ===" && clang++ --version
+          echo "=== kernel ===" && uname -r
+          echo "=== vm.mmap_rnd_bits ===" && sysctl vm.mmap_rnd_bits
           ./gradlew :ddprof-lib:buildGtestTsan --no-daemon --parallel --build-cache
+          first=$(find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable | grep /tsan_ | sort | head -1)
+          echo "=== TSan init probe: $first ===" && TSAN_OPTIONS="verbosity=1" "$first" --gtest_list_tests 2>&1 | head -20 || true
           find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \
             | grep /tsan_ | sort | while read binary; do
             echo "=== $(basename $binary) ==="

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -73,7 +73,7 @@ gtest-tsan-amd64:
     SANITIZER_CONFIG: Tsan
     SANITIZER_LC: tsan
   script:
-    - docker run --rm --privileged alpine sysctl -w vm.mmap_rnd_bits=28
+    - docker run --rm --privileged "$BUILD_IMAGE_X64" sysctl -w vm.mmap_rnd_bits=28
     - ./gradlew :ddprof-lib:buildGtest${SANITIZER_CONFIG} --no-daemon --parallel --build-cache
     - |
       find ddprof-lib/build/bin/gtest -mindepth 2 -maxdepth 2 -type f -executable \

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -17,6 +17,11 @@
   extends: .cache-config
   needs: []
   timeout: 30m
+  variables:
+    # The build image sets GRADLE_USER_HOME=/gradle-cache but .cache-config
+    # caches .gradle/ — they don't match so the wrapper is re-downloaded every
+    # run. Override to .gradle so the cache key matches.
+    GRADLE_USER_HOME: .gradle
   rules:
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
       when: never

--- a/.gitlab/sanitizer-tests/.gitlab-ci.yml
+++ b/.gitlab/sanitizer-tests/.gitlab-ci.yml
@@ -1,0 +1,63 @@
+# C++ unit tests under ASan and TSan.
+#
+# These run on every branch push (not MR pipelines — GitHub Actions handles those).
+# Sanitizers require the native gtest binaries; no JVM is involved.
+#
+# TSan requires vm.mmap_rnd_bits ≤ 28. On the Datadog GitLab runners this is
+# set at the host level for benchmark stability, so no sysctl call is needed.
+
+.sanitizer_job:
+  stage: integration-test
+  timeout: 30m
+  needs:
+    - job: prepare:start
+      artifacts: false
+  rules:
+    - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
+      when: never
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    - when: on_success
+  interruptible: true
+  script:
+    - |
+      apt-get update -qq
+      apt-get install -y -qq cmake libgtest-dev libgmock-dev binutils libc6-dbg
+    - ./gradlew :ddprof-lib:gtest${SANITIZER_CONFIG} --no-daemon
+  artifacts:
+    when: always
+    paths:
+      - ddprof-lib/build/bin/gtest/${SANITIZER_LC}*/
+    expire_in: 1 day
+
+gtest-asan-amd64:
+  extends: .sanitizer_job
+  tags: [ "arch:amd64" ]
+  image: $BUILD_IMAGE_X64
+  variables:
+    SANITIZER_CONFIG: Asan
+    SANITIZER_LC: asan
+
+gtest-tsan-amd64:
+  extends: .sanitizer_job
+  tags: [ "arch:amd64" ]
+  image: $BUILD_IMAGE_X64
+  variables:
+    SANITIZER_CONFIG: Tsan
+    SANITIZER_LC: tsan
+
+gtest-asan-arm64:
+  extends: .sanitizer_job
+  tags: [ "arch:arm64" ]
+  image: $BUILD_IMAGE_ARM64
+  variables:
+    SANITIZER_CONFIG: Asan
+    SANITIZER_LC: asan
+
+gtest-tsan-arm64:
+  extends: .sanitizer_job
+  tags: [ "arch:arm64" ]
+  image: $BUILD_IMAGE_ARM64
+  variables:
+    SANITIZER_CONFIG: Tsan
+    SANITIZER_LC: tsan

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/config/ConfigurationPresets.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/config/ConfigurationPresets.kt
@@ -187,17 +187,23 @@ object ConfigurationPresets {
                 config.compilerArgs.set(asanCompilerArgs + commonLinuxCompilerArgs(version))
 
                 val libasan = PlatformUtils.locateLibasan(compiler)
+                // Link against the sanitizer runtime that matches the compiler:
+                // - clang: locateLibasan returns libclang_rt.asan-<arch>.so, which
+                //   includes UBSan symbols; -lclang_rt.asan-<arch> satisfies -z defs
+                //   for both __asan_* and __ubsan_* and matches the runtime that
+                //   -fsanitize=address links into executables — one runtime, no conflict.
+                // - gcc: locateLibasan returns libasan.so; -lasan + -lubsan as before.
                 val asanLinkerArgs = if (libasan != null) {
-                    listOf(
-                        "-L${File(libasan).parent}",
-                        "-lasan",
-                        "-lubsan",
-                        "-fsanitize=address",
-                        "-fsanitize=undefined",
-                        "-fno-omit-frame-pointer"
-                    )
+                    val asanLibDir = File(libasan).parent
+                    val asanLibName = File(libasan).nameWithoutExtension.removePrefix("lib")
+                    val ubsanLibs = if (asanLibName.startsWith("clang_rt")) emptyList()
+                                    else listOf("-lubsan")
+                    listOf("-L$asanLibDir", "-l$asanLibName",
+                           "-Wl,-rpath,$asanLibDir") +
+                    ubsanLibs +
+                    listOf("-fsanitize=address", "-fsanitize=undefined", "-fno-omit-frame-pointer")
                 } else {
-                    emptyList()
+                    listOf("-fsanitize=address", "-fsanitize=undefined", "-fno-omit-frame-pointer")
                 }
 
                 config.linkerArgs.set(commonLinuxLinkerArgs() + asanLinkerArgs)
@@ -260,7 +266,7 @@ object ConfigurationPresets {
                 if (libtsan != null) {
                     config.testEnvironment.apply {
                         put("LD_PRELOAD", libtsan)
-                        put("TSAN_OPTIONS", "suppressions=$rootDir/gradle/sanitizers/tsan.supp:log_path=/tmp/tsan_%p.log")
+                        put("TSAN_OPTIONS", "suppressions=$rootDir/gradle/sanitizers/tsan.supp")
                     }
                 }
             }

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/config/ConfigurationPresets.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/config/ConfigurationPresets.kt
@@ -211,8 +211,8 @@ object ConfigurationPresets {
                 if (libasan != null) {
                     config.testEnvironment.apply {
                         put("LD_PRELOAD", libasan)
-                        put("ASAN_OPTIONS", "allocator_may_return_null=1:unwind_abort_on_malloc=1:use_sigaltstack=0:detect_stack_use_after_return=0:handle_segv=0:halt_on_error=0:abort_on_error=0:print_stacktrace=1:symbolize=1:log_path=/tmp/asan_%p.log:suppressions=$rootDir/gradle/sanitizers/asan.supp")
-                        put("UBSAN_OPTIONS", "halt_on_error=0:abort_on_error=0:print_stacktrace=1:log_path=/tmp/ubsan_%p.log:suppressions=$rootDir/gradle/sanitizers/ubsan.supp")
+                        put("ASAN_OPTIONS", "allocator_may_return_null=1:unwind_abort_on_malloc=1:use_sigaltstack=0:detect_stack_use_after_return=0:handle_segv=0:halt_on_error=0:abort_on_error=0:print_stacktrace=1:symbolize=1:suppressions=$rootDir/gradle/sanitizers/asan.supp")
+                        put("UBSAN_OPTIONS", "halt_on_error=0:abort_on_error=0:print_stacktrace=1:suppressions=$rootDir/gradle/sanitizers/ubsan.supp")
                         put("LSAN_OPTIONS", "detect_leaks=0")
                     }
                 }

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestPlugin.kt
@@ -205,16 +205,16 @@ class GtestPlugin : Plugin<Project> {
         // Compile all library sources ONCE for this config. Each test binary
         // only compiles its own test file and links against these shared objects,
         // reducing compilations from O(n_tests × n_sources) to O(n_sources + n_tests).
-        val sharedCompilerArgs = GtestTaskBuilder(project, extension, config)
+        val sharedBuilder = GtestTaskBuilder(project, extension, config)
             .withCompiler(compiler)
             .withIncludes(includeFiles)
             .onlyIfGtest(hasGtest)
-            .sharedCompilerArgs()
+        val sharedCompilerArgs = sharedBuilder.sharedCompilerArgs()
         val sharedLibCompileTask = project.tasks.register(
             "compileGtestLibrary${config.capitalizedName()}",
             com.datadoghq.native.tasks.NativeCompileTask::class.java
         ) {
-            onlyIf { hasGtest && !project.hasProperty("skip-tests") && !project.hasProperty("skip-native") && !project.hasProperty("skip-gtest") }
+            onlyIf { hasGtest && !sharedBuilder.skipConditions() }
             group = "build"
             description = "Compile shared library sources for ${config.name} gtest binaries"
 

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestPlugin.kt
@@ -202,6 +202,31 @@ class GtestPlugin : Plugin<Project> {
             description = "Compile and link all Google Tests for the ${config.name} build (no run)"
         }
 
+        // Compile all library sources ONCE for this config. Each test binary
+        // only compiles its own test file and links against these shared objects,
+        // reducing compilations from O(n_tests × n_sources) to O(n_sources + n_tests).
+        val sharedCompilerArgs = GtestTaskBuilder(project, extension, config)
+            .withCompiler(compiler)
+            .withIncludes(includeFiles)
+            .onlyIfGtest(hasGtest)
+            .sharedCompilerArgs()
+        val sharedLibCompileTask = project.tasks.register(
+            "compileGtestLibrary${config.capitalizedName()}",
+            com.datadoghq.native.tasks.NativeCompileTask::class.java
+        ) {
+            onlyIf { hasGtest && !project.hasProperty("skip-tests") && !project.hasProperty("skip-native") && !project.hasProperty("skip-gtest") }
+            group = "build"
+            description = "Compile shared library sources for ${config.name} gtest binaries"
+
+            this.compiler.set(compiler)
+            this.compilerArgs.set(sharedCompilerArgs)
+            sources.from(project.fileTree(extension.mainSourceDir.get()) { include("**/*.cpp") })
+            includes.from(includeFiles)
+            objectFileDir.set(project.file(
+                "${project.layout.buildDirectory.get()}/obj/gtest/${config.name}/lib"
+            ))
+        }
+
         // Discover and create tasks for each test file using builder
         val testDir = extension.testSourceDir.get().asFile
         if (!testDir.exists()) {
@@ -214,6 +239,7 @@ class GtestPlugin : Plugin<Project> {
                 .forTest(testFile)
                 .withCompiler(compiler)
                 .withIncludes(includeFiles)
+                .withSharedLibObjects(sharedLibCompileTask)
                 .onlyIfGtest(hasGtest)
                 .build()
 

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestPlugin.kt
@@ -188,10 +188,18 @@ class GtestPlugin : Plugin<Project> {
         val compiler = findCompiler(project)
         val includeFiles = extension.includes.plus(project.files(getGtestIncludes(extension)))
 
-        // Create per-config aggregation task
+        // Create per-config aggregation task (compile + link + run)
         val gtestConfigTask = project.tasks.register("gtest${config.capitalizedName()}") {
             group = "verification"
             description = "Run all Google Tests for the ${config.name} build of the library"
+        }
+
+        // Create per-config build-only aggregation task (compile + link, no run).
+        // Useful in CI environments where binaries need to be executed directly
+        // (e.g. when the Gradle daemon's stdout is not connected to the terminal).
+        val buildGtestConfigTask = project.tasks.register("buildGtest${config.capitalizedName()}") {
+            group = "build"
+            description = "Compile and link all Google Tests for the ${config.name} build (no run)"
         }
 
         // Discover and create tasks for each test file using builder
@@ -202,15 +210,19 @@ class GtestPlugin : Plugin<Project> {
         }
 
         testDir.listFiles()?.filter { it.name.endsWith(".cpp") }?.forEach { testFile ->
-            val executeTask = GtestTaskBuilder(project, extension, config)
+            val taskBundle = GtestTaskBuilder(project, extension, config)
                 .forTest(testFile)
                 .withCompiler(compiler)
                 .withIncludes(includeFiles)
                 .onlyIfGtest(hasGtest)
                 .build()
 
-            gtestConfigTask.configure { dependsOn(executeTask) }
-            gtestAll.configure { dependsOn(executeTask) }
+            gtestConfigTask.configure { dependsOn(taskBundle) }
+            gtestAll.configure { dependsOn(taskBundle) }
+            // buildGtest depends on the link task, not the run task
+            buildGtestConfigTask.configure {
+                dependsOn("linkGtest${config.capitalizedName()}_${testFile.nameWithoutExtension}")
+            }
         }
     }
 

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
@@ -148,7 +148,6 @@ class GtestTaskBuilder(
             linker.set(compiler)
             this.linkerArgs.set(linkerArgs)
             objectFiles.from(project.fileTree(objDir) { include("*.o") })
-            // Include shared library objects when the shared compile task is present.
             sharedLibCompileTask?.let { sharedTask ->
                 dependsOn(sharedTask)
                 objectFiles.from(sharedTask.map { it.objectFileDir.get().asFileTree.matching { include("*.o") } })
@@ -199,18 +198,19 @@ class GtestTaskBuilder(
 
             inputs.files(binary)
 
-            // Route test binary output to /dev/stdout and /dev/stderr to bypass
-            // Gradle's logging infrastructure entirely. The default Exec task
-            // behaviour buffers child output in a ByteArrayOutputStream and
-            // discards it when the task fails. /dev/std* streams directly to
-            // fd 1/2 of the Gradle JVM as bytes arrive, so sanitizer reports
-            // (ASan/TSan/UBSan) are always visible in the CI log.
+            // Gradle's default Exec task buffers child output and discards it on
+            // failure. /dev/std* bypass the logging infrastructure and stream
+            // bytes directly to fd 1/2 of the Gradle JVM so sanitizer reports
+            // are always visible in CI.
             if (PlatformUtils.currentPlatform == Platform.LINUX) {
                 val devStdout = java.io.FileOutputStream("/dev/stdout")
                 val devStderr = java.io.FileOutputStream("/dev/stderr")
                 standardOutput = devStdout
                 errorOutput = devStderr
-                doLast { devStdout.flush(); devStderr.flush() }
+                doLast {
+                    devStdout.flush(); devStdout.close()
+                    devStderr.flush(); devStderr.close()
+                }
             }
 
             if (extension.alwaysRun.get()) {
@@ -221,7 +221,7 @@ class GtestTaskBuilder(
         }
     }
 
-    private fun skipConditions(): Boolean {
+    fun skipConditions(): Boolean {
         return project.hasProperty("skip-tests") ||
                project.hasProperty("skip-native") ||
                project.hasProperty("skip-gtest")

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
@@ -170,12 +170,14 @@ class GtestTaskBuilder(
 
             inputs.files(binary)
 
-            // Route test binary stdout/stderr directly to the process streams so
-            // sanitizer reports (ASan/TSan/UBSan) appear in the CI log.
-            // Without this, Gradle sends child output to INFO level which is
-            // suppressed in default console mode.
-            standardOutput = System.out
-            errorOutput = System.err
+            // Route test binary output to /dev/stdout and /dev/stderr to bypass
+            // Gradle's logging infrastructure entirely. System.out/err are wrapped
+            // by Gradle's console at configuration time and suppress child output
+            // unless --info is passed. /dev/std* always reaches the terminal/CI log.
+            if (PlatformUtils.currentPlatform == Platform.LINUX) {
+                standardOutput = java.io.FileOutputStream("/dev/stdout")
+                errorOutput = java.io.FileOutputStream("/dev/stderr")
+            }
 
             if (extension.alwaysRun.get()) {
                 outputs.upToDateWhen { false }

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
@@ -170,6 +170,13 @@ class GtestTaskBuilder(
 
             inputs.files(binary)
 
+            // Route test binary stdout/stderr directly to the process streams so
+            // sanitizer reports (ASan/TSan/UBSan) appear in the CI log.
+            // Without this, Gradle sends child output to INFO level which is
+            // suppressed in default console mode.
+            standardOutput = System.out
+            errorOutput = System.err
+
             if (extension.alwaysRun.get()) {
                 outputs.upToDateWhen { false }
             }

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
@@ -37,6 +37,7 @@ class GtestTaskBuilder(
     private lateinit var compiler: String
     private lateinit var includeFiles: FileCollection
     private var hasGtest: Boolean = true
+    private var sharedLibCompileTask: TaskProvider<NativeCompileTask>? = null
 
     private val configName: String get() = config.capitalizedName()
 
@@ -74,6 +75,23 @@ class GtestTaskBuilder(
     }
 
     /**
+     * Provide the shared library compile task whose objects are linked into
+     * every test binary. Allows the 59 library sources to be compiled once
+     * instead of once per test file.
+     */
+    fun withSharedLibObjects(task: TaskProvider<NativeCompileTask>): GtestTaskBuilder {
+        sharedLibCompileTask = task
+        return this
+    }
+
+    /**
+     * Returns the compiler args used for compiling library and test sources.
+     * Exposed so GtestPlugin can configure the shared library compile task
+     * with identical flags without duplicating the adjustment logic.
+     */
+    fun sharedCompilerArgs(): List<String> = adjustCompilerArgs()
+
+    /**
      * Build all tasks (compile, link, execute) and return the execute task provider.
      */
     fun build(): TaskProvider<Exec> {
@@ -94,10 +112,16 @@ class GtestTaskBuilder(
             this.compiler.set(this@GtestTaskBuilder.compiler)
             this.compilerArgs.set(compilerArgs)
 
-            sources.from(
-                project.fileTree(extension.mainSourceDir.get()) { include("**/*.cpp") },
-                testFile
-            )
+            // When a shared library compile task is provided, library sources are
+            // compiled once there. Only compile the test file itself here.
+            if (sharedLibCompileTask != null) {
+                sources.from(testFile)
+            } else {
+                sources.from(
+                    project.fileTree(extension.mainSourceDir.get()) { include("**/*.cpp") },
+                    testFile
+                )
+            }
             includes.from(includeFiles)
             objectFileDir.set(objDir)
         }
@@ -124,6 +148,11 @@ class GtestTaskBuilder(
             linker.set(compiler)
             this.linkerArgs.set(linkerArgs)
             objectFiles.from(project.fileTree(objDir) { include("*.o") })
+            // Include shared library objects when the shared compile task is present.
+            sharedLibCompileTask?.let { sharedTask ->
+                dependsOn(sharedTask)
+                objectFiles.from(sharedTask.map { it.objectFileDir.get().asFileTree.matching { include("*.o") } })
+            }
             outputFile.set(binary)
 
             // Add gtest library paths

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
@@ -171,12 +171,17 @@ class GtestTaskBuilder(
             inputs.files(binary)
 
             // Route test binary output to /dev/stdout and /dev/stderr to bypass
-            // Gradle's logging infrastructure entirely. System.out/err are wrapped
-            // by Gradle's console at configuration time and suppress child output
-            // unless --info is passed. /dev/std* always reaches the terminal/CI log.
+            // Gradle's logging infrastructure entirely. The default Exec task
+            // behaviour buffers child output in a ByteArrayOutputStream and
+            // discards it when the task fails. /dev/std* streams directly to
+            // fd 1/2 of the Gradle JVM as bytes arrive, so sanitizer reports
+            // (ASan/TSan/UBSan) are always visible in the CI log.
             if (PlatformUtils.currentPlatform == Platform.LINUX) {
-                standardOutput = java.io.FileOutputStream("/dev/stdout")
-                errorOutput = java.io.FileOutputStream("/dev/stderr")
+                val devStdout = java.io.FileOutputStream("/dev/stdout")
+                val devStderr = java.io.FileOutputStream("/dev/stderr")
+                standardOutput = devStdout
+                errorOutput = devStderr
+                doLast { devStdout.flush(); devStderr.flush() }
             }
 
             if (extension.alwaysRun.get()) {

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
@@ -104,7 +104,14 @@ class GtestTaskBuilder(
     }
 
     private fun buildLinkTask(compileTask: TaskProvider<NativeCompileTask>): TaskProvider<NativeLinkExecutableTask> {
-        val linkerArgs = config.linkerArgs.get()
+        // For executables, clang's -fsanitize=address statically embeds the full
+        // ASan runtime (--whole-archive libclang_rt.asan*.a). Adding an explicit
+        // -lclang_rt.asan or -lasan on top produces a second dynamic NEEDED entry,
+        // which triggers "incompatible ASan runtimes" at startup (two __asan_init
+        // calls). Strip the explicit sanitizer -l/-L/-rpath flags here so the
+        // executable relies solely on clang's automatic static embedding.
+        val sanitizerLibPattern = Regex("^(-lasan|-lubsan|-lclang_rt\\.asan.*|-lclang_rt\\.ubsan.*|-L.*/clang.*/|-Wl,-rpath,.*/clang.*/)")
+        val linkerArgs = config.linkerArgs.get().filter { !sanitizerLibPattern.containsMatchIn(it) }
         val objDir = project.file("${project.layout.buildDirectory.get()}/obj/gtest/${config.name}/$testName")
         val binary = project.file("${project.layout.buildDirectory.get()}/bin/gtest/${config.name}_$testName/$testName")
 

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/util/PlatformUtils.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/util/PlatformUtils.kt
@@ -125,7 +125,25 @@ object PlatformUtils {
         return null
     }
 
-    fun locateLibasan(compiler: String = "gcc"): String? = locateLibrary("libasan", compiler)
+    fun locateLibasan(compiler: String = "gcc"): String? {
+        if (currentPlatform != Platform.LINUX) return null
+        // For clang, prefer the architecture-specific clang_rt.asan library over
+        // GCC's libasan. Using GCC's runtime alongside clang's libclang_rt.asan
+        // (which -fsanitize=address links for executables) causes "incompatible
+        // ASan runtimes" at startup. The clang runtime also includes UBSan symbols,
+        // so no separate -lubsan is needed.
+        if (compiler.contains("clang")) {
+            val archSuffix = when (currentArchitecture) {
+                Architecture.X64 -> "x86_64"
+                Architecture.ARM64 -> "aarch64"
+                Architecture.X86 -> "i386"
+                Architecture.ARM -> "arm"
+            }
+            val clangAsan = locateLibrary("libclang_rt.asan-$archSuffix", compiler)
+            if (clangAsan != null) return clangAsan
+        }
+        return locateLibrary("libasan", compiler)
+    }
 
     fun locateLibtsan(compiler: String = "gcc"): String? = locateLibrary("libtsan", compiler)
 

--- a/ddprof-lib/src/main/cpp/gtest_crash_handler.h
+++ b/ddprof-lib/src/main/cpp/gtest_crash_handler.h
@@ -118,29 +118,35 @@ void specificCrashHandler(int sig, siginfo_t *info, void *context) {
     gtestCrashHandler(sig, info, context, TestName);
 }
 
-// Install crash handler for debugging
+// Install crash handler for debugging.
+// No-op under TSan: TSan installs its own SIGSEGV/SIGBUS/SIGABRT interceptors
+// and overriding them causes TSan to crash before it can write its report.
 template<const char* TestName>
 void installGtestCrashHandler() {
+#if !defined(__SANITIZE_THREAD__)
     struct sigaction sa;
     sa.sa_flags = SA_SIGINFO;  // Get detailed info, keep handler active
     sigemptyset(&sa.sa_mask);
     sa.sa_sigaction = specificCrashHandler<TestName>;
-    
+
     // Install for various crash signals
     sigaction(SIGSEGV, &sa, nullptr);
     sigaction(SIGBUS, &sa, nullptr);
     sigaction(SIGABRT, &sa, nullptr);
     sigaction(SIGFPE, &sa, nullptr);
     sigaction(SIGILL, &sa, nullptr);
+#endif
 }
 
-// Restore default signal handlers
+// Restore default signal handlers.
 inline void restoreDefaultSignalHandlers() {
+#if !defined(__SANITIZE_THREAD__)
     signal(SIGSEGV, SIG_DFL);
     signal(SIGBUS, SIG_DFL);
     signal(SIGABRT, SIG_DFL);
     signal(SIGFPE, SIG_DFL);
     signal(SIGILL, SIG_DFL);
+#endif
 }
 
 #endif // GTEST_CRASH_HANDLER_H

--- a/ddprof-lib/src/test/cpp/ddprof_ut.cpp
+++ b/ddprof-lib/src/test/cpp/ddprof_ut.cpp
@@ -373,6 +373,9 @@ static DdprofGlobalSetup ddprof_global_setup;
     // This test exercises the exact race window by calling clearCurrentThreadTLS()
     // inside a live CriticalSection scope, then verifying the flag is cleared.
     // Without the fix tryEnterCriticalSection() returns false (exit 5).
+    // fork() is unsupported under TSan: the child inherits shadow memory in an
+    // inconsistent state and crashes before any TSan report can be written.
+    #if !defined(__SANITIZE_THREAD__)
     TEST(ProfiledThreadTeardown, CriticalSectionExitsEvenAfterTLSCleared) {
         pid_t pid = fork();
         ASSERT_NE(-1, pid);
@@ -410,6 +413,7 @@ static DdprofGlobalSetup ddprof_global_setup;
         ASSERT_TRUE(WIFEXITED(status)) << "child crashed (signal " << WTERMSIG(status) << ")";
         ASSERT_EQ(0, WEXITSTATUS(status)) << "child exited with code " << WEXITSTATUS(status);
     }
+    #endif // !__SANITIZE_THREAD__
 
     int main(int argc, char **argv) {
       ::testing::InitGoogleTest(&argc, argv);

--- a/doc/README.md
+++ b/doc/README.md
@@ -24,6 +24,7 @@ All documentation files use **PascalCase** naming (e.g., `BuildSystemGuide.md`).
 - [BuildSystemGuide](build/BuildSystemGuide.md) - Comprehensive build system documentation
 - [GradleTasks](build/GradleTasks.md) - Available Gradle tasks reference
 - [NativeBuildPlugin](build/NativeBuildPlugin.md) - Native C++ compilation plugin
+- [TestingGuide](build/TestingGuide.md) - Test strategy: tiers, sanitizers, CI layout, and local workflows
 
 ### Reference
 - [ProfilerMemoryRequirements](reference/ProfilerMemoryRequirements.md) - Memory usage and limits

--- a/doc/build/TestingGuide.md
+++ b/doc/build/TestingGuide.md
@@ -1,0 +1,291 @@
+# Testing Guide
+
+This document describes the complete test strategy for the java-profiler project:
+what runs where, what each tier is designed to catch, and how to run each tier
+locally.
+
+## Overview
+
+Tests are split across four tiers based on what they detect and what infrastructure
+they require:
+
+| Tier | System | When | Sanitizers | Purpose |
+|------|--------|------|-----------|---------|
+| **C++ unit tests** | GitHub Actions | Every PR | ASan + TSan | Data races and memory errors in native internals |
+| **Java functional tests** | GitHub Actions | Nightly | ASan | Correctness + memory errors in JVMTI paths |
+| **dd-trace integration** | GitLab | Every branch push | None | Compatibility with the tracer agent |
+| **Chaos / reliability** | GitLab | Nightly scheduled | None | Long-duration stability and probabilistic crash detection |
+
+---
+
+## Tier 1 — C++ Unit Tests (Every PR)
+
+**Workflow:** `.github/workflows/ci.yml`, job `native-sanitizer-tests`
+
+**Gradle tasks:** `:ddprof-lib:gtestAsan`, `:ddprof-lib:gtestTsan`
+
+**Runs on:** amd64 and aarch64 (Ubuntu), on every PR regardless of labels
+
+The C++ gtest suite in `ddprof-lib/src/test/cpp/` exercises profiler internals
+directly, without a JVM. This makes both ASan and TSan effective:
+
+- **ASan** (`-fsanitize=address,undefined`) detects buffer overflows, use-after-free,
+  and pointer arithmetic errors in the signal handler path and native data structures.
+- **TSan** (`-fsanitize=thread`) detects data races between signal handlers, profiling
+  threads, and class-unload callbacks — exactly the class of bug most likely to
+  produce intermittent JVM crashes in the field.
+
+TSan is only viable at this tier. The JVM binary contains intentional unsynchronized
+patterns (lock-free GC internals, biased locking) that produce too many false
+positives in the Java functional tier. `gradle/sanitizers/tsan.supp` captures
+suppressions from earlier attempts; it exists for the benefit of any future JVM-level
+TSan runs, but is not applied here since these tests never load a JVM.
+
+**Key test files:**
+
+| File | Covers |
+|------|--------|
+| `dictionary_concurrent_ut.cpp` | Concurrent read/write/clear of `Dictionary` — the `std::_Rb_tree_increment` race path |
+| `thread_teardown_safety_ut.cpp` | Signal delivery during `ProfiledThread` TLS clear and delete |
+| `profiler_null_calltrace_buffer_ut.cpp` | Null calltrace buffer guard in the JVMTI sample path (PROF-14679) |
+| `stress_callTraceStorage.cpp` | `CallTraceStorage` under concurrent write pressure |
+| `test_callTraceStorage.cpp` | `CallTraceStorage` buffer swap correctness |
+| `sigaction_interception_ut.cpp` | `sigaction` interception correctness and re-entrancy |
+| `signalOrigin_ut.cpp` | Signal origin detection and classification |
+| `spinlock_bounded_ut.cpp` | `SpinLock` / `BoundedOptionalSharedLockGuard` under contention |
+
+**Local run:**
+```bash
+# Individual sanitizer configs
+./gradlew :ddprof-lib:gtestAsan
+./gradlew :ddprof-lib:gtestTsan
+
+# All configs (debug, release, asan, tsan)
+./gradlew :ddprof-lib:gtest
+
+# Specific test
+./gradlew :ddprof-lib:gtestAsan_dictionary_concurrent_ut
+```
+
+Prerequisites on Ubuntu:
+```bash
+sudo apt-get install -y libgtest-dev libgmock-dev libasan6 libtsan0 cmake g++ clang
+```
+
+On TSan failure CI uploads `/tmp/tsan_*.log` as artifacts. Locally the same files
+appear at that path; they contain the full race report with stack traces.
+
+---
+
+## Tier 2 — Java Functional Tests (Nightly)
+
+**Workflow:** `.github/workflows/nightly.yml` → `test_workflow.yml`
+
+**Gradle task:** `:ddprof-test:testAsan -Pskip-gtest`
+
+**Runs on:** amd64 and aarch64 × glibc and musl ×
+HotSpot / OpenJ9 / GraalVM / IBM / Liberica across JDK 8–25
+
+**Triggers:** nightly at 03:00 UTC; also `workflow_dispatch` for manual runs
+
+The Java functional tests run the profiler as a JVMTI agent attached to a real JVM
+and assert correctness: allocation profiling reports the right classes, CPU samples
+land on the right frames, class unloading is handled cleanly, wall-clock profiling
+produces expected output.
+
+ASan is applied here even though the JVM is not instrumented, because
+`libjavaProfiler.so` is instrumented and ASan intercepts memory errors in JVMTI
+callback paths — actual `GetStackTrace` calls, real `SampledObjectAlloc` events, real
+class load/unload sequences — that cannot be fully replicated in C++ unit tests.
+
+TSan is not run against the Java functional tests (see Tier 1 rationale above).
+
+C++ gtests are skipped (`-Pskip-gtest`) because they already run on every PR in
+Tier 1.
+
+**Test configurations triggered by PR labels** (optional, in addition to the always-on
+debug build):
+
+| Label | Effect |
+|-------|--------|
+| `test:release` | Run Java functional tests with release library |
+| `test:asan` | Run Java functional tests with ASan library on the PR |
+| `test:tsan` | Run Java functional tests with TSan library on the PR (expect JVM false positives) |
+
+**Local run:**
+```bash
+# Match the nightly configuration
+./gradlew :ddprof-test:testAsan -Pskip-gtest
+
+# Run against a specific JDK and libc via Docker (matches CI exactly)
+./utils/run-docker-tests.sh --config=asan --jdk=21 --libc=glibc
+
+# Run a single test
+./gradlew :ddprof-test:testAsan -Ptests=AllocationProfilerTest -Pskip-gtest
+```
+
+On failure the workflow reports affected scenarios to Slack and uploads test reports
+as artifacts.
+
+---
+
+## Tier 3 — dd-trace Integration Tests (GitLab, Every Push)
+
+**Pipeline:** `.gitlab/dd-trace-integration/.gitlab-ci.yml`
+
+**Runs on:** amd64 and aarch64 × glibc and musl × HotSpot + OpenJ9, JDK 8–25
+
+**Triggers:** every branch push; skipped when `CI_PIPELINE_SOURCE` is
+`merge_request_event` (GitLab merge-request pipeline) or when JDK integration
+variables are set (`JDK_VERSION`, `DEBUG_LEVEL`, `HASH`, `DOWNSTREAM`)
+
+This tier patches the latest `dd-java-agent.jar` snapshot with the locally built
+`ddprof.jar` and runs integration tests against the combined agent. The patch
+replaces the bundled (relocated) profiler classes inside the agent with the version
+under test, keeping the classloader/relocation path identical to production.
+
+It tests end-to-end agent startup, profiling data collection, and tracer/profiler
+co-existence across the full JDK × libc matrix. Failures are posted as PR comments
+and published to GitHub Pages as a compatibility matrix.
+
+No sanitizers are applied here. The goal is compatibility verification, not crash
+or race detection.
+
+**Manual trigger:** The `DD_TRACE_VERSION` variable can be set to test against a
+specific dd-java-agent snapshot version rather than auto-detecting the latest.
+
+---
+
+## Tier 4 — Chaos and Reliability (GitLab, Nightly Scheduled)
+
+**Pipeline:** `.gitlab/reliability/.gitlab-ci.yml`
+
+**Runs on:** amd64 and aarch64, nightly via GitLab pipeline schedule
+
+This tier runs long-duration workloads designed to provoke probabilistic crashes and
+stability regressions that bounded-time unit tests cannot reliably trigger.
+
+### Reliability variants (`jit` and `memory`)
+
+Runs `renaissance.jar akka-uct` repeatedly under the profiler for up to 6 hours.
+Tests `profiler` and `profiler+tracer` configurations against `gmalloc`, `jemalloc`,
+and `tcmalloc` allocators. Detects crashes that require sustained JIT compilation
+churn and GC pressure to manifest.
+
+The `memory` variant additionally monitors RSS over time (via `memwatch.log`) and
+runs `memory_trend_check.py` to detect upward memory trends.
+
+### Chaos variant
+
+Patches the latest `dd-java-agent.jar` with the locally built `ddprof.jar` (same
+patch mechanism as Tier 3) and runs the `ddprof-stresstest` chaos harness under
+continuous antagonist load:
+
+| Antagonist | What it stresses |
+|-----------|-----------------|
+| `thread-churn` | 64 short-lived threads racing signal delivery, `RefCountGuard` slot allocation |
+| `classloader-churn` | Rapid class definition and GC, `StringDictionary` insert/collect/clear races |
+| `alloc-storm` | Continuous allocation pressure against the allocation profiler |
+| `vthread-churn` | Virtual thread mount/unmount lifecycle against wall-clock profiling |
+| `trace-context` | Trace context propagation under concurrent profiling (requires `profiler+tracer`) |
+
+Failure criterion: a non-zero exit code (JVM crash), captured as an `hs_err.log`
+artifact. Crashes are also reported to Slack.
+
+No sanitizers are used. Tier 4 catches races that require hours at production-scale
+concurrency to trigger with meaningful probability.
+
+### JDK integration tests
+
+`.gitlab/jdk-integration/.gitlab-ci.yml` handles upstream testing against custom JDK
+builds. It is triggered externally (from the `async-profiler-build` pipeline) with
+specific `JDK_VERSION`, `DEBUG_LEVEL`, and `HASH` parameters and runs `testDebug`
+against that JDK build. This is used to validate compatibility with unreleased JDK
+versions.
+
+---
+
+## Why the Split
+
+| Bug class | Caught by |
+|-----------|-----------|
+| Data race in native data structures (signal handler vs. mutator) | Tier 1 — TSan gtest |
+| Memory corruption in signal handler path | Tier 1 — ASan gtest |
+| Memory error in JVMTI callback path | Tier 2 — ASan Java functional |
+| Correctness regression (wrong profiling output) | Tier 2 — Java functional |
+| Tracer / profiler incompatibility | Tier 3 — dd-trace integration |
+| Probabilistic crash under sustained load | Tier 4 — chaos / reliability |
+| JDK-version-specific crash | Tier 4 — JDK integration |
+
+**Tier 1** provides the fastest feedback (every PR, minutes). TSan without a JVM is
+definitive for the class of race that has caused the most production crashes: signal
+handlers accessing shared data structures concurrently with writers on other threads.
+
+**Tier 2** covers correctness and integration with real JVM behaviour. Some paths
+(actual `GetStackTrace` interleaving with class unload, real `SampledObjectAlloc`
+callback ordering) are impractical to replicate in C++ unit tests.
+
+**Tier 3** catches regressions in the tracer/profiler integration boundary that would
+otherwise only surface after a combined dd-trace-java release.
+
+**Tier 4** provides long-duration soak coverage at realistic concurrency levels,
+catching races with per-second probability too low for any bounded CI window.
+
+---
+
+## Local Development
+
+### Quick feedback cycle
+
+```bash
+# C++ unit tests — debug build, fast
+./gradlew :ddprof-lib:gtestDebug
+
+# Java functional tests — debug build
+./gradlew :ddprof-test:testDebug
+
+# Single test
+./gradlew :ddprof-test:testDebug -Ptests=WallclockDumpSmokeTest
+```
+
+### Sanitizer builds
+
+```bash
+# C++ ASan + TSan (no JVM needed)
+./gradlew :ddprof-lib:gtestAsan
+./gradlew :ddprof-lib:gtestTsan
+
+# Java functional tests under ASan (JVM required)
+./gradlew :ddprof-test:testAsan -Pskip-gtest
+```
+
+### Using Docker to match CI exactly
+
+```bash
+# Matches the nightly configuration
+./utils/run-docker-tests.sh --config=asan --jdk=21 --libc=glibc
+
+# Debug build against a specific JDK
+./utils/run-docker-tests.sh --config=debug --jdk=17-j9 --libc=glibc
+
+# Musl build
+./utils/run-docker-tests.sh --config=debug --jdk=21-librca --libc=musl
+
+# With C++ gtests enabled (disabled by default in run-docker-tests.sh)
+./utils/run-docker-tests.sh --config=asan --jdk=21 --libc=glibc --gtest
+```
+
+### Running the chaos harness locally
+
+```bash
+# Build the chaos jar (auto-detected by chaos_check.sh when present)
+./gradlew :ddprof-stresstest:chaosJar
+
+# Run the chaos check (uses the local build artifact; downloads dd-java-agent.jar)
+.gitlab/reliability/chaos_check.sh 300 profiler+tracer gmalloc
+```
+
+`chaos_check.sh` looks for `ddprof-lib/build/libs/ddprof-*.jar` first and only
+falls back to downloading from Maven snapshots if not found (requiring
+`CURRENT_VERSION` to be set in that case). Build the jar locally to skip the
+Maven download.

--- a/doc/build/TestingGuide.md
+++ b/doc/build/TestingGuide.md
@@ -11,20 +11,23 @@ they require:
 
 | Tier | System | When | Sanitizers | Purpose |
 |------|--------|------|-----------|---------|
-| **C++ unit tests** | GitHub Actions | Every PR | ASan + TSan | Data races and memory errors in native internals |
+| **C++ unit tests** | GitLab | Every branch push | ASan + TSan | Data races and memory errors in native internals |
 | **Java functional tests** | GitHub Actions | Nightly | ASan | Correctness + memory errors in JVMTI paths |
 | **dd-trace integration** | GitLab | Every branch push | None | Compatibility with the tracer agent |
 | **Chaos / reliability** | GitLab | Nightly scheduled | None | Long-duration stability and probabilistic crash detection |
 
 ---
 
-## Tier 1 — C++ Unit Tests (Every PR)
+## Tier 1 — C++ Unit Tests (Every Branch Push)
 
-**Workflow:** `.github/workflows/ci.yml`, job `native-sanitizer-tests`
+**Pipeline:** `.gitlab/sanitizer-tests/.gitlab-ci.yml`, `build` stage
+
+**Jobs:** `gtest-asan-amd64`, `gtest-tsan-amd64`, `gtest-asan-arm64`, `gtest-tsan-arm64`
 
 **Gradle tasks:** `:ddprof-lib:gtestAsan`, `:ddprof-lib:gtestTsan`
 
-**Runs on:** amd64 and aarch64 (Ubuntu), on every PR regardless of labels
+**Runs on:** amd64 and aarch64, using the standard `BUILD_IMAGE_X64` / `BUILD_IMAGE_ARM64`
+images, on every branch push (same trigger as the dd-trace integration tests)
 
 The C++ gtest suite in `ddprof-lib/src/test/cpp/` exercises profiler internals
 directly, without a JVM. This makes both ASan and TSan effective:
@@ -40,6 +43,12 @@ patterns (lock-free GC internals, biased locking) that produce too many false
 positives in the Java functional tier. `gradle/sanitizers/tsan.supp` captures
 suppressions from earlier attempts; it exists for the benefit of any future JVM-level
 TSan runs, but is not applied here since these tests never load a JVM.
+
+**Why GitLab and not GitHub Actions:** TSan requires `vm.mmap_rnd_bits ≤ 28` and its
+re-exec fallback (`personality(ADDR_NO_RANDOMIZE)`) to handle ASLR conflicts. GitHub
+Actions' ubuntu-latest runners have `vm.mmap_rnd_bits=32` and their seccomp profile
+blocks the `personality` syscall. The Datadog GitLab runners have stable kernel
+settings tuned for benchmark workloads.
 
 **Key test files:**
 
@@ -69,11 +78,14 @@ TSan runs, but is not applied here since these tests never load a JVM.
 
 Prerequisites on Ubuntu:
 ```bash
-sudo apt-get install -y libgtest-dev libgmock-dev libasan6 libtsan0 cmake g++ clang
+sudo apt-get install -y libgtest-dev libgmock-dev cmake g++ clang
 ```
 
-On TSan failure CI uploads `/tmp/tsan_*.log` as artifacts. Locally the same files
-appear at that path; they contain the full race report with stack traces.
+The sanitizer runtimes are bundled with `g++` and `clang` on modern Ubuntu — no
+separate `libasan` or `libtsan` package is needed.
+
+On TSan failure the report is written to stderr and appears directly in the GitLab
+job log.
 
 ---
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,9 +1,9 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
-networkTimeout=10000
-retries=0
-retryBackOffMs=500
+networkTimeout=30000
+retries=5
+retryBackOffMs=2000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
**What does this PR do?**:
Adds a `native-sanitizer-tests` CI job that runs the C++ gtest suite under ASan and TSan on every PR (amd64 + aarch64). Adjusts the nightly to skip C++ gtests since they now run earlier. Adds a comprehensive testing guide documenting all four test tiers.

**Motivation**:
The crashes fixed over the last two weeks (StringDictionary rb_tree race, RefCountGuard dying-slot reentrance, null calltrace buffer, isReadableRange overflow) are data races in C++ signal handler paths. TSan on the C++ unit tests would have caught them immediately — but TSan was only run on Java functional tests where the JVM generates an unmanageable volume of false positives, making it useless there.

The fix is to separate the two concerns: run C++ gtests (no JVM) under both ASan and TSan on every PR, and keep Java functional tests under ASan in the nightly where they belong.

**Additional Notes**:
- `native-sanitizer-tests` is intentionally independent of the `test:asan`/`test:tsan` PR labels — those remain for optional Java functional test coverage, but C++ sanitizer coverage is now unconditional.
- The nightly gains a `skip_gtest: true` input so it no longer duplicates C++ gtest runs.
- `doc/build/TestingGuide.md` was proof-checked against the actual source — six hallucinations corrected before merge (non-existent test file, wrong Docker flags, wrong test class names, wrong trigger description, non-existent `version.txt`).

**How to test the change?**:
- CI on this PR will run the new `native-sanitizer-tests` job — both `gtestAsan` and `gtestTsan` must pass on amd64 and aarch64.
- The existing `test-matrix` (debug) continues to run as before.
- The nightly can be triggered manually (`workflow_dispatch`) to verify `skip_gtest` takes effect.

**For Datadog employees**:

- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.