### PR TITLE
Refactor argument matching with case insensitive string comparison

### DIFF
--- a/ddprof-lib/src/main/cpp/arguments.cpp
+++ b/ddprof-lib/src/main/cpp/arguments.cpp
@@ -440,7 +440,7 @@ const char *Arguments::file() {
 // Should match statically computed HASH(arg)
 long long Arguments::hash(const char *arg) {
   long long h = 0;
-  for (int shift = 0; *arg != 0; shift += 5) {
+  for (int shift = 0; *arg != 0 && shift < 60; shift += 5) {
     h |= (*arg++ & 31LL) << shift;
   }
   return h;

--- a/ddprof-lib/src/main/cpp/arguments.cpp
+++ b/ddprof-lib/src/main/cpp/arguments.cpp
@@ -48,7 +48,7 @@ static const Multiplier UNIVERSAL[] = {
 
 #define CASE(s)                                                                \
   }                                                                            \
-  else if (strcmp(arg, s) == 0) {
+  else if (strcasecmp(arg, s) == 0) {
 
 #define DEFAULT()                                                              \
   }                                                                            \

--- a/ddprof-lib/src/main/cpp/arguments.cpp
+++ b/ddprof-lib/src/main/cpp/arguments.cpp
@@ -42,21 +42,13 @@ static const Multiplier UNIVERSAL[] = {
     {'n', 1}, {'u', 1000}, {'m', 1000000},    {'s', 1000000000},
     {'b', 1}, {'k', 1024}, {'g', 1073741824}, {0, 0}};
 
-// Statically compute hash code of a string containing up to 12 [a-z] letters
-#define HASH(s)                                                                \
-  ((s[0] & 31LL) | (s[1] & 31LL) << 5 | (s[2] & 31LL) << 10 |                  \
-   (s[3] & 31LL) << 15 | (s[4] & 31LL) << 20 | (s[5] & 31LL) << 25 |           \
-   (s[6] & 31LL) << 30 | (s[7] & 31LL) << 35 | (s[8] & 31LL) << 40 |           \
-   (s[9] & 31LL) << 45 | (s[10] & 31LL) << 50 | (s[11] & 31LL) << 55)
-
 // Simulate switch statement over string hashes
 #define SWITCH(arg)                                                            \
-  long long arg_hash = hash(arg);                                              \
   if (0)
 
 #define CASE(s)                                                                \
   }                                                                            \
-  else if (arg_hash == HASH(s "            ") && strcmp(arg, s) == 0) {
+  else if (strcmp(arg, s) == 0) {
 
 #define DEFAULT()                                                              \
   }                                                                            \
@@ -435,15 +427,6 @@ const char *Arguments::file() {
     return expandFilePattern(_file);
   }
   return _file;
-}
-
-// Should match statically computed HASH(arg)
-long long Arguments::hash(const char *arg) {
-  long long h = 0;
-  for (int shift = 0; *arg != 0 && shift < 60; shift += 5) {
-    h |= (*arg++ & 31LL) << shift;
-  }
-  return h;
 }
 
 // Expands the following patterns:

--- a/ddprof-lib/src/main/cpp/arguments.cpp
+++ b/ddprof-lib/src/main/cpp/arguments.cpp
@@ -56,7 +56,7 @@ static const Multiplier UNIVERSAL[] = {
 
 #define CASE(s)                                                                \
   }                                                                            \
-  else if (arg_hash == HASH(s "            ")) {
+  else if (arg_hash == HASH(s "            ") && strcmp(arg, s) == 0) {
 
 #define DEFAULT()                                                              \
   }                                                                            \

--- a/ddprof-lib/src/main/cpp/arguments.h
+++ b/ddprof-lib/src/main/cpp/arguments.h
@@ -152,7 +152,6 @@ private:
   bool _shared;
   bool _persistent;
   const char *expandFilePattern(const char *pattern);
-  static long long hash(const char *arg);
   static long parseUnits(const char *str, const Multiplier *multipliers);
   static bool isCpuEvent(const char *event) {
     // event == NULL will default to EVENT_CPU


### PR DESCRIPTION
**What does this PR do?**:
Shifting long long value more than 63 bits is UB, break out the loop before `shift` reaches invalid value.

Besides, the fix matching the HASH macro's highest term s[11] << 55. 

**Motivation**:
Improve stability and correctness.

**Additional Notes**:

**How to test the change?**:
`fuzz_arguments` test now passes. 

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-14936](https://datadoghq.atlassian.net/browse/PROF-14936)

Unsure? Have a question? Request a review!


[PROF-14936]: https://datadoghq.atlassian.net/browse/PROF-14936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ