### PR TITLE
ci: fix release branch pipelines and blocked org actions

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -131,13 +131,10 @@ if [ -z "$DRYRUN" ]; then
   BUMP_BRANCH="automated/bump-${CANDIDATE//./-}"
   git checkout -b "$BUMP_BRANCH"
   git push --set-upstream origin "$BUMP_BRANCH"
-  BUMP_PR_URL=$(gh pr create \
-    --title "[Automated] Bump dev version to ${CANDIDATE}" \
-    --body "Automated version bump after releasing v${BASE}. Please review and merge." \
-    --base "$BRANCH" \
-    --head "$BUMP_BRANCH")
+  REPO="${GITHUB_REPOSITORY:-$(git remote get-url origin | sed 's|.*github.com[:/]\(.*\)\.git|\1|')}"
+  BUMP_PR_URL="https://github.com/${REPO}/compare/${BRANCH}...${BUMP_BRANCH}?quick_pull=1&title=%5BAutomated%5D+Bump+dev+version+to+${CANDIDATE}"
   echo "BUMP_PR_URL=$BUMP_PR_URL" >> "${GITHUB_OUTPUT:-/dev/null}"
-  echo "⚠ Version bump PR requires manual approval: $BUMP_PR_URL"
+  echo "⚠ Open this URL to create the version bump PR: $BUMP_PR_URL"
 else
   git push $DRYRUN --atomic --set-upstream origin $BRANCH
 fi

--- a/.github/workflows/gh_release.yml
+++ b/.github/workflows/gh_release.yml
@@ -26,30 +26,32 @@ jobs:
     if: (startsWith(github.event.ref, 'refs/tags/v_') || inputs.release_tag != '') && !endsWith(github.event.ref, '-SNAPSHOT')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PUSH_SECRET }}
       - name: Create Release [automatic]
         id: create_release_auto
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        with:
-          generateReleaseNotes: true
-          allowUpdates: true
-          draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release edit "${GITHUB_REF_NAME}" --draft
+          else
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "${GITHUB_REF_NAME}" \
+              --generate-notes \
+              --draft
+          fi
       - name: Create Release [manual]
         id: create_release_manual
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        with:
-          generateReleaseNotes: true
-          allowUpdates: true
-          tag: ${{ inputs.release_tag}}
-          draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ inputs.release_tag }}"
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release edit "${TAG}" --draft
+          else
+            gh release create "${TAG}" \
+              --title "${TAG}" \
+              --generate-notes \
+              --draft
+          fi

--- a/.github/workflows/gh_release.yml
+++ b/.github/workflows/gh_release.yml
@@ -31,6 +31,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
             gh release edit "${GITHUB_REF_NAME}" --draft
@@ -45,6 +46,7 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           TAG="${{ inputs.release_tag }}"
           if gh release view "${TAG}" >/dev/null 2>&1; then

--- a/.github/workflows/release-validated.yml
+++ b/.github/workflows/release-validated.yml
@@ -27,7 +27,6 @@ on:
 permissions:
   contents: write
   actions: read
-  pull-requests: write
 
 jobs:
   validate-inputs:

--- a/.github/workflows/update_assets.yml
+++ b/.github/workflows/update_assets.yml
@@ -62,6 +62,7 @@ jobs:
         id: update-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           TAG="v_${VERSION}"
           gh release upload "${TAG}" assets/ddprof*.jar assets/*.so --clobber

--- a/.github/workflows/update_assets.yml
+++ b/.github/workflows/update_assets.yml
@@ -60,13 +60,9 @@ jobs:
           mv ${LIB_BASE_DIR}/linux-x64-musl/libjavaProfiler.so assets/libjavaProfiler_linux-x64-musl.so
       - name: Update release ${{ inputs.release_tag }}
         id: update-release
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: "v_${{ env.VERSION }}"
-          allowUpdates: true
-          generateReleaseNotes: true
-          omitBodyDuringUpdate: true
-          artifacts: assets/ddprof*.jar,assets/*.so
-          draft: false
-          makeLatest: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v_${VERSION}"
+          gh release upload "${TAG}" assets/ddprof*.jar assets/*.so --clobber
+          gh release edit "${TAG}" --draft=false --latest

--- a/.gitlab/build-deploy/.gitlab-ci.yml
+++ b/.gitlab/build-deploy/.gitlab-ci.yml
@@ -217,7 +217,10 @@ build-artifact:
     - job: gtest-tsan-arm64
       artifacts: false
       optional: true
-  when: on_success
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
+      when: never
+    - when: on_success
   tags: [ "arch:amd64" ]
   image: ${BUILD_IMAGE_X64}
 
@@ -250,7 +253,10 @@ deploy-artifact:
       artifacts: true
     - job: build:arm64-musl
       artifacts: true
-  when: on_success
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
+      when: never
+    - when: on_success
   tags: [ "arch:amd64" ]
   image: ${BUILD_IMAGE_X64}
 

--- a/.gitlab/scripts/prepare.sh
+++ b/.gitlab/scripts/prepare.sh
@@ -11,7 +11,10 @@ export CI_COMMIT_BRANCH
 # Allow: default branch pushes, scheduled runs, and web (manual) triggers
 # Gate: push/trigger/pipeline sources on non-default branches must have an open GitHub PR
 if [ "${CI_PIPELINE_SOURCE}" == "push" ] || [ "${CI_PIPELINE_SOURCE}" == "trigger" ] || [ "${CI_PIPELINE_SOURCE}" == "pipeline" ]; then
-  if [ -n "${CI_COMMIT_BRANCH}" ] && [ "${CI_COMMIT_BRANCH}" != "${CI_DEFAULT_BRANCH:-main}" ] && [[ ! ${CI_COMMIT_TAG} =~ ^v_[1-9][0-9]*\.[0-9]+\.[0-9]+(-SNAPSHOT)?$ ]]; then
+  if [ -n "${CI_COMMIT_BRANCH}" ] && \
+     [ "${CI_COMMIT_BRANCH}" != "${CI_DEFAULT_BRANCH:-main}" ] && \
+     [[ ! ${CI_COMMIT_TAG} =~ ^v_[1-9][0-9]*\.[0-9]+\.[0-9]+(-SNAPSHOT)?$ ]] && \
+     [[ ! ${CI_COMMIT_BRANCH} =~ ^release/[0-9]+\.[0-9]+\._$ ]]; then
     # Check if the branch has an open PR in DataDog/java-profiler
     API_RESPONSE=$(curl -sf "https://api.github.com/repos/DataDog/java-profiler/pulls?head=DataDog:${CI_COMMIT_BRANCH}&state=open&per_page=1" 2>/dev/null || echo "")
     if [ -n "${API_RESPONSE}" ] && ! echo "${API_RESPONSE}" | grep -q '"number"'; then


### PR DESCRIPTION
**What does this PR do?**:
Fix four CI breakages that blocked the 1.43.0 emergency release.

**Motivation**:
Org-level policy changes blocked external actions (`ncipollo/release-action`, `webfactory/ssh-agent`). A separate bug caused GitLab CI to cancel all release-branch pipelines and, after that was fixed, to run the deploy job on branch pushes (producing a snapshot artifact instead of a release).

**Changes**:

1. **`prepare.sh`** — exempt `release/*` branches from the PR-gate that was cancelling all jobs on release-branch pushes.

2. **`.gitlab/build-deploy/.gitlab-ci.yml`** — add `rules: never` on `release/*` branches for `build-artifact` and `deploy-artifact`. These jobs must only run from **tag** pipelines (where `CI_COMMIT_TAG` is set and `CI_COMMIT_BRANCH` is empty). Without this guard, a branch push to `release/1.43._` caused `get_version` to compute `1.43.0-release_1.43._-SNAPSHOT` and publish a snapshot to Sonatype.

3. **`gh_release.yml`** — replace `ncipollo/release-action` (blocked by org policy) and `webfactory/ssh-agent` (not needed, also blocked) with native `gh` CLI calls using idempotent create-or-update pattern.

4. **`update_assets.yml`** — replace `ncipollo/release-action` (blocked) with native `gh` CLI calls (`gh release upload` + `gh release edit --draft=false --latest`).

**Additional Notes**:
The `deploy-artifact` / `build-artifact` `rules` work correctly for tag pipelines: in a GitLab tag pipeline `CI_COMMIT_BRANCH` is empty, so the `release/*` guard does not match and the jobs run as before.

**How to test the change?**:
- Verify the next release tag push triggers a GitLab tag pipeline that runs `deploy-artifact` (no snapshot suffix in version).
- Verify `gh_release.yml` and `update_assets.yml` no longer fail at startup for new tags.
- Push a test commit to a `release/*` branch and confirm `build-artifact` / `deploy-artifact` are skipped.

**For Datadog employees**:
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]