### PR TITLE
fix(ci): force-push bump branch to handle pre-existing remote

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -136,7 +136,7 @@ git commit -m "[Automated] Bump dev version to ${CANDIDATE}"
 if [ -z "$DRYRUN" ]; then
   BUMP_BRANCH="automated/bump-${CANDIDATE//./-}"
   git checkout -b "$BUMP_BRANCH"
-  git push --set-upstream origin "$BUMP_BRANCH"
+  git push --force-with-lease --set-upstream origin "$BUMP_BRANCH"
   REPO="${GITHUB_REPOSITORY:-$(git remote get-url origin | sed 's|.*github.com[:/]\(.*\)\.git|\1|')}"
   BUMP_PR_URL="https://github.com/${REPO}/compare/${BRANCH}...${BUMP_BRANCH}?quick_pull=1&title=%5BAutomated%5D+Bump+dev+version+to+${CANDIDATE}"
   echo "BUMP_PR_URL=$BUMP_PR_URL" >> "${GITHUB_OUTPUT:-/dev/null}"


### PR DESCRIPTION
**What does this PR do?**:
Changes the bump-branch push in `release.sh` from a plain push to `--force-with-lease`, so it succeeds when the remote branch already exists from a previous partial release run.

**Motivation**:
After the fix in #561 (skip tag/branch creation when the tag already exists), the `create-release` job now advances to the version-bump step correctly. However, the bump branch (e.g. `automated/bump-1-44-0`) may already exist on the remote from the previous run, causing a non-fast-forward rejection:

```
! [rejected]  automated/bump-1-44-0 -> automated/bump-1-44-0 (non-fast-forward)
```

`--force-with-lease` is safe here: the branch is always machine-generated with no human commits, and the lease ensures we don't clobber unexpected pushes from a third party.

**Additional Notes**:
This is a follow-up to #561, completing the recovery path for a release where the previous run left a stale bump branch.

**How to test the change?**:
Trigger the `Validated Release` workflow (`release_type=minor`, `dry_run=false`) when both the version tag and the bump branch already exist on the remote — the job should complete without error.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]