### PR TITLE
fix(ci): exclude publish-benchmark-gh-pages from schedule pipelines

### DIFF
--- a/.gitlab/benchmarks/.gitlab-ci.yml
+++ b/.gitlab/benchmarks/.gitlab-ci.yml
@@ -89,6 +89,8 @@ publish-benchmark-gh-pages:
     - job: benchmarks-candidate-aarch64
       artifacts: true
   rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+      when: never
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH || $CI_COMMIT_BRANCH == "main"'
       when: always
   timeout: 10m


### PR DESCRIPTION
**What does this PR do?**:
Adds a `when: never` rule for `$CI_PIPELINE_SOURCE == "schedule"` to the `publish-benchmark-gh-pages` job.

**Motivation**:
The reliability (scheduled) pipeline was failing at validation time with errors like:
```
'publish-benchmark-gh-pages' job needs 'benchmarks-candidate-amd64: [cpu]' job, but it does not exist in the pipeline.
```
The `benchmarks-candidate-amd64/aarch64` jobs have no `schedule` rule so they never run in scheduled pipelines. The `publish-benchmark-gh-pages` job, however, had no schedule exclusion — causing GitLab to reject the pipeline because its `needs` dependencies were absent.

**Additional Notes**:
The benchmark jobs intentionally don't run on schedule pipelines (they run on `trigger`/`pipeline`/`web`/`push` sources). This fix aligns `publish-benchmark-gh-pages` with that constraint.

**How to test the change?**:
Trigger a scheduled (reliability) pipeline and verify it no longer errors at validation. Trigger a normal pipeline on `main` and verify `publish-benchmark-gh-pages` still runs.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!