### PR TITLE
fix(wallclock): add signal-origin guard to WallClockJvmti

### DIFF
--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -60,6 +60,7 @@ void WallClockASGCT::sharedSignalHandler(int signo, siginfo_t *siginfo,
   // would otherwise drive our wallclock sampling path.
   if (!OS::shouldProcessSignal(siginfo, SI_QUEUE, SignalCookie::wallclock())) {
     Counters::increment(WALLCLOCK_SIGNAL_FOREIGN);
+    SIGNAL_HANDLER_GUARD_RELEASE();
     OS::forwardForeignSignal(signo, siginfo, ucontext);
     return;
   }
@@ -239,6 +240,7 @@ void WallClockJvmti::sharedSignalHandler(int signo, siginfo_t *siginfo,
   // external sigqueue driving the JVMTI RequestStackTrace path.
   if (!OS::shouldProcessSignal(siginfo, SI_QUEUE, SignalCookie::wallclock())) {
     Counters::increment(WALLCLOCK_SIGNAL_FOREIGN);
+    SIGNAL_HANDLER_GUARD_RELEASE();
     OS::forwardForeignSignal(signo, siginfo, ucontext);
     return;
   }

--- a/ddprof-lib/src/main/cpp/wallClock.cpp
+++ b/ddprof-lib/src/main/cpp/wallClock.cpp
@@ -234,6 +234,16 @@ void WallClockASGCT::timerLoop() {
 void WallClockJvmti::sharedSignalHandler(int signo, siginfo_t *siginfo,
                                          void *ucontext) {
   SIGNAL_HANDLER_GUARD();
+  // Reject any SIGVTALRM that did not originate from our rt_tgsigqueueinfo
+  // send (mirrors WallClockASGCT). Defends against stray in-process tgkill or
+  // external sigqueue driving the JVMTI RequestStackTrace path.
+  if (!OS::shouldProcessSignal(siginfo, SI_QUEUE, SignalCookie::wallclock())) {
+    Counters::increment(WALLCLOCK_SIGNAL_FOREIGN);
+    OS::forwardForeignSignal(signo, siginfo, ucontext);
+    return;
+  }
+  Counters::increment(WALLCLOCK_SIGNAL_OWN);
+
   WallClockJvmti *engine =
       reinterpret_cast<WallClockJvmti *>(Profiler::instance()->wallEngine());
   if (signo == SIGVTALRM) {
@@ -284,6 +294,7 @@ void WallClockJvmti::signalHandler(int signo, siginfo_t *siginfo,
 void WallClockJvmti::initialize(Arguments &args) {
   // Caller must have verified VM::canRequestStackTrace() before selecting
   // this engine; see Profiler::selectWallEngine().
+  OS::primeSignalOriginCheck();
   OS::installSignalHandler(SIGVTALRM, sharedSignalHandler);
 }
 
@@ -308,7 +319,7 @@ void WallClockJvmti::timerLoop() {
 
   auto sampleThreads = [&](int tid, int &num_failures,
                            int &threads_already_exited, int &permission_denied) {
-    if (!OS::sendSignalToThread(tid, SIGVTALRM)) {
+    if (!OS::sendSignalWithCookie(tid, SIGVTALRM, SignalCookie::wallclock())) {
       num_failures++;
       if (errno != 0) {
         if (errno == ESRCH) {

--- a/ddprof-lib/src/test/cpp/signalOrigin_ut.cpp
+++ b/ddprof-lib/src/test/cpp/signalOrigin_ut.cpp
@@ -333,6 +333,32 @@ TEST_F(SignalOriginTest, ResetForTestingClearsOldactionCache) {
     sigaction(SIGUSR1, &saved, nullptr);
 }
 
+// -------- WallclockGuardContract: predicate contract for WallClockJvmti guard --------
+//
+// WallClockJvmti::sharedSignalHandler gates on
+//   OS::shouldProcessSignal(siginfo, SI_QUEUE, SignalCookie::wallclock())
+// These cases cover the three branches the guard must handle: own send,
+// bare tgkill/kill (no cookie), and a queued signal with a foreign cookie.
+
+TEST_F(SignalOriginTest, WallclockGuardContract_OwnSignalAccepted) {
+    siginfo_t si = makeSiginfo(SI_QUEUE, SignalCookie::wallclock());
+    EXPECT_TRUE(OS::shouldProcessSignal(&si, SI_QUEUE, SignalCookie::wallclock()));
+}
+
+TEST_F(SignalOriginTest, WallclockGuardContract_BareKillRejected) {
+    // tgkill/pthread_kill delivers SI_TKILL; kill/raise delivers SI_USER.
+    for (int code : {SI_TKILL, SI_USER}) {
+        siginfo_t si = makeSiginfo(code, nullptr);
+        EXPECT_FALSE(OS::shouldProcessSignal(&si, SI_QUEUE, SignalCookie::wallclock()))
+            << "bare signal with si_code " << code << " must be rejected";
+    }
+}
+
+TEST_F(SignalOriginTest, WallclockGuardContract_ForeignCookieRejected) {
+    siginfo_t si = makeSiginfo(SI_QUEUE, (void*)0xF00D);
+    EXPECT_FALSE(OS::shouldProcessSignal(&si, SI_QUEUE, SignalCookie::wallclock()));
+}
+
 TEST_F(SignalOriginTest, ForwardAppliesSigmaskWhenEnabled) {
     // Verify that the slow path (DDPROF_FORWARD_APPLY_SIGMASK=1) still
     // chains to the previous SA_SIGINFO handler correctly.

--- a/ddprof-lib/src/test/cpp/signalOrigin_ut.cpp
+++ b/ddprof-lib/src/test/cpp/signalOrigin_ut.cpp
@@ -12,8 +12,10 @@
 #include <ctime>
 #include <string>
 
+#include "guards.h"
 #include "os.h"
 #include "signalCookie.h"
+#include "thread.h"
 
 #ifdef __linux__
 
@@ -357,6 +359,28 @@ TEST_F(SignalOriginTest, WallclockGuardContract_BareKillRejected) {
 TEST_F(SignalOriginTest, WallclockGuardContract_ForeignCookieRejected) {
     siginfo_t si = makeSiginfo(SI_QUEUE, (void*)0xF00D);
     EXPECT_FALSE(OS::shouldProcessSignal(&si, SI_QUEUE, SignalCookie::wallclock()));
+}
+
+// Regression test for the fix: when a foreign signal is handled,
+// SIGNAL_HANDLER_GUARD_RELEASE() must be called before forwardForeignSignal so
+// that a chained handler escaping via siglongjmp cannot leave _signal_depth
+// permanently incremented.  Verifies the SIGNAL_HANDLER_GUARD / release
+// contract directly: depth is 0 after an early release, and the destructor is
+// a no-op.
+TEST_F(SignalOriginTest, WallclockGuardContract_ForeignSignalReleasesGuard) {
+    ProfiledThread::initCurrentThread();
+    EXPECT_EQ(0, getInSignalDepth());
+    {
+        SIGNAL_HANDLER_GUARD();
+        EXPECT_EQ(1, getInSignalDepth());
+        // Mirrors the fix: release before forwarding so a non-returning
+        // chained handler cannot leave depth > 0.
+        SIGNAL_HANDLER_GUARD_RELEASE();
+        EXPECT_EQ(0, getInSignalDepth());
+        // Destructor runs here; must not double-decrement.
+    }
+    EXPECT_EQ(0, getInSignalDepth());
+    ProfiledThread::release();
 }
 
 TEST_F(SignalOriginTest, ForwardAppliesSigmaskWhenEnabled) {


### PR DESCRIPTION
**What does this PR do?**:
Port the signal-origin defence from `WallClockASGCT` to `WallClockJvmti`. Without this, any foreign SIGVTALRM (debugger, in-process `tgkill`, external `sigqueue`) was accepted unconditionally by the JVMTI handler, driving `VM::requestStackTrace` and producing spurious `jdk.ExecutionSample` events.

Three changes in `wallClock.cpp`, all mirroring `WallClockASGCT` exactly:
- **`sharedSignalHandler`**: add `OS::shouldProcessSignal` gate before engine resolution; increment `WALLCLOCK_SIGNAL_FOREIGN`/`_OWN` on reject/accept.
- **`initialize`**: call `OS::primeSignalOriginCheck()` so the `DDPROF_SIGNAL_ORIGIN_CHECK` env-var override is picked up when JVMTI is the selected engine (the ASGCT `initialize` never runs in that case).
- **`timerLoop`**: switch from `sendSignalToThread` to `sendSignalWithCookie` so our own sends carry the wallclock cookie the new gate requires.

**Motivation**:
The original signal-origin design doc (`doc/plans/2026-04-21-signal-origin-validation.md`, step 4) explicitly scoped the gate to both `WallClockASGCT::sharedSignalHandler` and the JVMTI variant. The JVMTI half was never implemented. Tracked in PROF-14753.

**Additional Notes**:
- macOS is unaffected: `OS::signalOriginCheckEnabled()` returns false there, making the guard a no-op.
- Kill-switch: `DDPROF_SIGNAL_ORIGIN_CHECK=0` disables the gate at runtime.
- The ticket's proposed snippet had two inaccuracies (missing `WALLCLOCK_SIGNAL_OWN` increment; reversed forward/increment order). Both corrected to match ASGCT.
- Stale line numbers in the ticket (L323/L299/L250) — actual locations in current code are L311/L284/L234.

**How to test the change?**:
Extended `ddprof-lib/src/test/cpp/signalOrigin_ut.cpp` with three `WallclockGuardContract` cases (Linux-only, `#ifdef __linux__`):

| Test | Assertion |
|---|---|
| `WallclockGuardContract_OwnSignalAccepted` | `SI_QUEUE` + `SignalCookie::wallclock()` → accepted |
| `WallclockGuardContract_BareKillRejected` | `SI_TKILL`/`SI_USER`, no cookie → rejected |
| `WallclockGuardContract_ForeignCookieRejected` | `SI_QUEUE` + foreign cookie → rejected |

19/19 pass on Linux/aarch64 glibc (Docker via `utils/run-docker-tests.sh`):
```
[==========] Running 19 tests from 1 test suite.
[ RUN      ] SignalOriginTest.WallclockGuardContract_OwnSignalAccepted
[       OK ] SignalOriginTest.WallclockGuardContract_OwnSignalAccepted (0 ms)
[ RUN      ] SignalOriginTest.WallclockGuardContract_BareKillRejected
[       OK ] SignalOriginTest.WallclockGuardContract_BareKillRejected (0 ms)
[ RUN      ] SignalOriginTest.WallclockGuardContract_ForeignCookieRejected
[       OK ] SignalOriginTest.WallclockGuardContract_ForeignCookieRejected (0 ms)
[  PASSED  ] 19 tests.
```

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-14753](https://datadoghq.atlassian.net/browse/PROF-14753)

[PROF-14753]: https://datadoghq.atlassian.net/browse/PROF-14753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ