### PR TITLE
fix(profiler): close onThreadEnd teardown race

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -103,19 +103,28 @@ void Profiler::onThreadEnd(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread) {
       _thread_filter.unregisterThread(slot_id);
       current->setFilterSlotId(-1);
     }
-    
-    ProfiledThread::release();
-  } else {
-    // ProfiledThread already cleaned up - try to get tid from JVMTI as fallback
-    tid = JVMThread::nativeThreadId(jni, thread);
-    if (tid < 0) {
-      // No ProfiledThread AND can't get tid from JVMTI - nothing we can do
-      return;
+
+    updateThreadName(jvmti, jni, thread, false);
+    // Block profiling signals around engine unregistration + TLS release to
+    // close the window where a wall-clock/CPU signal could sample a
+    // partially-torn-down thread (PROF-14674).
+    {
+      SignalBlocker blocker;
+      _cpu_engine->unregisterThread(tid);
+      _wall_engine->unregisterThread(tid);
+      ProfiledThread::release();
     }
+    return;
   }
-  
-  // These can run if we have a valid tid
-  updateThreadName(jvmti, jni, thread, false);  // false = not self
+
+  // ProfiledThread already cleaned up - try to get tid from JVMTI as fallback
+  tid = JVMThread::nativeThreadId(jni, thread);
+  if (tid < 0) {
+    // No ProfiledThread AND can't get tid from JVMTI - nothing we can do
+    return;
+  }
+
+  updateThreadName(jvmti, jni, thread, false);
   _cpu_engine->unregisterThread(tid);
   _wall_engine->unregisterThread(tid);
 }

--- a/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
@@ -175,6 +175,13 @@ TEST(ThreadTeardownSafetyTest, SignalSafeAccessorReturnsNullWithoutInit) {
 
 // ── T-05: Concurrent signals during teardown stress ──────────────────────────
 
+static std::atomic<int> g_t05_signal_count{0};
+
+static void t05_handler(int) {
+  (void)ProfiledThread::currentSignalSafe();
+  g_t05_signal_count.fetch_add(1, std::memory_order_relaxed);
+}
+
 static void *t05_worker(void *) {
   ProfiledThread::initCurrentThread();
   for (int i = 0; i < 10; ++i) {
@@ -184,14 +191,14 @@ static void *t05_worker(void *) {
   return nullptr;
 }
 
-// 20 threads × 5 rounds with signal spray; no crash expected.
-// Signal dispositions are process-wide — set SIG_IGN once from the test body
-// before spawning workers so concurrent SigGuard restore races cannot re-expose
-// the default (terminate) disposition while a worker is mid-flight.
+// 20 threads × 5 rounds with signal spray; handler invocation is verified.
+// Signal dispositions are process-wide — install once from the test body so
+// no worker can race to restore SIG_DFL (terminate) mid-flight.
 TEST(ThreadTeardownSafetyTest, ConcurrentSignalsDuringTeardownStress) {
   SigGuard gVtalrm(SIGVTALRM);
   SigGuard gProf(SIGPROF);
-  install_handler(SIGVTALRM, SIG_IGN);
+  g_t05_signal_count.store(0, std::memory_order_relaxed);
+  install_handler(SIGVTALRM, t05_handler);
   install_handler(SIGPROF, SIG_IGN);
   for (int round = 0; round < 5; ++round) {
     std::vector<pthread_t> threads(20);
@@ -202,6 +209,8 @@ TEST(ThreadTeardownSafetyTest, ConcurrentSignalsDuringTeardownStress) {
       pthread_join(tid, nullptr);
     }
   }
+  EXPECT_GT(g_t05_signal_count.load(std::memory_order_relaxed), 0)
+      << "SIGVTALRM handler must have been invoked at least once";
 }
 
 // ── T-06: SignalBlocker masks SIGPROF + SIGVTALRM and restores on exit ────────
@@ -335,6 +344,12 @@ TEST(ThreadTeardownSafetyTest, DoubleInitIsIdempotent) {
 // ── T-09: High-frequency signals during thread churn ─────────────────────────
 
 static std::atomic<bool> g_t09_stop{false};
+static std::atomic<int> g_t09_signal_count{0};
+
+static void t09_handler(int) {
+  (void)ProfiledThread::currentSignalSafe();
+  g_t09_signal_count.fetch_add(1, std::memory_order_relaxed);
+}
 
 static void *t09_injector(void *) {
   while (!g_t09_stop.load(std::memory_order_relaxed)) {
@@ -345,8 +360,6 @@ static void *t09_injector(void *) {
 }
 
 static void *t09_worker(void *) {
-  SigGuard guard(SIGVTALRM);
-  install_handler(SIGVTALRM, SIG_IGN);
   ProfiledThread::initCurrentThread();
   usleep(100);
   ProfiledThread::release();
@@ -354,10 +367,12 @@ static void *t09_worker(void *) {
 }
 
 // Mirrors DumpWhileChurningThreadsTest at native level: 100 short-lived threads
-// under continuous SIGVTALRM injection must complete without crash.
+// under continuous SIGVTALRM injection must complete without crash; handler
+// invocation is verified.
 TEST(ThreadTeardownSafetyTest, HighFrequencySignalsDuringThreadChurn) {
   SigGuard testGuard(SIGVTALRM);
-  install_handler(SIGVTALRM, SIG_IGN);
+  g_t09_signal_count.store(0, std::memory_order_relaxed);
+  install_handler(SIGVTALRM, t09_handler);
 
   g_t09_stop.store(false, std::memory_order_relaxed);
   pthread_t injector;
@@ -371,6 +386,8 @@ TEST(ThreadTeardownSafetyTest, HighFrequencySignalsDuringThreadChurn) {
 
   g_t09_stop.store(true, std::memory_order_relaxed);
   pthread_join(injector, nullptr);
+  EXPECT_GT(g_t09_signal_count.load(std::memory_order_relaxed), 0)
+      << "SIGVTALRM handler must have been invoked at least once";
 }
 
 // ── T-10: CriticalSection reentrancy guard prevents double-entry ──────────────


### PR DESCRIPTION
**What does this PR do?**:
Closes a signal-safety gap in `Profiler::onThreadEnd()` where a `SIGPROF` or `SIGVTALRM`
delivered between `ProfiledThread::release()` and `_wall_engine->unregisterThread(tid)` could
call `currentSignalSafe()` and dereference a freed `ProfiledThread` (SIGSEGV in
`JavaThread::thread_main_inner` on JDK 25.0.3).

Also upgrades T-05 and T-09 in `thread_teardown_safety_ut.cpp` from crash-only guards
(signals discarded via `SIG_IGN`) to active guards: a real handler now calls
`currentSignalSafe()` and asserts the handler was actually invoked.

**Motivation**:
SIGSEGV crash reproduced on JDK 25.0.3. The teardown sequence in
`onThreadEnd()` had a window between `ProfiledThread::release()` freeing TLS and
`unregisterThread()` removing the thread from the wall-clock filter; a profiling signal
in that window could sample the freed thread.

**Additional Notes**:
- `updateThreadName()` is kept *before* the `SignalBlocker` scope because JVMTI
  `GetThreadInfo` allocates memory. Under ASAN, JVMTI allocation acquires the same
  allocator lock a signal handler would try to acquire, causing deadlock. `ProfiledThread`
  is still live at that point, so concurrent signals are safe.
- Pattern mirrors the prior art in `libraryPatcher_linux.cpp` (`unregister_and_release`,
  PROF-14603).

**How to test the change?**:
- `thread_teardown_safety_ut` T-05 and T-09 now exercise the handler path and will fail
  (rather than silently pass) if signals are discarded or the handler is never invoked.
- Existing T-01 through T-10 cover the broader teardown contract.
- On debug builds: `./gradlew :ddprof-lib:testDebug` (Linux).

**For Datadog employees**:

- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-14674](https://datadoghq.atlassian.net/browse/PROF-14674)

[PROF-14674]: https://datadoghq.atlassian.net/browse/PROF-14674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ