### PR TITLE
Fix duplicated cookies

### DIFF
--- a/ddprof-lib/src/main/cpp/signalCookie.cpp
+++ b/ddprof-lib/src/main/cpp/signalCookie.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "signalCookie.h"
 
 namespace SignalCookie {

--- a/ddprof-lib/src/main/cpp/signalCookie.cpp
+++ b/ddprof-lib/src/main/cpp/signalCookie.cpp
@@ -1,0 +1,17 @@
+#include "signalCookie.h"
+
+namespace SignalCookie {
+    namespace detail {
+        // Place tags in a named section on Linux to prevent LTO from merging
+        // or reordering them across TUs (their addresses must be unique per DSO).
+#ifdef __linux__
+        [[gnu::section(".data.signal_cookie")]] char cpu_tag;
+        [[gnu::section(".data.signal_cookie")]] char wallclock_tag;
+#else
+        char cpu_tag;
+        char wallclock_tag;
+#endif
+    }
+    void* cpu()       { return &detail::cpu_tag; }
+    void* wallclock() { return &detail::wallclock_tag; }
+}

--- a/ddprof-lib/src/main/cpp/signalCookie.h
+++ b/ddprof-lib/src/main/cpp/signalCookie.h
@@ -21,19 +21,8 @@
 // forged by an unrelated in-process sender without reading our symbols, and
 // never collide with legitimate user-space pointers in third-party code.
 namespace SignalCookie {
-    namespace detail {
-        // Place tags in a named section on Linux to prevent LTO from merging
-        // or reordering them across TUs (their addresses must be unique per DSO).
-#ifdef __linux__
-        [[gnu::section(".data.signal_cookie")]] inline char cpu_tag;
-        [[gnu::section(".data.signal_cookie")]] inline char wallclock_tag;
-#else
-        inline char cpu_tag;
-        inline char wallclock_tag;
-#endif
-    }
-    inline void* cpu()       { return &detail::cpu_tag; }
-    inline void* wallclock() { return &detail::wallclock_tag; }
+    void* cpu();
+    void* wallclock();
 }
 
 #endif // SIGNAL_COOKIE_H


### PR DESCRIPTION
**What does this PR do?**:
Make signal cookie sentinels unique.

**Motivation**:
The sentinels should be unique, but each compilation unit may get own version - they are no longer unique.

**Additional Notes**:
Sentinels are defined in header file, every file that includes it having its own copies. Therefore, they are not unique.

**How to test the change?**:
Compilation failed on ubuntu - complaining multiple definition of the variables. The patch fixes the compilation errors.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-14835](https://datadoghq.atlassian.net/browse/PROF-14835)

Unsure? Have a question? Request a review!


[PROF-14835]: https://datadoghq.atlassian.net/browse/PROF-14835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ