### PR TITLE
fix(liveness): release jweak ref when liveness table overflows or realloc fails

### DIFF
--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -361,6 +361,9 @@ retry:
           } else {
               Log::debug("Cannot add sampled object to Liveness tracking table, "
                          "resize attempt failed, the table is overflowing");
+              _table_lock.unlock();
+              env->DeleteWeakGlobalRef(ref);
+              return;
           }
         }
 
@@ -370,6 +373,7 @@ retry:
       } else {
         Log::debug("Cannot add sampled object to Liveness tracking table, it's "
                    "overflowing");
+        env->DeleteWeakGlobalRef(ref);
       }
     }
   }

--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -363,6 +363,7 @@ retry:
                          "resize attempt failed, the table is overflowing");
               _table_lock.unlock();
               env->DeleteWeakGlobalRef(ref);
+              skipped = 0;
               return;
           }
         }
@@ -375,6 +376,8 @@ retry:
                    "overflowing");
         env->DeleteWeakGlobalRef(ref);
       }
+    } else {
+      env->DeleteWeakGlobalRef(ref);
     }
   }
   skipped = 0; // reset the subsampling skipped bytes

--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -361,10 +361,6 @@ retry:
           } else {
               Log::debug("Cannot add sampled object to Liveness tracking table, "
                          "resize attempt failed, the table is overflowing");
-              _table_lock.unlock();
-              env->DeleteWeakGlobalRef(ref);
-              skipped = 0;
-              return;
           }
         }
 


### PR DESCRIPTION
**What does this PR do?**:

Fixes three `jweak` reference leaks in `LivenessTracker::track()` when the tracking table cannot accept a new entry.

**Motivation**:

Some leftovers with potential of memory leaks in critical conditions.

**Additional Notes**:

Three paths in `livenessTracker.cpp` dropped the JNI weak global ref without calling `DeleteWeakGlobalRef`:

1. **`realloc` failure**: when resizing failed, the code fell through to `goto retry` so `cleanup_table`'s freed slots could still be used. If the retry also failed (`retried==true`, `idx==_table_cap`), the ref was silently dropped. Fixed by adding an `else { DeleteWeakGlobalRef(ref); }` on the `retried==true` path that handles final-failure cleanup.

2. **Table at max capacity (initial pass)**: the ref was silently dropped when `_table_cap == _table_max_cap`. Now deleted before exiting.

3. **Table still full after resize retry** (`retried==true`): concurrent threads can re-fill all newly-allocated slots before the retrying thread wins the CAS. This path had no cleanup. Fixed by the same `else { DeleteWeakGlobalRef(ref); }` added for case 1.

**How to test the change?**:

Code inspection — the three affected paths are straightforward error exits that previously had no `DeleteWeakGlobalRef` call.

- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-14823](https://datadoghq.atlassian.net/browse/PROF-14823)

[PROF-14823]: https://datadoghq.atlassian.net/browse/PROF-14823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ