### PR TITLE
ci: open PR for post-release version bump instead of direct push

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -127,7 +127,21 @@ CANDIDATE=$(./gradlew printVersion -Psnapshot=false | grep 'Version:' | cut -f2 
 git add build.gradle.kts
 git commit -m "[Automated] Bump dev version to ${CANDIDATE}"
 
-git push $DRYRUN --atomic --set-upstream origin $BRANCH
+if [ -z "$DRYRUN" ]; then
+  BUMP_BRANCH="automated/bump-${CANDIDATE//./-}"
+  git checkout -b "$BUMP_BRANCH"
+  git push --set-upstream origin "$BUMP_BRANCH"
+  BUMP_PR_URL=$(gh pr create \
+    --title "[Automated] Bump dev version to ${CANDIDATE}" \
+    --body "Automated version bump after releasing v${BASE}. Please review and merge." \
+    --base "$BRANCH" \
+    --head "$BUMP_BRANCH")
+  echo "BUMP_PR_URL=$BUMP_PR_URL" >> "${GITHUB_OUTPUT:-/dev/null}"
+  echo "⚠ Version bump PR requires manual approval: $BUMP_PR_URL"
+else
+  git push $DRYRUN --atomic --set-upstream origin $BRANCH
+fi
+
 git push $DRYRUN --atomic --tags
 
 echo "==================== RELEASE SUMMARY ===================="

--- a/.github/workflows/release-validated.yml
+++ b/.github/workflows/release-validated.yml
@@ -27,6 +27,7 @@ on:
 permissions:
   contents: write
   actions: read
+  pull-requests: write
 
 jobs:
   validate-inputs:
@@ -193,6 +194,7 @@ jobs:
           java-version: '21'
 
       - name: Create release
+        id: create-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -209,6 +211,8 @@ jobs:
 
       - name: Output Release Summary
         if: ${{ inputs.dry_run != true }}
+        env:
+          BUMP_PR_URL: ${{ steps.create-release.outputs.BUMP_PR_URL }}
         run: |
           echo "## ✅ Release Created Successfully" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -216,6 +220,12 @@ jobs:
           echo "- **Tag**: v_${{ needs.validate-inputs.outputs.release_version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Branch**: ${{ needs.validate-inputs.outputs.release_branch }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -n "$BUMP_PR_URL" ]; then
+            echo "### ⚠ Action Required" >> $GITHUB_STEP_SUMMARY
+            echo "A version bump PR needs review and merge before the next snapshot builds carry the correct version:" >> $GITHUB_STEP_SUMMARY
+            echo "- $BUMP_PR_URL" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "### Next Steps (Automatic)" >> $GITHUB_STEP_SUMMARY
           echo "1. 🔨 GitLab pipeline will build multi-platform artifacts" >> $GITHUB_STEP_SUMMARY
           echo "2. 📦 GitLab will publish to Maven Central" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
**What does this PR do?**:
The release script tried to push the post-release version bump commit directly to `main`, which is now blocked by the branch ruleset requiring all changes to go through a PR.

Instead of pushing directly, the script now:
1. Creates a `automated/bump-X-Y-Z` branch with the version bump commit
2. Opens a PR targeting `main`
3. Surfaces the PR URL in the workflow step summary so a reviewer can find it immediately

**Motivation**:
Branch ruleset enforcement broke the `Validated Release` workflow — direct pushes to `main` are no longer allowed. The bypass actor approach is locked down at org level, so a PR-based flow is the only path.

**Additional Notes**:
The release itself (tag + release branch + GitLab trigger) is unblocked. The version bump PR is a required manual follow-up step.

**How to test the change?**:
Run the `Validated Release` workflow with `dry_run: true` — the bump path is skipped in dry-run so no PR is created. A real run will create the bump PR and print its URL in the job summary.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Labels: AI