### PR TITLE
feat(fuzz): add GitLab fuzzing infra setup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,7 @@ stages:
   - integration-test
   - reliability
   - benchmarks
+  - fuzz
   - notify
 
 # Detects newer images in registry and creates GitHub PR with updates
@@ -162,3 +163,4 @@ include:
   - local: .gitlab/reliability/.gitlab-ci.yml
   - local: .gitlab/dd-trace-integration/.gitlab-ci.yml
   - local: .gitlab/sanitizer-tests/.gitlab-ci.yml
+  - local: .gitlab/fuzzing/.gitlab-ci.yml

--- a/.gitlab/fuzzing/.gitlab-ci.yml
+++ b/.gitlab/fuzzing/.gitlab-ci.yml
@@ -1,0 +1,32 @@
+variables:
+  FUZZ_IMAGE: registry.ddbuild.io/java-profiler-fuzz
+  FUZZYDOG_VERSION: "0.28.0"
+  BUILD_IMAGE: ${BUILD_IMAGE_X64}
+
+fuzz_infra:
+  needs: []
+  extends: .retry-config
+  image: registry.ddbuild.io/images/docker:27.3.1
+  tags: ["arch:amd64"]
+  stage: fuzz
+  timeout: 30m
+  allow_failure: true
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
+  rules:
+    - if: $NIGHTLY_BUILD == "true"
+    - when: manual
+  before_script:
+    - apt-get update -qq && apt-get install -y -qq curl unzip jq
+    - >-
+      curl -fsSL "https://binaries.ddbuild.io/fuzzing/fuzzydog/${FUZZYDOG_VERSION}/fuzzydog-tar.tar.gz"
+      | tar -xz -C /usr/local/bin fuzzydog-linux-amd64 &&
+      mv /usr/local/bin/fuzzydog-linux-amd64 /usr/local/bin/fuzzydog
+    - >-
+      curl -fsSL "https://releases.hashicorp.com/vault/1.21.1/vault_1.21.1_linux_amd64.zip"
+      -o /tmp/vault.zip &&
+      unzip -o /tmp/vault.zip -d /usr/local/bin vault &&
+      rm /tmp/vault.zip
+  script:
+    - .gitlab/scripts/fuzz_infra.sh

--- a/.gitlab/scripts/fuzz_infra.sh
+++ b/.gitlab/scripts/fuzz_infra.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FUZZ_IMAGE="${FUZZ_IMAGE:-registry.ddbuild.io/java-profiler-fuzz}"
+GIT_SHA="${CI_COMMIT_SHORT_SHA:-$(git rev-parse --short HEAD)}"
+
+export FUZZYDOG_AUTH_TOKEN
+FUZZYDOG_AUTH_TOKEN=$(vault read -field=token identity/oidc/token/security-fuzzing-platform)
+
+# Build and push the compiled image (all fuzz binaries + fuzzydog)
+docker buildx build \
+    --target build \
+    -f docker/Dockerfile.fuzz \
+    --build-arg "BUILD_IMAGE=${BUILD_IMAGE}" \
+    --build-arg "FUZZYDOG_VERSION=${FUZZYDOG_VERSION}" \
+    -t "${FUZZ_IMAGE}:${GIT_SHA}" \
+    --push \
+    --metadata-file compiled-metadata.json \
+    .
+
+COMPILED_DIGEST=$(jq -r '."containerimage.digest"' compiled-metadata.json)
+
+# Extract binary list from the compiled image
+mkdir -p manifest-out
+docker run --rm "${FUZZ_IMAGE}@${COMPILED_DIGEST}" cat /fuzz_binaries.txt > manifest-out/fuzz_binaries.txt
+
+# For each binary: build thin per-binary image, sign, replicate, register
+while IFS= read -r binary; do
+    [ -z "${binary}" ] && continue
+    IMAGE_REF="${FUZZ_IMAGE}:${GIT_SHA}-${binary}"
+
+    printf 'FROM %s@%s\nENV FUZZ_APP=%s\nENV FUZZ_BUILD_ID=%s\n' \
+        "${FUZZ_IMAGE}" "${COMPILED_DIGEST}" "${binary}" "${GIT_SHA}" \
+        | docker buildx build - \
+            -t "${IMAGE_REF}" \
+            --push \
+            --metadata-file "meta-${binary}.json"
+
+    ddsign sign "${IMAGE_REF}" --docker-metadata-file "meta-${binary}.json"
+    ddsign replicate --to us1.ddbuild.io \
+        "${FUZZ_IMAGE}@$(jq -r '."containerimage.digest"' "meta-${binary}.json")"
+
+    fuzzydog fuzzer create "${binary}" \
+        --image "${IMAGE_REF}" \
+        --version "${GIT_SHA}" \
+        --type libfuzzer \
+        --team profiling \
+        --slack-channel profiling-java \
+        --repository-url https://github.com/DataDog/java-profiler
+done < manifest-out/fuzz_binaries.txt

--- a/docker/Dockerfile.fuzz
+++ b/docker/Dockerfile.fuzz
@@ -1,0 +1,34 @@
+ARG BUILD_IMAGE
+
+FROM ${BUILD_IMAGE} AS build
+
+ARG FUZZYDOG_VERSION=0.27.1
+
+ENV JAVA_HOME=/root/.sdkman/candidates/java/current
+ENV PATH=$JAVA_HOME/bin:$PATH
+
+WORKDIR /src
+COPY . .
+
+RUN ./gradlew :ddprof-lib:fuzz:linkFuzz_dwarf \
+              :ddprof-lib:fuzz:linkFuzz_arguments \
+              :ddprof-lib:fuzz:linkFuzz_buffer \
+              :ddprof-lib:fuzz:linkFuzz_elf \
+              :ddprof-lib:fuzz:linkFuzz_stringDictionary \
+              --no-daemon
+
+RUN mkdir -p /fuzzer/builds && \
+    find ddprof-lib/fuzz/build/bin/fuzz -maxdepth 2 -type f -executable \
+        -exec cp {} /fuzzer/builds/ \; && \
+    ls /fuzzer/builds/ > /fuzz_binaries.txt
+
+RUN curl -fsSL "https://binaries.ddbuild.io/fuzzing/fuzzydog/${FUZZYDOG_VERSION}/fuzzydog-tar.tar.gz" \
+    | tar -xz -C /usr/local/bin fuzzydog-linux-amd64 && \
+    mv /usr/local/bin/fuzzydog-linux-amd64 /usr/local/bin/fuzzydog
+
+CMD fuzzydog fuzzer run "$FUZZ_APP" "$FUZZ_BUILD_ID" \
+    --type libfuzzer \
+    --team profiling \
+    --build-path /fuzzer/builds/ \
+    --skip-dl-build \
+    --repository-url https://github.com/DataDog/java-profiler


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->
This adds the internal fuzzing infra as a nightly run for all the fuzz test declared in this repository (so far).

**Motivation**:
<!-- What inspired you to submit this pull request? -->

Make sure the fuzz tests can run regularly!

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

There's some improvement to be made in the image builds (notably the pull of vault and fuzzydog, that could be set in the image). I believe it's acceptable as this is intended to be run once a day for now. Once we estabilishe this is working as intended, we can swap the base image to contain these 2 binaries.

It's a non blocking job because:
- It's possible that the fuzz test finds a bug that is unrelated to the latest commit
- It's made to be run nightly or manually on demand

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Go to gitlab and start this pipeline manually 

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
