### PR TITLE
ci: replace webfactory/ssh-agent with inline ssh-agent setup

### DIFF
--- a/.github/workflows/release-validated.yml
+++ b/.github/workflows/release-validated.yml
@@ -167,9 +167,14 @@ jobs:
           echo "::error::Pre-release tests failed. Cannot proceed with release."
           exit 1
 
-      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PUSH_SECRET }}
+      - name: Setup SSH agent
+        run: |
+          eval $(ssh-agent -s)
+          echo "${{ secrets.SSH_PUSH_SECRET }}" | ssh-add -
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> $GITHUB_ENV
+          echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> $GITHUB_ENV
 
       - name: Checkout repository
         run: git clone git@github.com:$GITHUB_REPOSITORY.git java-profiler


### PR DESCRIPTION
## Summary

- `webfactory/ssh-agent` is a third-party action now blocked by org policy, causing `startup_failure` on the `release-validated` workflow before any job runs
- Replaces it with equivalent inline shell commands (`ssh-agent`, `ssh-add`, `ssh-keyscan`) in a `run:` step — same `SSH_PUSH_SECRET` key, same authentication behaviour, no third-party dependency

## Test plan

- [ ] Trigger `release-validated` dry-run from `main` and verify it reaches the `create-release` job and authenticates SSH pushes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)