### PR TITLE
feat(profiler): async-signal-safety sanitizer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,14 @@ updates:
       - "no-release-notes"
       - "no-review"
     ignore:
+      # JUnit 5.10+ dropped Java 8 support; 5.12+ dropped Java 11; 6.x requires Java 17.
+      # CI targets on Java 8 and 11 (HotSpot and J9) run the Gradle test worker on the
+      # test JDK itself (the profiler attaches to its own process), so the JUnit Platform
+      # classes must be loadable by Java 8/11. Keep the entire JUnit stack at 5.9.x / 1.9.x.
+      - dependency-name: "org.junit.jupiter:*"
+        versions: [">=5.10.0"]
+      - dependency-name: "org.junit.platform:*"
+        versions: [">=1.10.0"]
       - dependency-name: "org.junit-pioneer:junit-pioneer"
         versions: [">=2.0.0"]
     groups:

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -290,6 +290,13 @@ jobs:
         with:
           name: (test-reports) test-linux-musl-amd64 (${{ matrix.java_version }}, ${{ matrix.config }})
           path: test-reports
+      - name: Upload signal-safety violation log
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: signal-safety-violation-musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64
+          path: /tmp/signal-safety-violation.txt
+          if-no-files-found: ignore
 
   test-linux-glibc-aarch64:
     needs: cache-jdks
@@ -554,3 +561,10 @@ jobs:
          with:
            name: (test-reports) test-linux-musl-aarch64 (${{ matrix.java_version }}, ${{ matrix.config }})
            path: test-reports
+       - name: Upload signal-safety violation log
+         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+         if: failure()
+         with:
+           name: signal-safety-violation-musl-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
+           path: /tmp/signal-safety-violation.txt
+           if-no-files-found: ignore

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -164,6 +164,13 @@ jobs:
         with:
           name: (test-reports) test-linux-glibc-amd64 (${{ matrix.java_version }}, ${{ matrix.config }})
           path: test-reports
+      - name: Upload signal-safety violation log
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: signal-safety-violation-glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64
+          path: /tmp/signal-safety-violation.txt
+          if-no-files-found: ignore
 
   test-linux-musl-amd64:
     needs: [cache-jdks, filter-musl-configs]
@@ -443,6 +450,13 @@ jobs:
         with:
           name: (test-reports) test-linux-glibc-aarch64 (${{ matrix.java_version }}, ${{ matrix.config }})
           path: test-reports
+      - name: Upload signal-safety violation log
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: signal-safety-violation-glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
+          path: /tmp/signal-safety-violation.txt
+          if-no-files-found: ignore
 
   test-linux-musl-aarch64:
      needs: [cache-jdks, filter-musl-configs]

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestPlugin.kt
@@ -188,10 +188,44 @@ class GtestPlugin : Plugin<Project> {
         val compiler = findCompiler(project)
         val includeFiles = extension.includes.plus(project.files(getGtestIncludes(extension)))
 
-        // Create per-config aggregation task
+        // Create per-config aggregation task (compile + link + run)
         val gtestConfigTask = project.tasks.register("gtest${config.capitalizedName()}") {
             group = "verification"
             description = "Run all Google Tests for the ${config.name} build of the library"
+        }
+
+        // Per-config build-only aggregation task (compile + link, no run).
+        // Useful in CI where binaries are executed directly without going
+        // through Gradle's logging infrastructure.
+        val buildGtestConfigTask = project.tasks.register("buildGtest${config.capitalizedName()}") {
+            group = "build"
+            description = "Compile and link all Google Tests for the ${config.name} build (no run)"
+        }
+
+        // Compile all library sources ONCE for this config.  Each test
+        // binary only compiles its own test file and links against these
+        // shared objects, reducing compilations from O(n_tests × n_sources)
+        // to O(n_sources + n_tests).
+        val sharedBuilder = GtestTaskBuilder(project, extension, config)
+            .withCompiler(compiler)
+            .withIncludes(includeFiles)
+            .onlyIfGtest(hasGtest)
+        val sharedCompilerArgs = sharedBuilder.sharedCompilerArgs()
+        val sharedLibCompileTask = project.tasks.register(
+            "compileGtestLibrary${config.capitalizedName()}",
+            com.datadoghq.native.tasks.NativeCompileTask::class.java
+        ) {
+            onlyIf { hasGtest && !sharedBuilder.skipConditions() }
+            group = "build"
+            description = "Compile shared library sources for ${config.name} gtest binaries"
+
+            this.compiler.set(compiler)
+            this.compilerArgs.set(sharedCompilerArgs)
+            sources.from(project.fileTree(extension.mainSourceDir.get()) { include("**/*.cpp") })
+            includes.from(includeFiles)
+            objectFileDir.set(project.file(
+                "${project.layout.buildDirectory.get()}/obj/gtest/${config.name}/lib"
+            ))
         }
 
         // Discover and create tasks for each test file using builder
@@ -206,11 +240,16 @@ class GtestPlugin : Plugin<Project> {
                 .forTest(testFile)
                 .withCompiler(compiler)
                 .withIncludes(includeFiles)
+                .withSharedLibObjects(sharedLibCompileTask)
                 .onlyIfGtest(hasGtest)
                 .build()
 
             gtestConfigTask.configure { dependsOn(executeTask) }
             gtestAll.configure { dependsOn(executeTask) }
+            // buildGtest depends on the link task, not the run task
+            buildGtestConfigTask.configure {
+                dependsOn("linkGtest${config.capitalizedName()}_${testFile.nameWithoutExtension}")
+            }
         }
     }
 

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/gtest/GtestTaskBuilder.kt
@@ -37,6 +37,7 @@ class GtestTaskBuilder(
     private lateinit var compiler: String
     private lateinit var includeFiles: FileCollection
     private var hasGtest: Boolean = true
+    private var sharedLibCompileTask: TaskProvider<NativeCompileTask>? = null
 
     private val configName: String get() = config.capitalizedName()
 
@@ -74,6 +75,23 @@ class GtestTaskBuilder(
     }
 
     /**
+     * Provide the shared library compile task whose objects are linked into
+     * every test binary.  Allows the library sources to be compiled once
+     * instead of once per test file.
+     */
+    fun withSharedLibObjects(task: TaskProvider<NativeCompileTask>): GtestTaskBuilder {
+        sharedLibCompileTask = task
+        return this
+    }
+
+    /**
+     * Returns the compiler args used for compiling library and test sources.
+     * Exposed so GtestPlugin can configure the shared library compile task
+     * with identical flags without duplicating the adjustment logic.
+     */
+    fun sharedCompilerArgs(): List<String> = adjustCompilerArgs()
+
+    /**
      * Build all tasks (compile, link, execute) and return the execute task provider.
      */
     fun build(): TaskProvider<Exec> {
@@ -94,10 +112,16 @@ class GtestTaskBuilder(
             this.compiler.set(this@GtestTaskBuilder.compiler)
             this.compilerArgs.set(compilerArgs)
 
-            sources.from(
-                project.fileTree(extension.mainSourceDir.get()) { include("**/*.cpp") },
-                testFile
-            )
+            // When a shared library compile task is provided, library sources
+            // are compiled once there.  Only compile the test file itself here.
+            if (sharedLibCompileTask != null) {
+                sources.from(testFile)
+            } else {
+                sources.from(
+                    project.fileTree(extension.mainSourceDir.get()) { include("**/*.cpp") },
+                    testFile
+                )
+            }
             includes.from(includeFiles)
             objectFileDir.set(objDir)
         }
@@ -117,6 +141,10 @@ class GtestTaskBuilder(
             linker.set(compiler)
             this.linkerArgs.set(linkerArgs)
             objectFiles.from(project.fileTree(objDir) { include("*.o") })
+            sharedLibCompileTask?.let { sharedTask ->
+                dependsOn(sharedTask)
+                objectFiles.from(sharedTask.map { it.objectFileDir.get().asFileTree.matching { include("*.o") } })
+            }
             outputFile.set(binary)
 
             // Add gtest library paths
@@ -171,7 +199,7 @@ class GtestTaskBuilder(
         }
     }
 
-    private fun skipConditions(): Boolean {
+    fun skipConditions(): Boolean {
         return project.hasProperty("skip-tests") ||
                project.hasProperty("skip-native") ||
                project.hasProperty("skip-gtest")

--- a/ddprof-lib/src/main/cpp/ctimer_linux.cpp
+++ b/ddprof-lib/src/main/cpp/ctimer_linux.cpp
@@ -202,6 +202,7 @@ Error CTimerJvmti::start(Arguments &args) {
 }
 
 void CTimerJvmti::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
+  SIGNAL_HANDLER_GUARD();
   if (!OS::shouldProcessSignal(siginfo, SI_TIMER, SignalCookie::cpu())) {
     Counters::increment(CTIMER_SIGNAL_FOREIGN);
     OS::forwardForeignSignal(signo, siginfo, ucontext);
@@ -248,6 +249,7 @@ void CTimerJvmti::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
 }
 
 void CTimer::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
+  SIGNAL_HANDLER_GUARD();
   // Reject signals that did not originate from our timer_create timers.
   // This guards against Go's process-wide setitimer(ITIMER_PROF) and other
   // foreign SIGPROF sources that would otherwise drive our handler onto

--- a/ddprof-lib/src/main/cpp/dictionary.cpp
+++ b/ddprof-lib/src/main/cpp/dictionary.cpp
@@ -81,17 +81,24 @@ unsigned int Dictionary::hash(const char *key, size_t length) {
 }
 
 unsigned int Dictionary::lookup(const char *key) {
-  DEBUG_ASSERT_NOT_IN_SIGNAL();
   return lookup(key, strlen(key));
 }
 
 unsigned int Dictionary::lookup(const char *key, size_t length) {
-  DEBUG_ASSERT_NOT_IN_SIGNAL();
   return lookup(key, length, true, 0);
 }
 
 unsigned int Dictionary::lookup(const char *key, size_t length, bool for_insert,
                                 unsigned int sentinel) {
+  // The insert path mallocs (allocateKey) and may calloc a DictTable —
+  // both AS-unsafe.  Read-only lookups (for_insert == false, used by
+  // check() and bounded_lookup at capacity) only touch already-allocated
+  // memory and are AS-safe.  Assert here rather than in the overloads
+  // so bounded_lookup's runtime-decided for_insert is also covered.
+  if (for_insert) {
+    DEBUG_ASSERT_NOT_IN_SIGNAL();
+  }
+
   DictTable *table = _table;
   unsigned int h = hash(key, length);
 

--- a/ddprof-lib/src/main/cpp/dictionary.cpp
+++ b/ddprof-lib/src/main/cpp/dictionary.cpp
@@ -17,6 +17,7 @@
 #include "dictionary.h"
 #include "arch.h"
 #include "counters.h"
+#include "signalSafety.h"
 #include <climits>
 #include <stdlib.h>
 #include <string.h>
@@ -41,6 +42,7 @@ Dictionary::~Dictionary() {
 }
 
 void Dictionary::clear() {
+  DEBUG_ASSERT_NOT_IN_SIGNAL();
   clear(_table, _id);
   memset(_table, 0, sizeof(DictTable));
   _table->base_index = _base_index = 1;
@@ -79,10 +81,12 @@ unsigned int Dictionary::hash(const char *key, size_t length) {
 }
 
 unsigned int Dictionary::lookup(const char *key) {
+  DEBUG_ASSERT_NOT_IN_SIGNAL();
   return lookup(key, strlen(key));
 }
 
 unsigned int Dictionary::lookup(const char *key, size_t length) {
+  DEBUG_ASSERT_NOT_IN_SIGNAL();
   return lookup(key, length, true, 0);
 }
 

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -19,6 +19,7 @@
 #include "jniHelper.h"
 #include "os.h"
 #include "profiler.h"
+#include "signalSafety.h"
 #include "rustDemangler.h"
 #include "safeAccess.h"
 #include "spinLock.h"
@@ -1411,6 +1412,7 @@ void Recording::writeMethods(Buffer *buf, Lookup *lookup) {
 }
 
 void Recording::writeClasses(Buffer *buf, Lookup *lookup) {
+  DEBUG_ASSERT_NOT_IN_SIGNAL();
   std::map<u32, const char *> classes;
   // Hold classMapSharedGuard() for the full function. The const char* pointers
   // stored in classes point into dictionary row storage; clear() frees that
@@ -1720,10 +1722,11 @@ void Recording::recordCpuLoad(Buffer *buf, float proc_user, float proc_system,
 // assumption is that we hold the lock (with lock_index)
 void Recording::addThread(int lock_index, int tid) {
     int active = _active_index.load(std::memory_order_acquire);
-    _thread_ids[lock_index][active].insert(tid);
+    _thread_ids[lock_index][active].insert(tid);  // ThreadIdTable::insert is signal-safe (atomics only)
 }
 
 Error FlightRecorder::start(Arguments &args, bool reset) {
+  DEBUG_ASSERT_NOT_IN_SIGNAL();
   ExclusiveLockGuard locker(&_rec_lock);
   const char *file = args.file();
   if (file == NULL || file[0] == 0) {
@@ -1751,6 +1754,7 @@ Error FlightRecorder::newRecording(bool reset) {
 }
 
 void FlightRecorder::stop() {
+  DEBUG_ASSERT_NOT_IN_SIGNAL();
   ExclusiveLockGuard locker(&_rec_lock);
   Recording* rec = _rec;
   if (rec != nullptr) {
@@ -1761,6 +1765,7 @@ void FlightRecorder::stop() {
 }
 
 Error FlightRecorder::dump(const char *filename, const int length) {
+  DEBUG_ASSERT_NOT_IN_SIGNAL();
   assert(length >= 0);
   ExclusiveLockGuard locker(&_rec_lock);
   Recording* rec = _rec;
@@ -1781,6 +1786,7 @@ Error FlightRecorder::dump(const char *filename, const int length) {
 }
 
 void FlightRecorder::flush() {
+  DEBUG_ASSERT_NOT_IN_SIGNAL();
   ExclusiveLockGuard locker(&_rec_lock);
   Recording* rec = _rec;
   if (rec != nullptr) {
@@ -1845,6 +1851,7 @@ void FlightRecorder::recordQueueTime(int lock_index, int tid,
 void FlightRecorder::recordDatadogSetting(int lock_index, int length,
                                           const char *name, const char *value,
                                           const char *unit) {
+  DEBUG_ASSERT_NOT_IN_SIGNAL();
   OptionalSharedLockGuard locker(&_rec_lock);
   if (locker.ownsLock()) {
     Recording* rec = _rec;
@@ -1856,6 +1863,7 @@ void FlightRecorder::recordDatadogSetting(int lock_index, int length,
 }
 
 void FlightRecorder::recordHeapUsage(int lock_index, long value, bool live) {
+  DEBUG_ASSERT_NOT_IN_SIGNAL();
   OptionalSharedLockGuard locker(&_rec_lock);
   if (locker.ownsLock()) {
     Recording* rec = _rec;

--- a/ddprof-lib/src/main/cpp/guards.cpp
+++ b/ddprof-lib/src/main/cpp/guards.cpp
@@ -20,7 +20,7 @@
 #include "thread.h"
 
 // Always-on signal-context depth counter; see comments in guards.h.
-thread_local int _in_signal_handler_depth = 0;
+thread_local uint8_t _in_signal_handler_depth _PROFILER_TLS_IE = 0;
 
 // Static bitmap storage for fallback cases
 uint64_t CriticalSection::_fallback_bitmap[CriticalSection::FALLBACK_BITMAP_WORDS] = {};

--- a/ddprof-lib/src/main/cpp/guards.cpp
+++ b/ddprof-lib/src/main/cpp/guards.cpp
@@ -19,8 +19,56 @@
 #include "os.h"
 #include "thread.h"
 
-// Always-on signal-context depth counter; see comments in guards.h.
-thread_local uint8_t _in_signal_handler_depth _PROFILER_TLS_IE = 0;
+// Signal-context tracking — backed by ProfiledThread::_signal_depth; see
+// the comment block in guards.h for the rationale (initial-exec TLS was
+// rejected because of the static TLS surplus on Graal).
+
+int getInSignalDepth() {
+    ProfiledThread *pt = ProfiledThread::currentSignalSafe();
+    return pt != nullptr ? static_cast<int>(pt->signalDepth()) : 0;
+}
+
+bool isInSignalContext() {
+    ProfiledThread *pt = ProfiledThread::currentSignalSafe();
+    // null ProfiledThread = no thread context yet; treat as "assume signal"
+    // so AS-safety gates default to the conservative deferred path.
+    return pt == nullptr || pt->signalDepth() != 0;
+}
+
+SignalHandlerScope::SignalHandlerScope() : _active(true) {
+    ProfiledThread *pt = ProfiledThread::currentSignalSafe();
+    if (pt != nullptr) {
+        pt->enterSignalScope();
+    } else {
+        // No thread context: nothing to update; mark inactive so destructor
+        // and release() are no-ops.
+        _active = false;
+    }
+}
+
+SignalHandlerScope::~SignalHandlerScope() {
+    if (!_active) return;
+    ProfiledThread *pt = ProfiledThread::currentSignalSafe();
+    if (pt != nullptr) {
+        pt->exitSignalScope();
+    }
+}
+
+void SignalHandlerScope::release() {
+    if (!_active) return;
+    ProfiledThread *pt = ProfiledThread::currentSignalSafe();
+    if (pt != nullptr) {
+        pt->exitSignalScope();
+    }
+    _active = false;
+}
+
+void signalHandlerUnwindAfterLongjmp() {
+    ProfiledThread *pt = ProfiledThread::currentSignalSafe();
+    if (pt != nullptr) {
+        pt->exitSignalScope();
+    }
+}
 
 // Static bitmap storage for fallback cases
 uint64_t CriticalSection::_fallback_bitmap[CriticalSection::FALLBACK_BITMAP_WORDS] = {};

--- a/ddprof-lib/src/main/cpp/guards.cpp
+++ b/ddprof-lib/src/main/cpp/guards.cpp
@@ -35,6 +35,14 @@ bool isInSignalContext() {
     return pt == nullptr || pt->signalDepth() != 0;
 }
 
+bool isInTrackedSignalContext() {
+    ProfiledThread *pt = ProfiledThread::currentSignalSafe();
+    // null ProfiledThread = no thread context; the SignalHandlerScope
+    // never ran, so we have no positive evidence of a signal frame.
+    // See header comment for the rationale of returning false here.
+    return pt != nullptr && pt->signalDepth() != 0;
+}
+
 SignalHandlerScope::SignalHandlerScope() : _active(true) {
     ProfiledThread *pt = ProfiledThread::currentSignalSafe();
     if (pt != nullptr) {

--- a/ddprof-lib/src/main/cpp/guards.cpp
+++ b/ddprof-lib/src/main/cpp/guards.cpp
@@ -19,6 +19,9 @@
 #include "os.h"
 #include "thread.h"
 
+// Always-on signal-context depth counter; see comments in guards.h.
+thread_local int _in_signal_handler_depth = 0;
+
 // Static bitmap storage for fallback cases
 uint64_t CriticalSection::_fallback_bitmap[CriticalSection::FALLBACK_BITMAP_WORDS] = {};
 

--- a/ddprof-lib/src/main/cpp/guards.cpp
+++ b/ddprof-lib/src/main/cpp/guards.cpp
@@ -28,13 +28,6 @@ int getInSignalDepth() {
     return pt != nullptr ? static_cast<int>(pt->signalDepth()) : 0;
 }
 
-bool isInSignalContext() {
-    ProfiledThread *pt = ProfiledThread::currentSignalSafe();
-    // null ProfiledThread = no thread context yet; treat as "assume signal"
-    // so AS-safety gates default to the conservative deferred path.
-    return pt == nullptr || pt->signalDepth() != 0;
-}
-
 bool isInTrackedSignalContext() {
     ProfiledThread *pt = ProfiledThread::currentSignalSafe();
     // null ProfiledThread = no thread context; the SignalHandlerScope

--- a/ddprof-lib/src/main/cpp/guards.h
+++ b/ddprof-lib/src/main/cpp/guards.h
@@ -28,19 +28,31 @@ class ProfiledThread;
 // Signal-context depth tracking — always on.
 //
 // Code paths that must choose between an async-signal-safe deferred path and
-// a synchronous path (e.g. Profiler::dlopen_hook, which has to defer when a
-// library is lazily loaded from signal context) query isInSignalContext().
-// The debug-only DEBUG_ASSERT_NOT_IN_SIGNAL() macro in signalSafety.h
-// asserts on the same counter.
+// a synchronous path (e.g. Profiler::dlopen_hook, which defers refresh() when
+// a library is loaded from signal context) query isInSignalContext().  The
+// debug-only DEBUG_ASSERT_NOT_IN_SIGNAL() macro in signalSafety.h asserts on
+// the same counter.
 //
-// Cost in release: ~2 thread-local writes per signal handler invocation
-// (negligible).  Pre-warming libgcc_s in Profiler::start() closes the
-// known case; this counter is the safety net for the remainder.
+// TLS model: initial-exec.  Default (global-dynamic) lazily allocates the
+// dtv slot via malloc on first access — and the *first* access happens
+// inside our signal handler (SIGNAL_HANDLER_GUARD).  That malloc takes the
+// heap lock and deadlocks when the holder is paused for a safepoint
+// (observed on Graal aarch64 / libjvmcicompiler.so).  initial-exec instructs
+// the loader to allocate the slot from the static TLS surplus at library
+// load — every existing thread is fixed up at dlopen and every new thread
+// gets the slot at pthread_create.  Access is a register-relative load with
+// no malloc, lock, or syscall, so it is async-signal-safe by construction.
+//
+// uint8_t is sufficient: realistic max depth is 3 (e.g. SIGSEGV nested in
+// SIGPROF nested in something else); using a byte over an int makes the
+// "tiny counter, never grows" intent explicit.  Slot alignment is the same.
 // ---------------------------------------------------------------------------
+
+#define _PROFILER_TLS_IE __attribute__((tls_model("initial-exec")))
 
 // Counter so nested signals (e.g. SIGSEGV inside SIGPROF) keep the flag
 // asserted until the outermost handler returns.
-extern thread_local int _in_signal_handler_depth;
+extern thread_local uint8_t _in_signal_handler_depth _PROFILER_TLS_IE;
 
 inline int getInSignalDepth()    { return _in_signal_handler_depth; }
 inline bool isInSignalContext()  { return _in_signal_handler_depth != 0; }

--- a/ddprof-lib/src/main/cpp/guards.h
+++ b/ddprof-lib/src/main/cpp/guards.h
@@ -24,6 +24,60 @@
 
 class ProfiledThread;
 
+// ---------------------------------------------------------------------------
+// Signal-context depth tracking — always on.
+//
+// Code paths that must choose between an async-signal-safe deferred path and
+// a synchronous path (e.g. Profiler::dlopen_hook, which has to defer when a
+// library is lazily loaded from signal context) query isInSignalContext().
+// The debug-only DEBUG_ASSERT_NOT_IN_SIGNAL() macro in signalSafety.h
+// asserts on the same counter.
+//
+// Cost in release: ~2 thread-local writes per signal handler invocation
+// (negligible).  Pre-warming libgcc_s in Profiler::start() closes the
+// known case; this counter is the safety net for the remainder.
+// ---------------------------------------------------------------------------
+
+// Counter so nested signals (e.g. SIGSEGV inside SIGPROF) keep the flag
+// asserted until the outermost handler returns.
+extern thread_local int _in_signal_handler_depth;
+
+inline int getInSignalDepth()    { return _in_signal_handler_depth; }
+inline bool isInSignalContext()  { return _in_signal_handler_depth != 0; }
+
+// Internal RAII type — do not instantiate directly; use the macros below.
+class SignalHandlerScope {
+public:
+    SignalHandlerScope()  { ++_in_signal_handler_depth; }
+    ~SignalHandlerScope() { if (_active) --_in_signal_handler_depth; }
+    void release()        { if (_active) { --_in_signal_handler_depth; _active = false; } }
+    SignalHandlerScope(const SignalHandlerScope&)            = delete;
+    SignalHandlerScope& operator=(const SignalHandlerScope&) = delete;
+private:
+    bool _active = true;
+};
+
+// Declare a scope guard local that increments the depth on entry and
+// decrements on scope exit.  Use as the very first statement in every
+// installed signal handler.
+#define SIGNAL_HANDLER_GUARD() SignalHandlerScope _signal_handler_scope
+
+// Manually release the most recent SIGNAL_HANDLER_GUARD() before chaining to
+// another handler that may longjmp through us (e.g. J9's SIGSEGV null-pointer
+// check handler).  After release(), depth has already been decremented; the
+// destructor becomes a no-op.
+#define SIGNAL_HANDLER_GUARD_RELEASE() _signal_handler_scope.release()
+
+// Compensate for a longjmp that bypassed a SignalHandlerScope's destructor.
+// Call at the setjmp landing point AFTER a known longjmp originated from
+// within a signal handler frame (e.g. HotSpot's checkFault → longjmp recovery
+// in walkVM).
+#define SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP()           \
+    do {                                                \
+        if (_in_signal_handler_depth > 0)               \
+            --_in_signal_handler_depth;                 \
+    } while (0)
+
 /**
  * Race-free critical section using atomic compare-and-swap.
  *

--- a/ddprof-lib/src/main/cpp/guards.h
+++ b/ddprof-lib/src/main/cpp/guards.h
@@ -25,51 +25,51 @@
 class ProfiledThread;
 
 // ---------------------------------------------------------------------------
-// Signal-context depth tracking.
+// Signal-context depth tracking — always on.
 //
-// Code paths that must choose between an async-signal-safe deferred path and
-// a synchronous path (e.g. Profiler::dlopen_hook, which defers refresh() when
-// a library is loaded from signal context) query isInSignalContext().  The
-// debug-only DEBUG_ASSERT_NOT_IN_SIGNAL() macro in signalSafety.h asserts on
-// the same counter.
+// Profiler::dlopen_hook is the production caller — it queries
+// isInTrackedSignalContext() to decide between the synchronous refresh()
+// path and the deferred markDirty() path.  The debug-only
+// DEBUG_ASSERT_NOT_IN_SIGNAL() macro in signalSafety.h asserts on the
+// same counter.
 //
 // Storage: the depth lives in ProfiledThread::_signal_depth.  An earlier
 // design used a thread_local int, but on Graal aarch64 the lazy DTV slot
 // allocation triggered malloc inside our signal handler and deadlocked
-// against the JVMCI compiler holding the heap lock.  initial-exec fixed the
-// malloc but tripped the static TLS surplus and broke dlopen on Graal.
-// ProfiledThread is already AS-safe-accessible via pthread_getspecific
-// (POSIX guarantees it does not allocate; returns nullptr when unset).
+// against the JVMCI compiler holding the heap lock.  initial-exec fixed
+// the malloc but tripped the static TLS surplus and broke dlopen on
+// Graal.  ProfiledThread is already AS-safe-accessible via
+// pthread_getspecific (POSIX guarantees it does not allocate; returns
+// nullptr when unset).
 //
-// When ProfiledThread is null on a thread, we don't yet have a thread
+// When ProfiledThread is null on a thread we don't yet have a thread
 // context — uninstrumented JVM-internal threads (VM Thread, JIT, GC) fall
-// into this bucket too, and they can receive signals.  isInSignalContext()
-// treats null as "assume signal" so dlopen_hook defers conservatively
-// rather than risking a synchronous refresh from a signal frame.
-// DEBUG_ASSERT_NOT_IN_SIGNAL skips the check when null so well-behaved
-// non-signal code on uninstrumented threads doesn't trip a false abort.
+// into this bucket too, and they can receive signals.  The
+// SignalHandlerScope guard is a no-op on those threads (nothing to
+// update), so isInTrackedSignalContext() returns false: production code
+// prefers synchronous refresh() on null-PT threads because (a) those
+// threads regularly call dlopen during normal JVM operation, and (b)
+// wasmtime's broken sigaction patching depends on switchLibraryTrap
+// running work inline.  The residual risk — an uninstrumented thread
+// calling dlopen from inside a foreign signal handler — is small in
+// practice: prewarmUnwinder() closes the known libgcc_s lazy-load case
+// and mainstream JVM signal handlers are AS-safe by design.
+//
+// DEBUG_ASSERT_NOT_IN_SIGNAL likewise skips its check when ProfiledThread
+// is null so well-behaved non-signal code on uninstrumented threads
+// doesn't trip a false abort.
 // ---------------------------------------------------------------------------
 
 // Returns the signal-handler depth for the calling thread, or 0 if the
-// thread has no ProfiledThread yet.  Use isInSignalContext() instead when
-// you only need a boolean — it handles the "no thread context" case
-// conservatively (returns true).
+// thread has no ProfiledThread yet.  Intended for tests and diagnostic
+// code; production callers should use isInTrackedSignalContext().
 int getInSignalDepth();
 
-// True when the calling thread is either inside an installed signal
-// handler (depth > 0) or has no thread context yet (treat as "unknown,
-// assume signal" — fail-safe for AS-safety gating).
-bool isInSignalContext();
-
-// Returns true ONLY when we have positively tracked entering one of our
-// installed signal handlers on this thread.  null ProfiledThread → false
-// (we have no way to know, so callers that prefer to do work
-// synchronously on uninstrumented threads — Profiler::dlopen_hook —
-// can use this.)  Accepts the small theoretical risk that an
-// uninstrumented JVM-internal thread (VM Thread, JIT, GC) doing a dlopen
-// from inside a *foreign* signal handler will look like regular code;
-// prewarmUnwinder() covers the known libgcc_s case and JVM-internal
-// signal handlers are generally AS-safe by design.
+// Returns true only when we have positively tracked entering one of our
+// installed signal handlers on this thread (depth > 0 on a non-null
+// ProfiledThread).  null ProfiledThread → false, matching the
+// SignalHandlerScope semantics (the guard is a no-op there).
+// Used by Profiler::dlopen_hook to gate the deferred-refresh branch.
 bool isInTrackedSignalContext();
 
 // Internal RAII type — do not instantiate directly; use the macros below.

--- a/ddprof-lib/src/main/cpp/guards.h
+++ b/ddprof-lib/src/main/cpp/guards.h
@@ -25,7 +25,7 @@
 class ProfiledThread;
 
 // ---------------------------------------------------------------------------
-// Signal-context depth tracking — always on.
+// Signal-context depth tracking.
 //
 // Code paths that must choose between an async-signal-safe deferred path and
 // a synchronous path (e.g. Profiler::dlopen_hook, which defers refresh() when
@@ -33,40 +33,44 @@ class ProfiledThread;
 // debug-only DEBUG_ASSERT_NOT_IN_SIGNAL() macro in signalSafety.h asserts on
 // the same counter.
 //
-// TLS model: initial-exec.  Default (global-dynamic) lazily allocates the
-// dtv slot via malloc on first access — and the *first* access happens
-// inside our signal handler (SIGNAL_HANDLER_GUARD).  That malloc takes the
-// heap lock and deadlocks when the holder is paused for a safepoint
-// (observed on Graal aarch64 / libjvmcicompiler.so).  initial-exec instructs
-// the loader to allocate the slot from the static TLS surplus at library
-// load — every existing thread is fixed up at dlopen and every new thread
-// gets the slot at pthread_create.  Access is a register-relative load with
-// no malloc, lock, or syscall, so it is async-signal-safe by construction.
+// Storage: the depth lives in ProfiledThread::_signal_depth.  An earlier
+// design used a thread_local int, but on Graal aarch64 the lazy DTV slot
+// allocation triggered malloc inside our signal handler and deadlocked
+// against the JVMCI compiler holding the heap lock.  initial-exec fixed the
+// malloc but tripped the static TLS surplus and broke dlopen on Graal.
+// ProfiledThread is already AS-safe-accessible via pthread_getspecific
+// (POSIX guarantees it does not allocate; returns nullptr when unset).
 //
-// uint8_t is sufficient: realistic max depth is 3 (e.g. SIGSEGV nested in
-// SIGPROF nested in something else); using a byte over an int makes the
-// "tiny counter, never grows" intent explicit.  Slot alignment is the same.
+// When ProfiledThread is null on a thread, we don't yet have a thread
+// context — uninstrumented JVM-internal threads (VM Thread, JIT, GC) fall
+// into this bucket too, and they can receive signals.  isInSignalContext()
+// treats null as "assume signal" so dlopen_hook defers conservatively
+// rather than risking a synchronous refresh from a signal frame.
+// DEBUG_ASSERT_NOT_IN_SIGNAL skips the check when null so well-behaved
+// non-signal code on uninstrumented threads doesn't trip a false abort.
 // ---------------------------------------------------------------------------
 
-#define _PROFILER_TLS_IE __attribute__((tls_model("initial-exec")))
+// Returns the signal-handler depth for the calling thread, or 0 if the
+// thread has no ProfiledThread yet.  Use isInSignalContext() instead when
+// you only need a boolean — it handles the "no thread context" case
+// conservatively (returns true).
+int getInSignalDepth();
 
-// Counter so nested signals (e.g. SIGSEGV inside SIGPROF) keep the flag
-// asserted until the outermost handler returns.
-extern thread_local uint8_t _in_signal_handler_depth _PROFILER_TLS_IE;
-
-inline int getInSignalDepth()    { return _in_signal_handler_depth; }
-inline bool isInSignalContext()  { return _in_signal_handler_depth != 0; }
+// True when the calling thread is either inside an installed signal
+// handler (depth > 0) or has no thread context yet (treat as "unknown,
+// assume signal" — fail-safe for AS-safety gating).
+bool isInSignalContext();
 
 // Internal RAII type — do not instantiate directly; use the macros below.
 class SignalHandlerScope {
 public:
-    SignalHandlerScope()  { ++_in_signal_handler_depth; }
-    ~SignalHandlerScope() { if (_active) --_in_signal_handler_depth; }
-    void release()        { if (_active) { --_in_signal_handler_depth; _active = false; } }
+    SignalHandlerScope();
+    ~SignalHandlerScope();
+    void release();
     SignalHandlerScope(const SignalHandlerScope&)            = delete;
     SignalHandlerScope& operator=(const SignalHandlerScope&) = delete;
 private:
-    bool _active = true;
+    bool _active;
 };
 
 // Declare a scope guard local that increments the depth on entry and
@@ -84,11 +88,8 @@ private:
 // Call at the setjmp landing point AFTER a known longjmp originated from
 // within a signal handler frame (e.g. HotSpot's checkFault → longjmp recovery
 // in walkVM).
-#define SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP()           \
-    do {                                                \
-        if (_in_signal_handler_depth > 0)               \
-            --_in_signal_handler_depth;                 \
-    } while (0)
+void signalHandlerUnwindAfterLongjmp();
+#define SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP() signalHandlerUnwindAfterLongjmp()
 
 /**
  * Race-free critical section using atomic compare-and-swap.

--- a/ddprof-lib/src/main/cpp/guards.h
+++ b/ddprof-lib/src/main/cpp/guards.h
@@ -61,6 +61,17 @@ int getInSignalDepth();
 // assume signal" — fail-safe for AS-safety gating).
 bool isInSignalContext();
 
+// Returns true ONLY when we have positively tracked entering one of our
+// installed signal handlers on this thread.  null ProfiledThread → false
+// (we have no way to know, so callers that prefer to do work
+// synchronously on uninstrumented threads — Profiler::dlopen_hook —
+// can use this.)  Accepts the small theoretical risk that an
+// uninstrumented JVM-internal thread (VM Thread, JIT, GC) doing a dlopen
+// from inside a *foreign* signal handler will look like regular code;
+// prewarmUnwinder() covers the known libgcc_s case and JVM-internal
+// signal handlers are generally AS-safe by design.
+bool isInTrackedSignalContext();
+
 // Internal RAII type — do not instantiate directly; use the macros below.
 class SignalHandlerScope {
 public:

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
@@ -13,6 +13,7 @@
 #include "hotspot/vmStructs.inline.h"
 #include "jvmSupport.h"
 #include "profiler.h"
+#include "guards.h"
 #include "stackWalker.inline.h"
 #include "frames.h"
 
@@ -187,6 +188,9 @@ __attribute__((no_sanitize("address"))) int HotspotSupport::walkVM(void* ucontex
             profiled_thread->setCrashProtectionActive(true);
         }
         if (setjmp(crash_protection_ctx) != 0) {
+            // checkFault() does a longjmp from inside segvHandler, bypassing
+            // segvHandler's SignalHandlerScope destructor.  Compensate.
+            SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP();
             if (profiled_thread != nullptr) {
                 profiled_thread->setCrashProtectionActive(false);
             }

--- a/ddprof-lib/src/main/cpp/itimer.cpp
+++ b/ddprof-lib/src/main/cpp/itimer.cpp
@@ -31,6 +31,7 @@ long ITimer::_interval;
 CStack ITimer::_cstack;
 
 void ITimer::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
+  SIGNAL_HANDLER_GUARD();
   // NOTE: ITimer uses setitimer(ITIMER_PROF) which delivers signals with
   // si_code==SI_KERNEL — no sival payload is available. The signal-origin
   // check implemented in CTimer/WallClock cannot be applied here. ITimer
@@ -102,6 +103,7 @@ volatile bool ITimerJvmti::_enabled = false;
 long ITimerJvmti::_interval = 0;
 
 void ITimerJvmti::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
+  SIGNAL_HANDLER_GUARD();
   CriticalSection cs;
   if (!cs.entered()) {
     return;

--- a/ddprof-lib/src/main/cpp/libraries.cpp
+++ b/ddprof-lib/src/main/cpp/libraries.cpp
@@ -69,14 +69,13 @@ void Libraries::refresh() {
 void *Libraries::refresherLoop(void *arg) {
   Libraries *self = static_cast<Libraries *>(arg);
 
-  // Publish our TID so sampler thread-list enumerations can skip us.
-  self->_refresher_tid.store(OS::threadId(), std::memory_order_release);
-
-  // Block profiling signals so this thread is never sampled.  Without
-  // this, SIGPROF can fire on the refresher and run the full stack-walk
-  // path here — pure overhead, and in debug builds with
-  // DDPROF_FORCE_STACKWALK_CRASH it inflates the SIGSEGV recovery count
-  // enough to starve the test work thread and break
+  // Block profiling signals BEFORE publishing our TID.  Otherwise a
+  // SIGPROF / SIGVTALRM armed for this thread (e.g. a stale per-thread
+  // timer from a previous lifecycle, or an in-flight signal queued during
+  // pthread_create) could fire on us between TID-publish and sigmask, and
+  // run the full stack-walk path here — pure overhead, and in debug
+  // builds with DDPROF_FORCE_STACKWALK_CRASH it inflates the SIGSEGV
+  // recovery count enough to starve the test work thread and break
   // vmStackwalkerCrashRecoveryTest.  SIGIO (WAKEUP_SIGNAL) is left
   // unmasked because stopRefresher() relies on it to interrupt sleep.
   sigset_t mask;
@@ -85,10 +84,27 @@ void *Libraries::refresherLoop(void *arg) {
   sigaddset(&mask, SIGVTALRM);
   pthread_sigmask(SIG_BLOCK, &mask, nullptr);
 
+  // Publish our TID so sampler thread-list enumerations can skip us.
+  self->_refresher_tid.store(OS::threadId(), std::memory_order_release);
+
   while (self->_refresher_running.load(std::memory_order_acquire)) {
-    // OS::sleep uses nanosleep, which returns early on EINTR — the wakeup
-    // signal sent from stopRefresher() will interrupt this immediately.
-    OS::sleep(REFRESH_INTERVAL_NS);
+    // Sleep until the next tick or until interrupted.  OS::sleep wraps a
+    // single nanosleep that returns early on EINTR; loop on the remaining
+    // time so unrelated unmasked signals (SIGCHLD, debugger SIGSTOP/CONT,
+    // etc.) do not cause premature ticks.  The stopRefresher path sends
+    // SIGIO and flips _refresher_running first, so the outer-loop check
+    // catches the wake-up and exits without sleeping again.
+    u64 remaining = REFRESH_INTERVAL_NS;
+    while (remaining > 0 &&
+           self->_refresher_running.load(std::memory_order_acquire)) {
+      u64 before = OS::nanotime();
+      OS::sleep(remaining);
+      u64 elapsed = OS::nanotime() - before;
+      if (elapsed >= remaining) {
+        break;
+      }
+      remaining -= elapsed;
+    }
     if (!self->_refresher_running.load(std::memory_order_acquire)) {
       break;
     }

--- a/ddprof-lib/src/main/cpp/libraries.cpp
+++ b/ddprof-lib/src/main/cpp/libraries.cpp
@@ -14,7 +14,9 @@
 // Cadence for the background refresher thread.  Bounds the window during
 // which a library lazily loaded from signal context (and therefore unable
 // to call refresh() synchronously) is unresolvable by the stack walker.
-static constexpr u64 REFRESH_INTERVAL_NS = 5ULL * 1'000'000'000ULL;
+// 500 ms is short enough that frame resolution gaps are barely observable
+// in typical sampling, and the refresher only wakes once per tick (cheap).
+static constexpr u64 REFRESH_INTERVAL_NS = 500ULL * 1'000'000ULL;
 
 void Libraries::mangle(const char *name, char *buf, size_t size) {
   char *buf_end = buf + size;

--- a/ddprof-lib/src/main/cpp/libraries.cpp
+++ b/ddprof-lib/src/main/cpp/libraries.cpp
@@ -5,9 +5,16 @@
 #include "libraries.h"
 #include "libraryPatcher.h"
 #include "log.h"
+#include "mallocTracer.h"
+#include "os.h"
 #include "symbols.h"
 #include "symbols_linux.h"
 #include "vmEntry.h"
+
+// Cadence for the background refresher thread.  Bounds the window during
+// which a library lazily loaded from signal context (and therefore unable
+// to call refresh() synchronously) is unresolvable by the stack walker.
+static constexpr u64 REFRESH_INTERVAL_NS = 5ULL * 1'000'000'000ULL;
 
 void Libraries::mangle(const char *name, char *buf, size_t size) {
   char *buf_end = buf + size;
@@ -39,6 +46,76 @@ end:
 void Libraries::updateSymbols(bool kernel_symbols) {
   Symbols::parseLibraries(&_native_libs, kernel_symbols);
   LibraryPatcher::patch_libraries();
+}
+
+void Libraries::refresh() {
+  // Clear the flag before scanning so any concurrent markDirty() between
+  // now and the end of this call re-arms us for the next tick.  All
+  // downstream operations are idempotent (parseLibraries tracks
+  // _parsed_inodes, patch_sigaction checks _sigaction_entries,
+  // installHooks uses monotonic _patched_libs, updateBuildIds tracks
+  // _build_id_processed), so redundant invocations are cheap.
+  _dirty.store(false, std::memory_order_release);
+  updateSymbols(false);
+  LibraryPatcher::patch_sigaction();
+  MallocTracer::installHooks();
+  if (_remote_symbolication) {
+    updateBuildIds();
+  }
+}
+
+void *Libraries::refresherLoop(void *arg) {
+  Libraries *self = static_cast<Libraries *>(arg);
+
+  // Publish our TID so sampler thread-list enumerations can skip us.
+  self->_refresher_tid.store(OS::threadId(), std::memory_order_release);
+
+  // Block profiling signals so this thread is never sampled.  Without
+  // this, SIGPROF can fire on the refresher and run the full stack-walk
+  // path here — pure overhead, and in debug builds with
+  // DDPROF_FORCE_STACKWALK_CRASH it inflates the SIGSEGV recovery count
+  // enough to starve the test work thread and break
+  // vmStackwalkerCrashRecoveryTest.  SIGIO (WAKEUP_SIGNAL) is left
+  // unmasked because stopRefresher() relies on it to interrupt sleep.
+  sigset_t mask;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGPROF);
+  sigaddset(&mask, SIGVTALRM);
+  pthread_sigmask(SIG_BLOCK, &mask, nullptr);
+
+  while (self->_refresher_running.load(std::memory_order_acquire)) {
+    // OS::sleep uses nanosleep, which returns early on EINTR — the wakeup
+    // signal sent from stopRefresher() will interrupt this immediately.
+    OS::sleep(REFRESH_INTERVAL_NS);
+    if (!self->_refresher_running.load(std::memory_order_acquire)) {
+      break;
+    }
+    if (self->_dirty.load(std::memory_order_acquire)) {
+      self->refresh();
+    }
+  }
+  return nullptr;
+}
+
+void Libraries::startRefresher() {
+  if (_refresher_running.exchange(true, std::memory_order_acq_rel)) {
+    return;  // already running
+  }
+  if (pthread_create(&_refresher_thread, nullptr, refresherLoop, this) != 0) {
+    _refresher_running.store(false, std::memory_order_release);
+    Log::warn("Unable to start Libraries refresher thread");
+  }
+}
+
+void Libraries::stopRefresher() {
+  if (!_refresher_running.exchange(false, std::memory_order_acq_rel)) {
+    return;  // not running
+  }
+  pthread_kill(_refresher_thread, WAKEUP_SIGNAL);
+  pthread_join(_refresher_thread, nullptr);
+  // Clear the published TID so a later sampler doesn't skip an unrelated
+  // thread that may have inherited the same TID after we exited.
+  _refresher_tid.store(-1, std::memory_order_release);
 }
 
 // Platform-specific implementation of updateBuildIds() is in libraries_linux.cpp (Linux)

--- a/ddprof-lib/src/main/cpp/libraries.cpp
+++ b/ddprof-lib/src/main/cpp/libraries.cpp
@@ -88,23 +88,10 @@ void *Libraries::refresherLoop(void *arg) {
   self->_refresher_tid.store(OS::threadId(), std::memory_order_release);
 
   while (self->_refresher_running.load(std::memory_order_acquire)) {
-    // Sleep until the next tick or until interrupted.  OS::sleep wraps a
-    // single nanosleep that returns early on EINTR; loop on the remaining
-    // time so unrelated unmasked signals (SIGCHLD, debugger SIGSTOP/CONT,
-    // etc.) do not cause premature ticks.  The stopRefresher path sends
-    // SIGIO and flips _refresher_running first, so the outer-loop check
-    // catches the wake-up and exits without sleeping again.
-    u64 remaining = REFRESH_INTERVAL_NS;
-    while (remaining > 0 &&
-           self->_refresher_running.load(std::memory_order_acquire)) {
-      u64 before = OS::nanotime();
-      OS::sleep(remaining);
-      u64 elapsed = OS::nanotime() - before;
-      if (elapsed >= remaining) {
-        break;
-      }
-      remaining -= elapsed;
-    }
+    // Absolute-deadline sleep that resumes across EINTR (SIGCHLD, debugger
+    // SIGSTOP/SIGCONT, etc.) and wakes early when stopRefresher() flips
+    // _refresher_running false and sends SIGIO.  See OS::sleepWhile.
+    OS::sleepWhile(REFRESH_INTERVAL_NS, self->_refresher_running);
     if (!self->_refresher_running.load(std::memory_order_acquire)) {
       break;
     }

--- a/ddprof-lib/src/main/cpp/libraries.h
+++ b/ddprof-lib/src/main/cpp/libraries.h
@@ -1,16 +1,59 @@
 #ifndef _LIBRARIES_H
 #define _LIBRARIES_H
 
+#include <atomic>
+#include <pthread.h>
+
 #include "codeCache.h"
 
 class Libraries {
  private:
   CodeCacheArray _native_libs;
   CodeCache _runtime_stubs;
+  bool _remote_symbolication;  // set via setRemoteSymbolication()
+
+  // Pending-refresh flag set by dlopen_hook when it cannot call refresh()
+  // synchronously (signal context).  Polled by the refresher thread.
+  std::atomic<bool> _dirty;
+
+  // Background refresher thread: periodically (every REFRESH_INTERVAL_NS)
+  // checks _dirty and runs refresh() outside signal context, narrowing the
+  // window during which newly-loaded libraries are unresolvable.
+  pthread_t _refresher_thread;
+  std::atomic<bool> _refresher_running;
+  std::atomic<int> _refresher_tid;  // captured from OS::threadId() on entry
+  static void *refresherLoop(void *arg);
 
   static void mangle(const char *name, char *buf, size_t size);
  public:
-  Libraries() : _native_libs(), _runtime_stubs("runtime stubs") {}
+  Libraries() : _native_libs(), _runtime_stubs("runtime stubs"),
+                _remote_symbolication(false), _dirty(false),
+                _refresher_thread(), _refresher_running(false),
+                _refresher_tid(-1) {}
+
+  void setRemoteSymbolication(bool enabled) { _remote_symbolication = enabled; }
+
+  // Refresh symbol tables and reinstall hooks/patches for any libraries
+  // loaded since the last refresh.  Idempotent and cheap when no new
+  // libraries have been loaded (parseLibraries tracks _parsed_inodes).
+  // Clears the dirty flag.  Must be called from non-signal context:
+  // updateSymbols acquires a Mutex and reads /proc/self/maps.
+  void refresh();
+
+  // Async-signal-safe: just sets a flag.  The refresher thread will pick
+  // up the change on its next tick.
+  void markDirty() { _dirty.store(true, std::memory_order_release); }
+
+  // Start/stop the background refresher thread.  Called from
+  // Profiler::start/stop.
+  void startRefresher();
+  void stopRefresher();
+
+  // TID of the refresher thread once it has captured its own ID, or -1 if
+  // the thread is not currently running.  Used by sampler thread-list
+  // enumeration to skip this profiler-internal thread.
+  int refresherTid() const { return _refresher_tid.load(std::memory_order_acquire); }
+
   void updateSymbols(bool kernel_symbols);
   void updateBuildIds();  // Extract build-ids for all loaded libraries
   const void *resolveSymbol(const char *name);

--- a/ddprof-lib/src/main/cpp/mutex.cpp
+++ b/ddprof-lib/src/main/cpp/mutex.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "mutex.h"
+#include "signalSafety.h"
 
 
 Mutex::Mutex() {
@@ -14,6 +15,7 @@ Mutex::Mutex() {
 }
 
 void Mutex::lock() {
+    DEBUG_ASSERT_NOT_IN_SIGNAL();
     pthread_mutex_lock(&_mutex);
 }
 

--- a/ddprof-lib/src/main/cpp/mutex.h
+++ b/ddprof-lib/src/main/cpp/mutex.h
@@ -19,6 +19,8 @@ class Mutex {
 
     void lock();
     void unlock();
+    // async-signal-safe: pthread_mutex_trylock is on the POSIX AS-safe list
+    bool tryLock() { return pthread_mutex_trylock(&_mutex) == 0; }
 };
 
 class WaitableMutex : public Mutex {

--- a/ddprof-lib/src/main/cpp/mutex.h
+++ b/ddprof-lib/src/main/cpp/mutex.h
@@ -19,8 +19,6 @@ class Mutex {
 
     void lock();
     void unlock();
-    // async-signal-safe: pthread_mutex_trylock is on the POSIX AS-safe list
-    bool tryLock() { return pthread_mutex_trylock(&_mutex) == 0; }
 };
 
 class WaitableMutex : public Mutex {

--- a/ddprof-lib/src/main/cpp/os.h
+++ b/ddprof-lib/src/main/cpp/os.h
@@ -7,6 +7,7 @@
 #ifndef _OS_H
 #define _OS_H
 
+#include <atomic>
 #include <functional>
 #include <signal.h>
 #include <stddef.h>
@@ -104,7 +105,22 @@ class OS {
     static u64 micros();
     static u64 processStartTime();
     static void sleep(u64 nanos);
-    static void uninterruptibleSleep(u64 nanos, volatile bool* flag);
+
+    // Sleep for up to max_nanos, restarting against an absolute monotonic
+    // deadline on EINTR so unrelated signals (SIGCHLD, debugger
+    // SIGSTOP/SIGCONT, etc.) do not shorten the wait.  Returns early when
+    // keep_sleeping becomes false — used by background threads (e.g. the
+    // Libraries refresher) to respond to a stop request without waiting
+    // out the full interval.  Pair with pthread_kill(thread, SOMESIG) +
+    // keep_sleeping=false in the caller's stop path: the signal triggers
+    // EINTR, the loop re-checks the flag, and the function returns.
+    //
+    // On Linux this uses clock_nanosleep with TIMER_ABSTIME + CLOCK_MONOTONIC
+    // so the deadline is absolute and arithmetic-free.  On macOS we fall
+    // back to nanosleep with a recomputed remainder (clock_nanosleep with
+    // TIMER_ABSTIME is unavailable there).
+    static void sleepWhile(u64 max_nanos, std::atomic<bool>& keep_sleeping);
+
     static u64 overrun(siginfo_t* siginfo);
 
     static u64 hton64(u64 x);

--- a/ddprof-lib/src/main/cpp/os_linux.cpp
+++ b/ddprof-lib/src/main/cpp/os_linux.cpp
@@ -171,11 +171,18 @@ void OS::sleep(u64 nanos) {
     nanosleep(&ts, NULL);
 }
 
-void OS::uninterruptibleSleep(u64 nanos, volatile bool* flag) {
-    // Workaround nanosleep bug: https://man7.org/linux/man-pages/man2/nanosleep.2.html#BUGS
-    u64 deadline = OS::nanotime() + nanos;
-    struct timespec ts = {(time_t)(deadline / 1000000000), (long)(deadline % 1000000000)};
-    while (*flag && clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, &ts) == EINTR);
+void OS::sleepWhile(u64 max_nanos, std::atomic<bool>& keep_sleeping) {
+    // Compute the deadline once and reuse it across EINTR retries so
+    // unrelated signals don't shorten the wait.
+    u64 deadline = OS::nanotime() + max_nanos;
+    struct timespec ts;
+    ts.tv_sec  = (time_t)(deadline / 1000000000ULL);
+    ts.tv_nsec = (long)(deadline % 1000000000ULL);
+    while (keep_sleeping.load(std::memory_order_acquire) &&
+           clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, nullptr) == EINTR) {
+        // Re-issue against the same absolute deadline.  EINTR absorbs
+        // SIGCHLD, SIGSTOP/CONT, etc. without arithmetic on remaining time.
+    }
 }
 
 u64 OS::overrun(siginfo_t* siginfo) {

--- a/ddprof-lib/src/main/cpp/os_macos.cpp
+++ b/ddprof-lib/src/main/cpp/os_macos.cpp
@@ -127,9 +127,20 @@ void OS::sleep(u64 nanos) {
     nanosleep(&ts, NULL);
 }
 
-void OS::uninterruptibleSleep(u64 nanos, volatile bool* flag) {
-    struct timespec ts = {(time_t)(nanos / 1000000000), (long)(nanos % 1000000000)};
-    while (*flag && nanosleep(&ts, &ts) < 0 && errno == EINTR);
+void OS::sleepWhile(u64 max_nanos, std::atomic<bool>& keep_sleeping) {
+    // macOS does not expose clock_nanosleep(TIMER_ABSTIME).  Recompute the
+    // remaining interval against OS::nanotime() each iteration so spurious
+    // wake-ups don't shorten the wait, mirroring the Linux semantics.
+    u64 deadline = OS::nanotime() + max_nanos;
+    while (keep_sleeping.load(std::memory_order_acquire)) {
+        u64 now = OS::nanotime();
+        if (now >= deadline) {
+            return;
+        }
+        u64 remaining = deadline - now;
+        struct timespec ts = {(time_t)(remaining / 1000000000ULL), (long)(remaining % 1000000000ULL)};
+        nanosleep(&ts, nullptr);
+    }
 }
 
 u64 OS::overrun(siginfo_t* siginfo) {

--- a/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
+++ b/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
@@ -730,6 +730,7 @@ u64 PerfEvents::readCounter(siginfo_t *siginfo, void *ucontext) {
 }
 
 void PerfEvents::signalHandler(int signo, siginfo_t *siginfo, void *ucontext) {
+  SIGNAL_HANDLER_GUARD();
   if (siginfo->si_code <= 0) {
     // Looks like an external signal; don't treat as a profiling event
     return;

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -11,7 +11,6 @@
 #include "context.h"
 #include "context_api.h"
 #include "guards.h"
-#include "signalSafety.h"
 #include "common.h"
 #include "counters.h"
 #include "ctimer.h"
@@ -749,20 +748,50 @@ void Profiler::writeHeapUsage(long value, bool live) {
   _locks[lock_index].unlock();
 }
 
+void Profiler::prewarmUnwinder() {
+#ifdef __linux__
+  // J9 on aarch64 (and other JVMs) lazily loads libgcc_s.so.1 from its DWARF
+  // unwinder during stack walks. When that happens inside a signal handler
+  // frame, our dlopen_hook fires from signal context and tries to refresh the
+  // library list — Mutex::lock and malloc on a signal stack.  By forcing the
+  // load here, before any signal handler is installed, subsequent calls find
+  // libgcc_s already mapped and the lazy-load path never runs.
+  //
+  // The handle is intentionally leaked: keeping the refcount > 0 prevents the
+  // library from being unmapped for the remainder of the process lifetime.
+  //
+  // SONAME note: "libgcc_s.so.1" is hardcoded deliberately. Referencing
+  // _Unwind_Backtrace from C++ would normally let the linker resolve the
+  // SONAME implicitly, but our release build uses -static-libgcc
+  // (ConfigurationPresets.kt: "-static-libgcc"), which embeds the unwinder
+  // into libjavaProfiler.so and removes libgcc_s.so from our NEEDED entries
+  // — so a symbol reference would not trigger the shared-library load.
+  // dlopen by SONAME is the only mechanism that works under static-libgcc.
+  // libgcc_s.so.1 has been the stable SONAME since 2002; a bump would
+  // constitute a glibc/GCC C++ ABI break and is treated as a fixed contract.
+  (void)dlopen("libgcc_s.so.1", RTLD_LAZY | RTLD_GLOBAL);
+#endif
+}
+
 void *Profiler::dlopen_hook(const char *filename, int flags) {
   void *result = dlopen(filename, flags);
 
   if (result != NULL) {
-    // Static function of Profiler -> can not use the instance variable _libs
-    // Since Libraries is a singleton, this does not matter
-    Libraries::instance()->updateSymbols(false);
-    // Patch sigaction in newly loaded libraries
-    LibraryPatcher::patch_sigaction();
-    MallocTracer::installHooks();
-    // Extract build-ids for newly loaded libraries if remote symbolication is enabled
-    Profiler* profiler = instance();
-    if (profiler != nullptr && profiler->_remote_symbolication) {
-      Libraries::instance()->updateBuildIds();
+    if (!isInSignalContext()) {
+      // Normal (non-signal) dlopen: refresh synchronously so symbols in
+      // the new library are resolved immediately.
+      Libraries::instance()->refresh();
+    } else {
+      // Async-signal context.  Profiler::prewarmUnwinder closes the known
+      // libgcc_s case, but JVM/JIT lazy loads have been observed from
+      // signal handlers under Graal on aarch64.  refresh() must NOT run
+      // here — parseLibraries acquires a Mutex and calls malloc, both
+      // AS-unsafe.  Mark the library set dirty; the Libraries refresher
+      // thread picks it up within REFRESH_INTERVAL_NS (5s), bounding the
+      // window during which the new library is unresolvable.  flushJfr /
+      // dump / stop also call refresh() unconditionally, so this works
+      // even before the refresher thread starts.
+      Libraries::instance()->markDirty();
     }
   }
 
@@ -1140,6 +1169,10 @@ Error Profiler::start(Arguments &args, bool reset) {
     return Error("Profiler already started");
   }
 
+  // Force libgcc_s to load now (idempotent dlopen) so the JVM's DWARF
+  // unwinder cannot lazy-load it later from signal context.
+  prewarmUnwinder();
+
   Error error = checkJvmCapabilities();
   if (error) {
     return error;
@@ -1147,6 +1180,7 @@ Error Profiler::start(Arguments &args, bool reset) {
 
   _omit_stacktraces = args._lightweight;
   _remote_symbolication = args._remote_symbolication;
+  _libs->setRemoteSymbolication(_remote_symbolication);
   _event_mask =
       ((args._event != NULL && strcmp(args._event, EVENT_NOOP) != 0) ? EM_CPU
                                                                      : 0) |
@@ -1282,6 +1316,11 @@ Error Profiler::start(Arguments &args, bool reset) {
   // Always enable library trap to catch wasmtime loading and patch its broken sigaction
   switchLibraryTrap(true);
 
+  // Refresher must be running before the trap fires: dlopen_hook's
+  // signal-context branch only marks dirty and relies on the refresher
+  // to call refresh() within ~5s.
+  _libs->startRefresher();
+
   JfrMetadata::reset();
   JfrMetadata::initialize(args._context_attributes);
   _num_context_attributes = args._context_attributes.size();
@@ -1292,6 +1331,7 @@ Error Profiler::start(Arguments &args, bool reset) {
   if (error) {
     disableEngines();
     switchLibraryTrap(false);
+    _libs->stopRefresher();
     return error;
   }
 
@@ -1334,6 +1374,7 @@ Error Profiler::start(Arguments &args, bool reset) {
         // nativemem is the only requested mode: propagate the real error
         disableEngines();
         switchLibraryTrap(false);
+        _libs->stopRefresher();
         lockAll();
         _jfr.stop();
         unlockAll();
@@ -1363,6 +1404,7 @@ Error Profiler::start(Arguments &args, bool reset) {
   // no engine was activated; perform cleanup
   disableEngines();
   switchLibraryTrap(false);
+  _libs->stopRefresher();
 
   lockAll();
   _jfr.stop();
@@ -1390,7 +1432,11 @@ Error Profiler::stop() {
     _cpu_engine->stop();
 
   switchLibraryTrap(false);
+  // Stop the refresher before the final refresh() so it doesn't race the
+  // teardown.  startRefresher/stopRefresher are idempotent.
+  _libs->stopRefresher();
   switchThreadEvents(JVMTI_DISABLE);
+  Libraries::instance()->refresh();
   updateJavaThreadNames();
   updateNativeThreadNames();
 
@@ -1493,6 +1539,7 @@ Error Profiler::flushJfr() {
     return Error("Profiler is not active");
   }
 
+  Libraries::instance()->refresh();
   updateJavaThreadNames();
   updateNativeThreadNames();
 
@@ -1515,6 +1562,7 @@ Error Profiler::dump(const char *path, const int length) {
     // by the live objects
     LivenessTracker::instance()->flush(thread_ids);
 
+    Libraries::instance()->refresh();
     updateJavaThreadNames();
     updateNativeThreadNames();
 

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -11,6 +11,7 @@
 #include "context.h"
 #include "context_api.h"
 #include "guards.h"
+#include "signalSafety.h"
 #include "common.h"
 #include "counters.h"
 #include "ctimer.h"
@@ -801,10 +802,18 @@ void Profiler::disableEngines() {
 }
 
 void Profiler::segvHandler(int signo, siginfo_t *siginfo, void *ucontext) {
+  // J9 installs a SIGSEGV handler that uses siglongjmp() to recover from
+  // null-pointer-check faults during normal Java execution.  When we chain to
+  // it, that longjmp unwinds past our stack frame and skips the RAII
+  // destructor, permanently leaking depth on the thread.  Release the guard
+  // before chaining so depth is correct whether the chained handler returns
+  // or longjmps.
+  SIGNAL_HANDLER_GUARD();
   if (crashHandlerInternal(signo, siginfo, ucontext)) {
-    return;  // Handled
+    return;  // Handled — destructor decrements depth
   }
-  // Not handled, chain to next handler
+  SIGNAL_HANDLER_GUARD_RELEASE();
+  // Not handled, chain to next handler (may longjmp; never return through us)
   SigAction chain = OS::getSegvChainTarget();
   if (chain != nullptr) {
     chain(signo, siginfo, ucontext);
@@ -814,9 +823,13 @@ void Profiler::segvHandler(int signo, siginfo_t *siginfo, void *ucontext) {
 }
 
 void Profiler::busHandler(int signo, siginfo_t *siginfo, void *ucontext) {
+  // See segvHandler: release before chaining in case the chained handler
+  // longjmps through us.
+  SIGNAL_HANDLER_GUARD();
   if (crashHandlerInternal(signo, siginfo, ucontext)) {
-    return;  // Handled
+    return;  // Handled — destructor decrements depth
   }
+  SIGNAL_HANDLER_GUARD_RELEASE();
   // Not handled, chain to next handler
   SigAction chain = OS::getBusChainTarget();
   if (chain != nullptr) {

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -777,20 +777,24 @@ void *Profiler::dlopen_hook(const char *filename, int flags) {
   void *result = dlopen(filename, flags);
 
   if (result != NULL) {
-    if (!isInSignalContext()) {
-      // Normal (non-signal) dlopen: refresh synchronously so symbols in
-      // the new library are resolved immediately.
+    if (!isInTrackedSignalContext()) {
+      // Either confirmed non-signal context, or no ProfiledThread on this
+      // thread (uninstrumented JVM internals — VM Thread, JIT, GC).  We
+      // prefer synchronous refresh for the null-PT case too because (a)
+      // those threads call dlopen synchronously during normal JVM
+      // operation, and (b) wasmtime's broken sigaction patching depends
+      // on switchLibraryTrap running its work inline (the original reason
+      // for the trap).  The residual risk — an uninstrumented thread
+      // calling dlopen from inside a foreign signal handler — is small:
+      // prewarmUnwinder() closes the known libgcc_s lazy-load case, and
+      // mainstream JVM signal handlers are AS-safe by design.
       Libraries::instance()->refresh();
     } else {
-      // Async-signal context.  Profiler::prewarmUnwinder closes the known
-      // libgcc_s case, but JVM/JIT lazy loads have been observed from
-      // signal handlers under Graal on aarch64.  refresh() must NOT run
-      // here — parseLibraries acquires a Mutex and calls malloc, both
-      // AS-unsafe.  Mark the library set dirty; the Libraries refresher
-      // thread picks it up within REFRESH_INTERVAL_NS (5s), bounding the
-      // window during which the new library is unresolvable.  flushJfr /
-      // dump / stop also call refresh() unconditionally, so this works
-      // even before the refresher thread starts.
+      // Confirmed signal context (one of our SignalHandlerScopes is on
+      // the stack).  refresh() must NOT run here — parseLibraries
+      // acquires a Mutex and calls malloc, both AS-unsafe.  Mark the
+      // library set dirty; the Libraries refresher thread picks it up
+      // within REFRESH_INTERVAL_NS (500 ms).
       Libraries::instance()->markDirty();
     }
   }
@@ -837,6 +841,13 @@ void Profiler::segvHandler(int signo, siginfo_t *siginfo, void *ucontext) {
   // destructor, permanently leaking depth on the thread.  Release the guard
   // before chaining so depth is correct whether the chained handler returns
   // or longjmps.
+  //
+  // Sanitizer-coverage note: this also means depth == 0 inside the chained
+  // handler, so DEBUG_ASSERT_NOT_IN_SIGNAL() will NOT fire for AS-unsafe
+  // code reachable from a chained handler that returns normally.  This is
+  // the lesser of two evils — leaking depth on longjmp would silently
+  // break the production deferred-refresh gate, while the sanitizer gap
+  // is bounded to third-party signal handler code we don't own.
   SIGNAL_HANDLER_GUARD();
   if (crashHandlerInternal(signo, siginfo, ucontext)) {
     return;  // Handled — destructor decrements depth
@@ -1313,13 +1324,13 @@ Error Profiler::start(Arguments &args, bool reset) {
 
   enableEngines();
 
-  // Always enable library trap to catch wasmtime loading and patch its broken sigaction
-  switchLibraryTrap(true);
-
   // Refresher must be running before the trap fires: dlopen_hook's
   // signal-context branch only marks dirty and relies on the refresher
-  // to call refresh() within ~5s.
+  // to call refresh() within REFRESH_INTERVAL_NS (500 ms).
   _libs->startRefresher();
+
+  // Always enable library trap to catch wasmtime loading and patch its broken sigaction
+  switchLibraryTrap(true);
 
   JfrMetadata::reset();
   JfrMetadata::initialize(args._context_attributes);

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -122,6 +122,7 @@ private:
   void **_dlopen_entry;
   static void *dlopen_hook(const char *filename, int flags);
   void switchLibraryTrap(bool enable);
+  static void prewarmUnwinder();
 
   void enableEngines();
   void disableEngines();

--- a/ddprof-lib/src/main/cpp/signalSafety.cpp
+++ b/ddprof-lib/src/main/cpp/signalSafety.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Header-only module — see signalSafety.h for DEBUG_ASSERT_NOT_IN_SIGNAL().
+// The signal-context depth counter (used by both the assertion and the
+// production AS-safe deferred path) lives in guards.{h,cpp}.
+#include "signalSafety.h"

--- a/ddprof-lib/src/main/cpp/signalSafety.h
+++ b/ddprof-lib/src/main/cpp/signalSafety.h
@@ -17,7 +17,8 @@
 #ifndef _SIGNAL_SAFETY_H
 #define _SIGNAL_SAFETY_H
 
-#include "guards.h"  // _in_signal_handler_depth, SIGNAL_HANDLER_GUARD, ...
+#include "guards.h"   // isInSignalContext, SIGNAL_HANDLER_GUARD, ...
+#include "thread.h"   // ProfiledThread::currentSignalSafe
 
 // Detect ASAN using compiler-provided macros so the ASAN_ENABLED guard below
 // works in every TU that includes this header, independent of include order.
@@ -38,9 +39,12 @@
 // invoked from inside a signal handler in debug / ASAN builds; compiles to a
 // no-op in release builds (NDEBUG).
 //
-// The depth counter itself lives in guards.h (always-on, needed by
-// Profiler::dlopen_hook for the AS-safe deferred path).  Only the diagnostic
-// abort is conditional.
+// The depth counter itself lives in ProfiledThread::_signal_depth (see
+// guards.h for the rationale).  The check is skipped when ProfiledThread
+// is null — uninstrumented threads (VM Thread, JIT, GC) have no thread
+// context, so the assertion has no way to know whether they're really in
+// a signal frame.  Treating "unknown" as a violation would produce false
+// positives every time AS-unsafe code legitimately ran on such a thread.
 //
 // write(2) is POSIX async-signal-safe.  abort() generates a core dump and
 // triggers ASAN's stack-trace symbolization, making it far more debuggable
@@ -59,7 +63,9 @@
 
 #define DEBUG_ASSERT_NOT_IN_SIGNAL()                                                        \
     do {                                                                                     \
-        if (_in_signal_handler_depth != 0) {                                                 \
+        ProfiledThread *_pt_for_assert = ProfiledThread::currentSignalSafe();                \
+        /* Skip when no thread context — see comment above. */                              \
+        if (_pt_for_assert != nullptr && _pt_for_assert->signalDepth() != 0) {              \
             static const char _msg[] =                                                       \
                 "[java-profiler] AS-safety violation at "                                    \
                 __FILE__ ":" _SIGNAL_SAFETY_TOSTR(__LINE__)                                  \

--- a/ddprof-lib/src/main/cpp/signalSafety.h
+++ b/ddprof-lib/src/main/cpp/signalSafety.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _SIGNAL_SAFETY_H
+#define _SIGNAL_SAFETY_H
+
+#include "guards.h"  // _in_signal_handler_depth, SIGNAL_HANDLER_GUARD, ...
+
+// Detect ASAN using compiler-provided macros so the ASAN_ENABLED guard below
+// works in every TU that includes this header, independent of include order.
+#ifdef __has_feature
+#  if __has_feature(address_sanitizer)
+#    ifndef ASAN_ENABLED
+#      define ASAN_ENABLED 1
+#    endif
+#  endif
+#endif
+#ifdef __SANITIZE_ADDRESS__
+#  ifndef ASAN_ENABLED
+#    define ASAN_ENABLED 1
+#  endif
+#endif
+
+// Debug-only AS-safety assertion.  Aborts with a file:line diagnostic when
+// invoked from inside a signal handler in debug / ASAN builds; compiles to a
+// no-op in release builds (NDEBUG).
+//
+// The depth counter itself lives in guards.h (always-on, needed by
+// Profiler::dlopen_hook for the AS-safe deferred path).  Only the diagnostic
+// abort is conditional.
+//
+// write(2) is POSIX async-signal-safe.  abort() generates a core dump and
+// triggers ASAN's stack-trace symbolization, making it far more debuggable
+// than _exit(1).  The macro is only active in debug/ASAN builds where we
+// intentionally trade AS-safety of the abort path for diagnosability.
+#define _SIGNAL_SAFETY_STR(x) #x
+#define _SIGNAL_SAFETY_TOSTR(x) _SIGNAL_SAFETY_STR(x)
+
+#if !defined(NDEBUG) || defined(ASAN_ENABLED)
+#include <unistd.h>  // write, STDERR_FILENO, open, close
+#include <stdlib.h>  // abort
+#include <fcntl.h>   // O_WRONLY, O_CREAT, O_APPEND
+
+// Path for the diagnostic file — picked up as a CI artifact on failure.
+#define _SIGNAL_SAFETY_DIAG_FILE "/tmp/signal-safety-violation.txt"
+
+#define DEBUG_ASSERT_NOT_IN_SIGNAL()                                                        \
+    do {                                                                                     \
+        if (_in_signal_handler_depth != 0) {                                                 \
+            static const char _msg[] =                                                       \
+                "[java-profiler] AS-safety violation at "                                    \
+                __FILE__ ":" _SIGNAL_SAFETY_TOSTR(__LINE__)                                  \
+                ": async-signal-unsafe call made from signal handler context\n";             \
+            (void)write(STDERR_FILENO, _msg, sizeof(_msg) - 1);                             \
+            /* Also write to a file so CI can capture it regardless of output routing. */   \
+            int _diag_fd = open(_SIGNAL_SAFETY_DIAG_FILE,                                   \
+                                O_WRONLY | O_CREAT | O_APPEND, 0644);                       \
+            if (_diag_fd >= 0) {                                                             \
+                (void)write(_diag_fd, _msg, sizeof(_msg) - 1);                              \
+                close(_diag_fd);                                                             \
+            }                                                                                \
+            abort();                                                                         \
+        }                                                                                    \
+    } while (0)
+#else
+#define DEBUG_ASSERT_NOT_IN_SIGNAL() ((void)0)
+#endif
+
+#endif  // _SIGNAL_SAFETY_H

--- a/ddprof-lib/src/main/cpp/thread.h
+++ b/ddprof-lib/src/main/cpp/thread.h
@@ -55,6 +55,7 @@ private:
   u32 _misc_flags;
   int _filter_slot_id; // Slot ID for thread filtering
   uint8_t _init_window; // Countdown for JVM thread init race window (PROF-13072)
+  uint8_t _signal_depth; // Nested signal-handler depth (see SignalHandlerScope)
   UnwindFailures _unwind_failures;
   bool _otel_ctx_initialized;
   bool _crash_protection_active;
@@ -73,6 +74,7 @@ private:
   ProfiledThread(int tid)
       : ThreadLocalData(), _pc(0), _sp(0), _span_id(0), _crash_depth(0), _tid(tid), _cpu_epoch(0),
         _wall_epoch(0), _call_trace_id(0), _recording_epoch(0), _misc_flags(0), _filter_slot_id(-1), _init_window(0),
+        _signal_depth(0),
         _otel_ctx_initialized(false), _crash_protection_active(false),
         _otel_ctx_record{}, _otel_tag_encodings{}, _otel_local_root_span_id(0) {};
 
@@ -167,6 +169,14 @@ public:
   bool isDeepCrashHandler() {
     return _crash_depth > CRASH_HANDLER_NESTING_LIMIT;
   }
+
+  // Signal-handler depth counter used by SignalHandlerScope (guards.h).  All
+  // access happens on the owning thread (signal handlers are delivered to the
+  // thread that's interrupted), so plain reads/writes are AS-safe — no locks,
+  // no malloc, no syscalls.  See guards.h for the public API.
+  inline uint8_t signalDepth() const { return _signal_depth; }
+  inline void enterSignalScope()    { ++_signal_depth; }
+  inline void exitSignalScope()     { if (_signal_depth > 0) --_signal_depth; }
 
   UnwindFailures* unwindFailures(bool reset = true) {
     if (reset) {

--- a/ddprof-lib/src/main/cpp/vmEntry.cpp
+++ b/ddprof-lib/src/main/cpp/vmEntry.cpp
@@ -21,6 +21,7 @@
 #include "hotspot/jitCodeCache.h"
 #include <dlfcn.h>
 #include <stdlib.h>
+#include "guards.h"
 #include <string.h>
 #include <sys/mman.h>
 
@@ -56,6 +57,7 @@ AsyncGetCallTrace VM::_asyncGetCallTrace;
 JVM_GetManagement VM::_getManagement;
 
 static void wakeupHandler(int signo) {
+  SIGNAL_HANDLER_GUARD();
   // Dummy handler for interrupting syscalls
 }
 

--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -178,14 +178,18 @@ void WallClockASGCT::timerLoop() {
     auto collectThreads = [&](std::vector<int>& tids) {
       // Get thread IDs from the filter if it's enabled
       // Otherwise list all threads in the system
+      const int refresher_tid = Libraries::instance()->refresherTid();
       if (Profiler::instance()->threadFilter()->enabled()) {
         Profiler::instance()->threadFilter()->collect(tids);
       } else {
         ThreadList *thread_list = OS::listThreads();
         while (thread_list->hasNext()) {
           int tid = thread_list->next();
-          // Don't include the current thread
-          if (tid != OS::threadId()) {
+          // Don't include the current thread, nor the Libraries refresher
+          // thread (profiler-internal — masking SIGVTALRM there is not
+          // enough; we also want to avoid the kill() round-trip and any
+          // pending-signal accumulation).
+          if (tid != OS::threadId() && tid != refresher_tid) {
             tids.push_back(tid);
           }
         }
@@ -285,13 +289,16 @@ void WallClockJvmti::initialize(Arguments &args) {
 
 void WallClockJvmti::timerLoop() {
   auto collectThreads = [&](std::vector<int> &tids) {
+    const int refresher_tid = Libraries::instance()->refresherTid();
     if (Profiler::instance()->threadFilter()->enabled()) {
       Profiler::instance()->threadFilter()->collect(tids);
     } else {
       ThreadList *thread_list = OS::listThreads();
       while (thread_list->hasNext()) {
         int tid = thread_list->next();
-        if (tid != OS::threadId()) {
+        // Exclude the wallclock timer thread itself and the Libraries
+        // refresher (profiler-internal).
+        if (tid != OS::threadId() && tid != refresher_tid) {
           tids.push_back(tid);
         }
       }

--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -54,6 +54,7 @@ bool BaseWallClock::inSyscall(void *ucontext) {
 
 void WallClockASGCT::sharedSignalHandler(int signo, siginfo_t *siginfo,
                                     void *ucontext) {
+  SIGNAL_HANDLER_GUARD();
   // Reject any SIGVTALRM that did not originate from our rt_tgsigqueueinfo
   // send. Defends against stray in-process tgkill / external sigqueue that
   // would otherwise drive our wallclock sampling path.
@@ -228,6 +229,7 @@ void WallClockASGCT::timerLoop() {
 
 void WallClockJvmti::sharedSignalHandler(int signo, siginfo_t *siginfo,
                                          void *ucontext) {
+  SIGNAL_HANDLER_GUARD();
   WallClockJvmti *engine =
       reinterpret_cast<WallClockJvmti *>(Profiler::instance()->wallEngine());
   if (signo == SIGVTALRM) {

--- a/ddprof-lib/src/test/cpp/signalSafety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/signalSafety_ut.cpp
@@ -15,13 +15,23 @@
  */
 
 #include "signalSafety.h"
+#include "thread.h"
 #include <gtest/gtest.h>
 
 class SignalSafetyTest : public ::testing::Test {
 protected:
+    void SetUp() override {
+        // SignalHandlerScope reads/writes ProfiledThread::_signal_depth — the
+        // tests need a thread context to exist on the gtest thread, otherwise
+        // every scope is a no-op (which is the intended production behavior
+        // on uninstrumented threads, but not what these unit tests assert).
+        ProfiledThread::initCurrentThread();
+    }
+
     void TearDown() override {
         // Catch leaked depth from a failed test so subsequent tests start clean.
         ASSERT_EQ(0, getInSignalDepth()) << "depth not zero after test — check for leaked SignalHandlerScope";
+        ProfiledThread::release();
     }
 };
 
@@ -49,5 +59,12 @@ TEST_F(SignalSafetyTest, NestedDepth) {
         }
         EXPECT_EQ(1, getInSignalDepth());
     }
+    EXPECT_EQ(0, getInSignalDepth());
+}
+
+TEST(SignalSafetyTestNoContext, NullProfiledThreadIsTreatedAsSignal) {
+    // No ProfiledThread on this thread — isInSignalContext() must return
+    // true (conservative default for AS-safety gates like dlopen_hook).
+    EXPECT_TRUE(isInSignalContext());
     EXPECT_EQ(0, getInSignalDepth());
 }

--- a/ddprof-lib/src/test/cpp/signalSafety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/signalSafety_ut.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "signalSafety.h"
+#include <gtest/gtest.h>
+
+class SignalSafetyTest : public ::testing::Test {
+protected:
+    void TearDown() override {
+        // Catch leaked depth from a failed test so subsequent tests start clean.
+        ASSERT_EQ(0, getInSignalDepth()) << "depth not zero after test — check for leaked SignalHandlerScope";
+    }
+};
+
+TEST_F(SignalSafetyTest, DepthStartsAtZero) {
+    EXPECT_EQ(0, getInSignalDepth());
+}
+
+TEST_F(SignalSafetyTest, DepthSymmetry) {
+    EXPECT_EQ(0, getInSignalDepth());
+    {
+        SignalHandlerScope scope;
+        EXPECT_EQ(1, getInSignalDepth());
+    }
+    EXPECT_EQ(0, getInSignalDepth());
+}
+
+TEST_F(SignalSafetyTest, NestedDepth) {
+    EXPECT_EQ(0, getInSignalDepth());
+    {
+        SignalHandlerScope outer;
+        EXPECT_EQ(1, getInSignalDepth());
+        {
+            SignalHandlerScope inner;
+            EXPECT_EQ(2, getInSignalDepth());
+        }
+        EXPECT_EQ(1, getInSignalDepth());
+    }
+    EXPECT_EQ(0, getInSignalDepth());
+}

--- a/ddprof-lib/src/test/cpp/signalSafety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/signalSafety_ut.cpp
@@ -62,10 +62,70 @@ TEST_F(SignalSafetyTest, NestedDepth) {
     EXPECT_EQ(0, getInSignalDepth());
 }
 
-TEST(SignalSafetyTestNoContext, NullProfiledThreadIsTreatedAsSignal) {
-    // No ProfiledThread on this thread — isInSignalContext() must return
-    // true (conservative default for AS-safety gates like dlopen_hook).
-    EXPECT_TRUE(isInSignalContext());
+TEST_F(SignalSafetyTest, TrackedSignalContextRequiresScope) {
+    EXPECT_FALSE(isInTrackedSignalContext());
+    {
+        SignalHandlerScope scope;
+        EXPECT_TRUE(isInTrackedSignalContext());
+    }
+    EXPECT_FALSE(isInTrackedSignalContext());
+}
+
+// SIGNAL_HANDLER_GUARD_RELEASE path: explicit early release inside a scope,
+// destructor must not double-decrement.
+TEST_F(SignalSafetyTest, ReleaseDecrementsAndDestructorIsNoOp) {
+    EXPECT_EQ(0, getInSignalDepth());
+    {
+        SignalHandlerScope scope;
+        EXPECT_EQ(1, getInSignalDepth());
+        scope.release();
+        EXPECT_EQ(0, getInSignalDepth());
+        // Destructor runs at end of scope and must NOT decrement again.
+    }
+    EXPECT_EQ(0, getInSignalDepth());
+}
+
+// SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP path: simulate a longjmp that bypasses
+// SignalHandlerScope's destructor.  signalHandlerUnwindAfterLongjmp() must
+// decrement the depth even when no live scope object is around.
+//
+// Sequence (longjmp simulated by an extra block-scope guard that we don't
+// destroy):
+//   outer scope ctor   → depth=1
+//   inner scope ctor   → depth=2
+//   imagine longjmp: inner scope's dtor is skipped
+//   signalHandlerUnwindAfterLongjmp() at landing → depth=1
+//   outer scope dtor   → depth=0
+TEST_F(SignalSafetyTest, SignalHandlerUnwindAfterLongjmpDecrementsOnce) {
+    EXPECT_EQ(0, getInSignalDepth());
+    {
+        SignalHandlerScope outer;
+        EXPECT_EQ(1, getInSignalDepth());
+
+        // Heap-allocate the inner scope so we can drop it without running its
+        // destructor — emulating a longjmp that bypasses the C++ stack unwind.
+        SignalHandlerScope *leaked_inner = new SignalHandlerScope();
+        EXPECT_EQ(2, getInSignalDepth());
+
+        // Pretend the longjmp landed here.  Compensate for the bypassed dtor.
+        SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP();
+        EXPECT_EQ(1, getInSignalDepth());
+
+        // Outer scope dtor runs next and brings depth back to 0.
+        // Free leaked_inner without calling its destructor (placement-new
+        // wasn't used so a plain operator delete would invoke the destructor;
+        // route the storage through ::operator delete to skip dtor).
+        ::operator delete(leaked_inner);
+    }
+    EXPECT_EQ(0, getInSignalDepth());
+}
+
+// Safety property: signalHandlerUnwindAfterLongjmp() saturates at zero;
+// double calls do not underflow.
+TEST_F(SignalSafetyTest, SignalHandlerUnwindAfterLongjmpSaturatesAtZero) {
+    EXPECT_EQ(0, getInSignalDepth());
+    signalHandlerUnwindAfterLongjmp();
+    signalHandlerUnwindAfterLongjmp();
     EXPECT_EQ(0, getInSignalDepth());
 }
 
@@ -77,11 +137,8 @@ TEST(SignalSafetyTestNoContext, NullProfiledThreadIsNotTrackedSignal) {
     EXPECT_FALSE(isInTrackedSignalContext());
 }
 
-TEST_F(SignalSafetyTest, TrackedSignalContextRequiresScope) {
-    EXPECT_FALSE(isInTrackedSignalContext());
-    {
-        SignalHandlerScope scope;
-        EXPECT_TRUE(isInTrackedSignalContext());
-    }
-    EXPECT_FALSE(isInTrackedSignalContext());
+TEST(SignalSafetyTestNoContext, NullProfiledThreadDepthIsZero) {
+    // Mutation guard: getInSignalDepth() must return 0 on null PT, not a
+    // sentinel that happens to equal zero today.
+    EXPECT_EQ(0, getInSignalDepth());
 }

--- a/ddprof-lib/src/test/cpp/signalSafety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/signalSafety_ut.cpp
@@ -68,3 +68,20 @@ TEST(SignalSafetyTestNoContext, NullProfiledThreadIsTreatedAsSignal) {
     EXPECT_TRUE(isInSignalContext());
     EXPECT_EQ(0, getInSignalDepth());
 }
+
+TEST(SignalSafetyTestNoContext, NullProfiledThreadIsNotTrackedSignal) {
+    // isInTrackedSignalContext() returns false on null because the
+    // SignalHandlerScope never ran — used by Profiler::dlopen_hook so
+    // uninstrumented JVM threads doing a normal dlopen take the fast
+    // (synchronous refresh) path instead of deferring.
+    EXPECT_FALSE(isInTrackedSignalContext());
+}
+
+TEST_F(SignalSafetyTest, TrackedSignalContextRequiresScope) {
+    EXPECT_FALSE(isInTrackedSignalContext());
+    {
+        SignalHandlerScope scope;
+        EXPECT_TRUE(isInTrackedSignalContext());
+    }
+    EXPECT_FALSE(isInTrackedSignalContext());
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,8 @@ kotlin = "1.9.22"
 spotless = "8.5.1"
 
 # Testing
-junit = "6.1.0"
-junit-platform = "6.1.0"  # JUnit Platform version corresponding to JUnit Jupiter 5.9.2
+junit = "5.9.2"
+junit-platform = "1.9.2"  # JUnit Platform version corresponding to JUnit Jupiter 5.9.2
 junit-pioneer = "1.9.1"
 slf4j = "2.0.18"
 

--- a/utils/run-docker-tests.sh
+++ b/utils/run-docker-tests.sh
@@ -8,7 +8,7 @@
 #
 # Usage: ./utils/run-docker-tests.sh [options]
 #   --libc=glibc|musl        (default: glibc)
-#   --jdk=8|11|17|21|25|8-j9|11-j9|17-j9|21-j9  (default: 21)
+#   --jdk=8|11|17|21|25|8-j9|11-j9|17-j9|21-j9|17-graal|21-graal|25-graal  (default: 21)
 #   --arch=x64|aarch64       (default: auto-detect)
 #   --config=debug|release|asan|tsan   (default: debug)
 #   --tests="TestPattern"    (optional, specific test to run)
@@ -90,6 +90,25 @@ get_glibc_jdk_url() {
         21-aarch64) echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.8_9.tar.gz" ;;
         25-x64)     echo "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_x64_linux_hotspot_25.0.2_10.tar.gz" ;;
         25-aarch64) echo "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_aarch64_linux_hotspot_25.0.2_10.tar.gz" ;;
+        *)          echo "" ;;
+    esac
+}
+
+# JDK Download URLs (Oracle GraalVM)
+# Versions match the SDKMAN-installed builds used in CI (java_setup.sh +
+# cache_java.yml: JAVA_<v>_GRAAL_VERSION).  Using Oracle's stable archive
+# URLs (not "latest") so the docker images match the CI configuration.
+get_graal_jdk_url() {
+    local version=$1
+    local arch=$2
+    # Oracle GraalVM archive arch labels: x64 / aarch64 (same as our $arch)
+    case "$version-$arch" in
+        17-x64)     echo "https://download.oracle.com/graalvm/17/archive/graalvm-jdk-17.0.12_linux-x64_bin.tar.gz" ;;
+        17-aarch64) echo "https://download.oracle.com/graalvm/17/archive/graalvm-jdk-17.0.12_linux-aarch64_bin.tar.gz" ;;
+        21-x64)     echo "https://download.oracle.com/graalvm/21/archive/graalvm-jdk-21.0.4_linux-x64_bin.tar.gz" ;;
+        21-aarch64) echo "https://download.oracle.com/graalvm/21/archive/graalvm-jdk-21.0.4_linux-aarch64_bin.tar.gz" ;;
+        25-x64)     echo "https://download.oracle.com/graalvm/25/archive/graalvm-jdk-25_linux-x64_bin.tar.gz" ;;
+        25-aarch64) echo "https://download.oracle.com/graalvm/25/archive/graalvm-jdk-25_linux-aarch64_bin.tar.gz" ;;
         *)          echo "" ;;
     esac
 }
@@ -205,6 +224,12 @@ if [[ "$JDK_VARIANT" == "j9" ]]; then
         exit 1
     fi
     JDK_URL=$(get_j9_jdk_url "$JDK_BASE_VERSION" "$ARCH")
+elif [[ "$JDK_VARIANT" == "graal" ]]; then
+    if [[ "$LIBC" == "musl" ]]; then
+        echo "Error: GraalVM is not available for musl libc"
+        exit 1
+    fi
+    JDK_URL=$(get_graal_jdk_url "$JDK_BASE_VERSION" "$ARCH")
 elif [[ "$LIBC" == "musl" ]]; then
     JDK_URL=$(get_musl_jdk_url "$JDK_BASE_VERSION" "$ARCH")
 else
@@ -212,7 +237,7 @@ else
 fi
 
 if [[ -z "$JDK_URL" ]]; then
-    echo "Error: --jdk must be one of: 8, 11, 17, 21, 25, 8-j9, 11-j9, 17-j9, 21-j9"
+    echo "Error: --jdk must be one of: 8, 11, 17, 21, 25, 8-j9, 11-j9, 17-j9, 21-j9, 17-graal, 21-graal, 25-graal"
     exit 1
 fi
 


### PR DESCRIPTION
**What does this PR do?**:
Adds a runtime async-signal-safety sanitizer for the profiler's signal handlers. All 10 installed signal handlers are wrapped with a `SignalHandlerScope` RAII guard that tracks nesting depth in a thread-local counter. 11 known-unsafe APIs (Dictionary inserting lookups, FlightRecorder lifecycle methods, `Mutex::lock`) get `DEBUG_ASSERT_NOT_IN_SIGNAL()` calls that abort via `write(2)+_exit(1)` in debug/ASAN builds if reached from signal context. Release builds are unaffected (macro compiles to `((void)0)`).

**Motivation**:
A number of profiler crashes in recent weeks all share the same root cause: async-signal-unsafe code reachable from signal handlers, caught only in production. Today the AS-safety rules exist only in contributor memory. This sanitizer enforces them in debug/ASAN builds so violations are caught at development time, not in production.

**Additional Notes**:
Two commits:
- `e9d70357` — [PROF-14764]: `SignalHandlerScope` RAII + `DEBUG_ASSERT_NOT_IN_SIGNAL()` macro + 3 unit tests
- `16baae4a` — [PROF-14765]: assertions wired into 11 unsafe call sites

`Recording::addThread` was audited and confirmed signal-safe — it uses `ThreadIdTable::insert` (atomic CAS only).

The `restoreSignalHandler` in `os_linux.cpp` / `os_macos.cpp` (trivial SIGSEGV/SIGBUS fallback handlers) has no `SignalHandlerScope` — their bodies are single-statement and call none of the asserted APIs, so no false-positive risk today. Tracked as a follow-up for completeness.

**How to test the change?**:
- `./gradlew :ddprof-lib:gtestDebug` — full debug suite must pass with no assertion fires
- `./gradlew :ddprof-lib:gtestDebug_signalSafety_ut` — 3 unit tests covering depth symmetry and nesting
- `./gradlew :ddprof-lib:gtestDebug_dictionary_concurrent_ut` — concurrent signal-context bounded_lookup + dump-thread clear; assertions in inserting overloads must not fire on the signal side

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-14763](https://datadoghq.atlassian.net/browse/PROF-14763)

[PROF-14763]: https://datadoghq.atlassian.net/browse/PROF-14763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PROF-14764]: https://datadoghq.atlassian.net/browse/PROF-14764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PROF-14765]: https://datadoghq.atlassian.net/browse/PROF-14765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ