### PR TITLE
fix(ci): skip tag/branch creation when MINOR tag already exists

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -8,6 +8,7 @@ DRYRUN=$2
 
 BRANCH=$(git branch --show-current)
 RELEASE_BRANCH=
+SKIP_RELEASE_CREATION=false
 
 BASE=$(./gradlew printVersion -Psnapshot=false | grep 'Version:' | cut -f2 -d' ')
 # BASE == 0.0.1
@@ -52,7 +53,12 @@ if [ "$TYPE" == "MINOR" ] || [ "$TYPE" == "MAJOR" ]; then
     # BASE == 1.0.0
   fi
   RELEASE_BRANCH="release/${BASE%.*}._"
-  create_annotated_tag "$BASE" "$TYPE" "$BRANCH"
+  if [ -z "$DRYRUN" ] && git rev-parse "v_${BASE}" >/dev/null 2>&1; then
+    echo "Tag v_${BASE} already exists; skipping tag and release branch creation — will only produce a version-bump PR"
+    SKIP_RELEASE_CREATION=true
+  else
+    create_annotated_tag "$BASE" "$TYPE" "$BRANCH"
+  fi
 fi
 
 if [ "$TYPE" == "PATCH" ]; then
@@ -106,7 +112,7 @@ if [ "$TYPE" == "RETAG" ]; then
   exit 0
 fi
 
-if [ "$BRANCH" != "$RELEASE_BRANCH" ]; then
+if [ "$SKIP_RELEASE_CREATION" == "false" ] && [ "$BRANCH" != "$RELEASE_BRANCH" ]; then
   git checkout -b $RELEASE_BRANCH
   if ! git diff --quiet; then
     git add build.gradle.kts


### PR DESCRIPTION
**What does this PR do?**:
In `release.sh`, when a MINOR release is triggered and the tag for the current Gradle version already exists (e.g. `v_1.43.0`), the script now skips tag and release-branch creation and falls through to only produce a version-bump PR. Previously it exited with `Tag v_X.Y.Z already exists`.

**Motivation**:
The `create-release` CI job was failing with:
```
Error: Tag v_1.43.0 already exists
```
This happens when a previous release run successfully created the tag and release branch but the version-bump PR was never merged into `main`. Re-running the release workflow hit the same wall. The fix recovers automatically: it skips what was already done and creates the missing bump PR so the next release run can proceed normally.

**Additional Notes**:
The `validate-inputs` job in `release-validated.yml` already handles this scenario correctly (it computes the next version when `ALREADY_RELEASED=true`). This PR brings `release.sh` into alignment with that logic.

The `SKIP_RELEASE_CREATION` flag guards only the MINOR/MAJOR path; PATCH and RETAG are unaffected.

**How to test the change?**:
1. Trigger the `Validated Release` workflow as a dry-run (`dry_run=true`, `release_type=minor`) on a branch where the current Gradle version's tag already exists — the step should complete without error.
2. Trigger with `dry_run=false` in the same condition — verify a bump PR is opened and no tag or release branch is (re)created.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]