### PR TITLE
fix: switch container runtime to podman

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,37 +167,40 @@ Release builds automatically extract debug symbols via `NativeLinkTask`, reducin
 
 **See:** `build-logic/README.md` for full documentation
 
-### Docker-based Testing (Recommended for ASan/Non-Local Environments)
+### Container-based Testing (Recommended for ASan/Non-Local Environments)
 
-**When to use**: For ASan testing, cross-architecture testing (aarch64), different libc variants (musl), or reproducing CI environment issues.
+**When to use**: For ASan testing, cross-architecture testing (aarch64), different libc variants (musl), or reproducing CI environment issues. The script defaults to Podman; set `CONTAINER_RUNTIME=docker` to use Docker.
 
 ```bash
 # ASan tests on aarch64 Linux
-./utils/run-docker-tests.sh --arch=aarch64 --config=asan --libc=glibc --jdk=21
+./utils/run-containers-tests.sh --arch=aarch64 --config=asan --libc=glibc --jdk=21
 
 # Run specific test pattern
-./utils/run-docker-tests.sh --arch=aarch64 --tests="*SpecificTest*"
+./utils/run-containers-tests.sh --arch=aarch64 --tests="*SpecificTest*"
 
 # Enable C++ gtests
-./utils/run-docker-tests.sh --arch=aarch64 --gtest
+./utils/run-containers-tests.sh --arch=aarch64 --gtest
+
+# Run one C++ gtest binary
+./utils/run-containers-tests.sh --config=asan --gtest-task=elfparser_ut
 
 # Drop to shell for debugging
-./utils/run-docker-tests.sh --arch=aarch64 --shell
+./utils/run-containers-tests.sh --arch=aarch64 --shell
 
 # Test with musl libc
-./utils/run-docker-tests.sh --libc=musl --jdk=21
+./utils/run-containers-tests.sh --libc=musl --jdk=21
 
 # Test with OpenJ9
-./utils/run-docker-tests.sh --jdk=21-j9
+./utils/run-containers-tests.sh --jdk=21-j9
 
 # Use mounted repo (faster, but may have stale artifacts)
-./utils/run-docker-tests.sh --mount
+./utils/run-containers-tests.sh --mount
 
-# Rebuild Docker images
-./utils/run-docker-tests.sh --rebuild
+# Rebuild container images
+./utils/run-containers-tests.sh --rebuild
 ```
 
-**Note**: The Docker script supports `--config=debug|release|asan|tsan`. Use this for cross-architecture testing and reproducing CI environments. For local development, use `./gradlew testAsan` directly.
+**Note**: The container script supports `--config=debug|release|asan|tsan`. Use this for cross-architecture testing and reproducing CI environments. For local development, use `./gradlew testAsan` directly.
 
 ### Build Options
 ```bash
@@ -650,7 +653,7 @@ When upgrading the build JDK (e.g., from JDK 21 to JDK 25), update these files:
 | `README.md` | Update "Prerequisites" section with new JDK version |
 | `.github/actions/setup_cached_java/action.yml` | Change `build_jdk=jdk21` to new version (line ~25) |
 | `.github/workflows/ci.yml` | Update `java-version` in `check-formatting` job's Setup Java step |
-| `utils/run-docker-tests.sh` | Update `BUILD_JDK_VERSION="21"` constant |
+| `utils/run-containers-tests.sh` | Update `BUILD_JDK_VERSION="21"` constant |
 | `build-logic/.../JavaConventionsPlugin.kt` | Update documentation comment if minimum changes |
 
 ### Files to Modify When Changing Target JDK Version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ Release builds automatically extract debug symbols via `NativeLinkTask`, reducin
 
 ### Container-based Testing (Recommended for ASan/Non-Local Environments)
 
-**When to use**: For ASan testing, cross-architecture testing (aarch64), different libc variants (musl), or reproducing CI environment issues. The script defaults to Podman; set `CONTAINER_RUNTIME=docker` to use Docker.
+**When to use**: For ASan testing, cross-architecture testing (aarch64), different libc variants (musl), or reproducing CI environment issues. The script defaults to Podman; use `--container=docker` to use Docker.
 
 ```bash
 # ASan tests on aarch64 Linux
@@ -183,6 +183,9 @@ Release builds automatically extract debug symbols via `NativeLinkTask`, reducin
 
 # Run one C++ gtest binary
 ./utils/run-containers-tests.sh --config=asan --gtest-task=elfparser_ut
+
+# Use Docker instead of the default Podman runtime
+./utils/run-containers-tests.sh --container=docker --libc=glibc --jdk=21
 
 # Drop to shell for debugging
 ./utils/run-containers-tests.sh --arch=aarch64 --shell

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The project includes both Java and C++ unit tests. You can run them using:
 `JAVA_TEST_HOME=<path to test JDK> ./gradlew testDebug`
 
 ### Container-Based Testing (musl/glibc)
-Run tests in containers to test on different libc implementations. The script defaults to Podman; set `CONTAINER_RUNTIME=docker` to use Docker instead. Uses two-level container image caching for fast subsequent runs:
+Run tests in containers to test on different libc implementations. The script defaults to Podman; use `--container=docker` to use Docker instead. Uses two-level container image caching for fast subsequent runs:
 1. **Base image** (`java-profiler-base:<libc>-<arch>`) - OS with all build tools + sanitizers
 2. **JDK image** (`java-profiler-test:<libc>-jdk<version>-<arch>`) - Adds JDK + Gradle
 
@@ -161,7 +161,7 @@ By default, the script clones the repository at the current commit for clean bui
 ./utils/run-containers-tests.sh --libc=glibc --config=asan --gtest-task=elfparser_ut
 
 # Use Docker instead of the default Podman runtime
-CONTAINER_RUNTIME=docker ./utils/run-containers-tests.sh --libc=glibc --jdk=21
+./utils/run-containers-tests.sh --container=docker --libc=glibc --jdk=21
 
 # Force rebuild of all cached container images
 ./utils/run-containers-tests.sh --libc=musl --jdk=21 --rebuild
@@ -178,6 +178,7 @@ Supported options:
 - `--jdk=8|11|17|21|25|8-j9|11-j9|17-j9|21-j9|17-graal|21-graal|25-graal` (default: 21)
 - `--arch=x64|aarch64` (default: auto-detect)
 - `--config=debug|release|asan|tsan` (default: debug)
+- `--container=podman|docker` (default: podman)
 - `--tests="TestPattern"`
 - `--gtest` (enable C++ gtests, disabled by default for faster runs)
 - `--gtest-task=Task` (run one C++ gtest task; accepts `elfparser_ut` or a full task path like `:ddprof-lib:gtestAsan_elfparser_ut`)

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ The project includes both Java and C++ unit tests. You can run them using:
 ### Cross-JDK Testing
 `JAVA_TEST_HOME=<path to test JDK> ./gradlew testDebug`
 
-### Docker-Based Testing (musl/glibc)
-Run tests in Docker containers to test on different libc implementations. Uses two-level Docker image caching for fast subsequent runs:
+### Container-Based Testing (musl/glibc)
+Run tests in containers to test on different libc implementations. The script defaults to Podman; set `CONTAINER_RUNTIME=docker` to use Docker instead. Uses two-level container image caching for fast subsequent runs:
 1. **Base image** (`java-profiler-base:<libc>-<arch>`) - OS with all build tools + sanitizers
 2. **JDK image** (`java-profiler-test:<libc>-jdk<version>-<arch>`) - Adds JDK + Gradle
 
@@ -143,40 +143,47 @@ By default, the script clones the repository at the current commit for clean bui
 
 ```bash
 # Run specific test on musl (Alpine) with JDK 21 (clone mode - clean build)
-./utils/run-docker-tests.sh --libc=musl --jdk=21 --tests="CTimerGCStressTest"
+./utils/run-containers-tests.sh --libc=musl --jdk=21 --tests="CTimerGCStressTest"
 
 # Run all tests on glibc (Ubuntu) with JDK 17
-./utils/run-docker-tests.sh --libc=glibc --jdk=17
+./utils/run-containers-tests.sh --libc=glibc --jdk=17
 
-# Run tests on aarch64 architecture (requires Docker with multi-arch support)
-./utils/run-docker-tests.sh --libc=musl --jdk=21 --arch=aarch64
+# Run tests on aarch64 architecture (requires container runtime with multi-arch support)
+./utils/run-containers-tests.sh --libc=musl --jdk=21 --arch=aarch64
 
 # Mount local repo for faster iteration (may have stale artifacts)
-./utils/run-docker-tests.sh --libc=musl --jdk=21 --mount --tests="MyTest"
+./utils/run-containers-tests.sh --libc=musl --jdk=21 --mount --tests="MyTest"
 
 # Drop to interactive shell in musl container
-./utils/run-docker-tests.sh --libc=musl --jdk=21 --shell
+./utils/run-containers-tests.sh --libc=musl --jdk=21 --shell
 
-# Force rebuild of all cached Docker images
-./utils/run-docker-tests.sh --libc=musl --jdk=21 --rebuild
+# Run one C++ gtest binary only
+./utils/run-containers-tests.sh --libc=glibc --config=asan --gtest-task=elfparser_ut
+
+# Use Docker instead of the default Podman runtime
+CONTAINER_RUNTIME=docker ./utils/run-containers-tests.sh --libc=glibc --jdk=21
+
+# Force rebuild of all cached container images
+./utils/run-containers-tests.sh --libc=musl --jdk=21 --rebuild
 
 # Force rebuild of base image only (useful after Alpine/Ubuntu updates)
-./utils/run-docker-tests.sh --libc=musl --rebuild-base
+./utils/run-containers-tests.sh --libc=musl --rebuild-base
 
 # Show options
-./utils/run-docker-tests.sh --help
+./utils/run-containers-tests.sh --help
 ```
 
 Supported options:
 - `--libc=glibc|musl` (default: glibc)
-- `--jdk=8|11|17|21|25` (default: 21)
+- `--jdk=8|11|17|21|25|8-j9|11-j9|17-j9|21-j9|17-graal|21-graal|25-graal` (default: 21)
 - `--arch=x64|aarch64` (default: auto-detect)
-- `--config=debug|release` (default: debug)
+- `--config=debug|release|asan|tsan` (default: debug)
 - `--tests="TestPattern"`
 - `--gtest` (enable C++ gtests, disabled by default for faster runs)
+- `--gtest-task=Task` (run one C++ gtest task; accepts `elfparser_ut` or a full task path like `:ddprof-lib:gtestAsan_elfparser_ut`)
 - `--shell` (interactive shell instead of running tests)
 - `--mount` (mount local repo instead of cloning - faster but may have stale artifacts)
-- `--rebuild` (force rebuild of all Docker images)
+- `--rebuild` (force rebuild of all container images)
 - `--rebuild-base` (force rebuild of base image only)
 
 ## Unwinding Validation Tool
@@ -442,7 +449,7 @@ The [`utils/`](utils/) directory contains helper scripts for common workflows. S
 | `release.sh` | Trigger a validated release (major/minor/patch) via GitHub Actions |
 | `backport-pr.sh` | Cherry-pick a merged PR onto a release branch and open a backport PR |
 | `patch-dd-java-agent.sh` | Patch `dd-java-agent.jar` with a local ddprof build for quick testing |
-| `run-docker-tests.sh` | Run tests in Docker containers (musl/glibc, multiple JDKs) |
+| `run-containers-tests.sh` | Run tests in containers (musl/glibc, multiple JDKs) |
 | `check_upstream_changes.sh` | Check for upstream async-profiler changes locally |
 | `track_upstream_changes.sh` | Track upstream changes and generate reports |
 | `generate_tracked_files.sh` | Generate the list of files tracked from upstream |

--- a/doc/plans/2026-05-29-logs-backend-crash-simulation-design.md
+++ b/doc/plans/2026-05-29-logs-backend-crash-simulation-design.md
@@ -164,7 +164,7 @@ overflows/UAF for Layer 2, complementing crash-on-signal.
 
 ### Layer 1 — ASan gtest (JDK 25, aarch64/glibc, 2026-05-29)
 
-Command: `./utils/run-docker-tests.sh --config=asan --gtest --jdk=25 --mount`
+Command: `./utils/run-containers-tests.sh --config=asan --gtest --jdk=25 --mount`
 
 Results:
 - `stress_threadLifecycle_ut` compiled and linked under ASan: **PASS**

--- a/doc/plans/2026-05-29-logs-backend-crash-simulation-plan.md
+++ b/doc/plans/2026-05-29-logs-backend-crash-simulation-plan.md
@@ -16,9 +16,9 @@
 This host is macOS/arm64; the test is `#ifdef __linux__` and the sanitizers are Linux-only.
 ALL build/run steps execute via the repo's Docker runner on **JDK 25**, which gives faithful
 Linux ASan/TSan:
-- Debug build + gtests: `./utils/run-docker-tests.sh --config=debug --gtest --jdk=25 --mount`
-- ASan: `./utils/run-docker-tests.sh --config=asan --gtest --jdk=25 --mount`
-- TSan: `./utils/run-docker-tests.sh --config=tsan --gtest --jdk=25 --mount`
+- Debug build + gtests: `./utils/run-containers-tests.sh --config=debug --gtest --jdk=25 --mount`
+- ASan: `./utils/run-containers-tests.sh --config=asan --gtest --jdk=25 --mount`
+- TSan: `./utils/run-containers-tests.sh --config=tsan --gtest --jdk=25 --mount`
 - Interactive iteration: add `--shell` to drop into the container and run the built
   `*_stress_threadLifecycle_ut*` binary directly with `--gtest_filter=StressThreadLifecycle.*`.
 

--- a/utils/README.md
+++ b/utils/README.md
@@ -77,22 +77,32 @@ Cherry-picks a merged PR onto a release branch, pushes the backport branch, and 
 
 ## Testing
 
-### `run-docker-tests.sh`
+### `run-containers-tests.sh`
 
-Runs tests in Docker across various OS/libc/JDK combinations, mirroring the CI matrix locally.
+Runs tests in containers across various OS/libc/JDK combinations, mirroring the CI matrix locally. Defaults to Podman; set `CONTAINER_RUNTIME=docker` to use Docker.
 
 **Usage:**
 ```bash
-./utils/run-docker-tests.sh [options]
+./utils/run-containers-tests.sh [options]
   --libc=glibc|musl               (default: glibc)
   --jdk=8|11|17|21|25|8-j9|...   (default: 21)
   --arch=x64|aarch64              (default: auto-detect)
   --config=debug|release|asan|tsan (default: debug)
   --tests="TestPattern"           (optional)
   --gtest                         (enable C++ gtests)
+  --gtest-task=Task               (run one C++ gtest task)
   --shell                         (drop to shell instead of running tests)
   --mount                         (mount local repo instead of cloning)
-  --rebuild                       (force rebuild of Docker images)
+  --rebuild                       (force rebuild of container images)
+```
+
+Examples:
+```bash
+# Run a single C++ gtest binary in ASan mode
+./utils/run-containers-tests.sh --config=asan --gtest-task=elfparser_ut
+
+# Use Docker instead of the default Podman runtime
+CONTAINER_RUNTIME=docker ./utils/run-containers-tests.sh --libc=glibc --jdk=21
 ```
 
 ### `patch-dd-java-agent.sh`

--- a/utils/README.md
+++ b/utils/README.md
@@ -79,7 +79,7 @@ Cherry-picks a merged PR onto a release branch, pushes the backport branch, and 
 
 ### `run-containers-tests.sh`
 
-Runs tests in containers across various OS/libc/JDK combinations, mirroring the CI matrix locally. Defaults to Podman; set `CONTAINER_RUNTIME=docker` to use Docker.
+Runs tests in containers across various OS/libc/JDK combinations, mirroring the CI matrix locally. Defaults to Podman; use `--container=docker` to use Docker.
 
 **Usage:**
 ```bash
@@ -88,6 +88,7 @@ Runs tests in containers across various OS/libc/JDK combinations, mirroring the 
   --jdk=8|11|17|21|25|8-j9|...   (default: 21)
   --arch=x64|aarch64              (default: auto-detect)
   --config=debug|release|asan|tsan (default: debug)
+  --container=podman|docker       (default: podman)
   --tests="TestPattern"           (optional)
   --gtest                         (enable C++ gtests)
   --gtest-task=Task               (run one C++ gtest task)
@@ -102,7 +103,7 @@ Examples:
 ./utils/run-containers-tests.sh --config=asan --gtest-task=elfparser_ut
 
 # Use Docker instead of the default Podman runtime
-CONTAINER_RUNTIME=docker ./utils/run-containers-tests.sh --libc=glibc --jdk=21
+./utils/run-containers-tests.sh --container=docker --libc=glibc --jdk=21
 ```
 
 ### `patch-dd-java-agent.sh`

--- a/utils/run-containers-tests.sh
+++ b/utils/run-containers-tests.sh
@@ -41,6 +41,16 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BASE_IMAGE_PREFIX="java-profiler-base"
 IMAGE_PREFIX="java-profiler-test"
 
+selinux_enforcing() {
+    if [[ -r /sys/fs/selinux/enforce ]]; then
+        [[ "$(cat /sys/fs/selinux/enforce)" == "1" ]]
+    elif command -v getenforce >/dev/null 2>&1; then
+        [[ "$(getenforce)" == "Enforcing" ]]
+    else
+        false
+    fi
+}
+
 # Auto-detect architecture
 detect_arch() {
     local machine
@@ -529,6 +539,12 @@ fi
 
 # Build container run command base
 CONTAINER_CMD="$CONTAINER_RUNTIME run --rm"
+CONTAINER_VOLUME_RW_OPTIONS=""
+CONTAINER_VOLUME_RO_OPTIONS=":ro"
+if [[ "${CONTAINER_RUNTIME##*/}" == "podman" ]] && selinux_enforcing; then
+    CONTAINER_VOLUME_RW_OPTIONS=":z"
+    CONTAINER_VOLUME_RO_OPTIONS=":ro,z"
+fi
 if $SHELL_MODE; then
     CONTAINER_CMD="$CONTAINER_CMD -it --init --ulimit core=-1 --cap-add=SYS_PTRACE"
 fi
@@ -543,7 +559,7 @@ CONTAINER_CMD="$CONTAINER_CMD -e GRADLE_USER_HOME=/gradle-cache"
 
 if $MOUNT_MODE; then
     # Mount mode: use local repo directly (faster, but may have stale artifacts)
-    CONTAINER_CMD="$CONTAINER_CMD -v \"$PROJECT_ROOT\":/workspace"
+    CONTAINER_CMD="$CONTAINER_CMD -v \"$PROJECT_ROOT\":/workspace${CONTAINER_VOLUME_RW_OPTIONS}"
     CONTAINER_CMD="$CONTAINER_CMD $IMAGE_NAME"
 
     if $SHELL_MODE; then
@@ -559,7 +575,7 @@ if $MOUNT_MODE; then
 else
     # Clone mode: shallow clone from mounted local repo for clean builds (default)
     # Mount the local repo as source, then clone from it to /workspace
-    CONTAINER_CMD="$CONTAINER_CMD -v \"$PROJECT_ROOT\":/source:ro"
+    CONTAINER_CMD="$CONTAINER_CMD -v \"$PROJECT_ROOT\":/source${CONTAINER_VOLUME_RO_OPTIONS}"
     CONTAINER_CMD="$CONTAINER_CMD $IMAGE_NAME"
 
     # Build clone and test command - clone from local mounted source

--- a/utils/run-containers-tests.sh
+++ b/utils/run-containers-tests.sh
@@ -7,7 +7,7 @@
 #   1. Base image with OS + build tools (java-profiler-base:<libc>-<arch>)
 #   2. JDK-specific image on top (java-profiler-test:<libc>-jdk<version>-<arch>)
 #
-# Usage: ./utils/run-docker-tests.sh [options]
+# Usage: ./utils/run-containers-tests.sh [options]
 #   --libc=glibc|musl        (default: glibc)
 #   --jdk=8|11|17|21|25|8-j9|11-j9|17-j9|21-j9|17-graal|21-graal|25-graal  (default: 21)
 #   --arch=x64|aarch64       (default: auto-detect)
@@ -17,7 +17,7 @@
 #   --gtest-task=Task        (run one C++ gtest task; accepts elfparser_ut or :ddprof-lib:gtestAsan_elfparser_ut)
 #   --shell                  (drop to shell instead of running tests; enables SYS_PTRACE for gdb)
 #   --mount                  (mount local repo instead of cloning - faster but may have stale artifacts)
-#   --rebuild                (force rebuild of Docker images)
+#   --rebuild                (force rebuild of container images)
 #   --rebuild-base           (force rebuild of base image only)
 #   --help                   (show this help)
 

--- a/utils/run-containers-tests.sh
+++ b/utils/run-containers-tests.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Copyright 2026, Datadog, Inc
 #
-# Run tests in Docker with various OS/libc/JDK combinations (similar to CI)
-# Uses two-level Docker image caching:
+# Run tests in containers with various OS/libc/JDK combinations (similar to CI)
+# Defaults to Podman; set CONTAINER_RUNTIME=docker to use Docker.
+# Uses two-level container image caching:
 #   1. Base image with OS + build tools (java-profiler-base:<libc>-<arch>)
 #   2. JDK-specific image on top (java-profiler-test:<libc>-jdk<version>-<arch>)
 #
@@ -13,6 +14,7 @@
 #   --config=debug|release|asan|tsan   (default: debug)
 #   --tests="TestPattern"    (optional, specific test to run)
 #   --gtest                  (enable C++ gtests, disabled by default)
+#   --gtest-task=Task        (run one C++ gtest task; accepts elfparser_ut or :ddprof-lib:gtestAsan_elfparser_ut)
 #   --shell                  (drop to shell instead of running tests; enables SYS_PTRACE for gdb)
 #   --mount                  (mount local repo instead of cloning - faster but may have stale artifacts)
 #   --rebuild                (force rebuild of Docker images)
@@ -22,11 +24,13 @@
 set -e
 
 # Defaults
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 LIBC="glibc"
 JDK_VERSION="21"
 ARCH=""
 CONFIG="debug"
 TESTS=""
+GTEST_TASK=""
 SHELL_MODE=false
 MOUNT_MODE=false
 GTEST_ENABLED=false
@@ -132,7 +136,7 @@ get_j9_jdk_url() {
 }
 
 usage() {
-    head -n 19 "$0" | tail -n 16
+    head -n 21 "$0" | tail -n 18
     exit 0
 }
 
@@ -168,6 +172,11 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --gtest)
+            GTEST_ENABLED=true
+            shift
+            ;;
+        --gtest-task=*)
+            GTEST_TASK="${1#*=}"
             GTEST_ENABLED=true
             shift
             ;;
@@ -210,6 +219,17 @@ if [[ "$CONFIG" != "debug" && "$CONFIG" != "release" && "$CONFIG" != "asan" && "
     exit 1
 fi
 
+if [[ -n "$GTEST_TASK" && -n "$TESTS" ]]; then
+    echo "Error: --tests cannot be combined with --gtest-task"
+    exit 1
+fi
+
+if ! command -v "$CONTAINER_RUNTIME" >/dev/null 2>&1; then
+    echo "Error: container runtime '$CONTAINER_RUNTIME' not found"
+    echo "Set CONTAINER_RUNTIME to override, e.g. CONTAINER_RUNTIME=docker $0 ..."
+    exit 1
+fi
+
 # Parse JDK version and variant (e.g., "21-j9" -> version="21", variant="j9")
 JDK_BASE_VERSION="${JDK_VERSION%%-*}"
 JDK_VARIANT="${JDK_VERSION#*-}"
@@ -245,20 +265,24 @@ fi
 BASE_IMAGE_NAME="${BASE_IMAGE_PREFIX}:${LIBC}-${ARCH}"
 IMAGE_NAME="${IMAGE_PREFIX}:${LIBC}-jdk${JDK_VERSION}-${ARCH}"
 
-# Docker platform for cross-architecture support
-DOCKER_PLATFORM=""
+# Container platform for cross-architecture support
+CONTAINER_PLATFORM=""
 if [[ "$ARCH" == "aarch64" ]]; then
-    DOCKER_PLATFORM="--platform linux/arm64"
+    CONTAINER_PLATFORM="--platform linux/arm64"
 elif [[ "$ARCH" == "x64" ]]; then
-    DOCKER_PLATFORM="--platform linux/amd64"
+    CONTAINER_PLATFORM="--platform linux/amd64"
 fi
 
-echo "=== Docker Test Runner ==="
+echo "=== Container Test Runner ==="
 echo "LIBC:       $LIBC"
 echo "Build JDK:  21 (Gradle 9 requirement)"
 echo "Test JDK:   $JDK_VERSION"
 echo "Arch:       $ARCH"
 echo "Config:     $CONFIG"
+echo "Runtime:    $CONTAINER_RUNTIME"
+if [[ -n "$GTEST_TASK" ]]; then
+    echo "GTest task: $GTEST_TASK"
+fi
 echo "Tests:      ${TESTS:-<all>}"
 echo "GTest:      $(if $GTEST_ENABLED; then echo 'enabled'; else echo 'disabled'; fi)"
 echo "Mode:       $(if $SHELL_MODE; then echo 'shell'; else echo 'test'; fi)"
@@ -278,7 +302,7 @@ cp -r "$PROJECT_ROOT/gradle" "$DOCKERFILE_DIR/"
 # ========== Build Base Image (if needed) ==========
 BASE_IMAGE_EXISTS=false
 if [[ "$REBUILD" == "false" && "$REBUILD_BASE" == "false" ]]; then
-    if docker image inspect "$BASE_IMAGE_NAME" >/dev/null 2>&1; then
+    if "$CONTAINER_RUNTIME" image inspect "$BASE_IMAGE_NAME" >/dev/null 2>&1; then
         BASE_IMAGE_EXISTS=true
         echo ">>> Using cached base image: $BASE_IMAGE_NAME"
     fi
@@ -311,7 +335,7 @@ EOF
     else
         # libclang-rt-dev is only available on x64, not arm64
         if [[ "$ARCH" == "x64" ]]; then
-            CLANG_RT_PKG="libclang-rt-dev"
+            CLANG_RT_PKG="libclang-dev"
         else
             CLANG_RT_PKG=""
         fi
@@ -362,7 +386,7 @@ WORKDIR /workspace
 EOF
     fi
 
-    docker build $DOCKER_PLATFORM -t "$BASE_IMAGE_NAME" -f "$DOCKERFILE_DIR/Dockerfile.base" "$DOCKERFILE_DIR"
+    "$CONTAINER_RUNTIME" build $CONTAINER_PLATFORM -t "$BASE_IMAGE_NAME" -f "$DOCKERFILE_DIR/Dockerfile.base" "$DOCKERFILE_DIR"
     echo ">>> Base image built: $BASE_IMAGE_NAME"
 fi
 
@@ -378,7 +402,7 @@ fi
 # ========== Build JDK Image (if needed) ==========
 IMAGE_EXISTS=false
 if [[ "$REBUILD" == "false" ]]; then
-    if docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
+    if "$CONTAINER_RUNTIME" image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
         IMAGE_EXISTS=true
         echo ">>> Using cached image: $IMAGE_NAME"
     fi
@@ -459,7 +483,7 @@ WORKDIR /workspace
 EOF
     fi
 
-    docker build $DOCKER_PLATFORM -t "$IMAGE_NAME" -f "$DOCKERFILE_DIR/Dockerfile" "$DOCKERFILE_DIR"
+    "$CONTAINER_RUNTIME" build $CONTAINER_PLATFORM -t "$IMAGE_NAME" -f "$DOCKERFILE_DIR/Dockerfile" "$DOCKERFILE_DIR"
     echo ">>> JDK image built: $IMAGE_NAME"
 fi
 
@@ -469,13 +493,21 @@ fi
 # Capitalize first letter for gradle task names (testDebug, testAsan, etc.)
 # Note: -Ptests property works uniformly across all platforms (glibc, musl, macOS)
 CONFIG_CAPITALIZED="$(tr '[:lower:]' '[:upper:]' <<< ${CONFIG:0:1})${CONFIG:1}"
-GRADLE_CMD="./gradlew -PCI -PkeepJFRs :ddprof-test:test${CONFIG_CAPITALIZED}"
-if [[ -n "$TESTS" ]]; then
-    # No need for quotes around $TESTS - Gradle property values don't require quoting
-    GRADLE_CMD="$GRADLE_CMD -Ptests=$TESTS"
-fi
-if ! $GTEST_ENABLED; then
-    GRADLE_CMD="$GRADLE_CMD -Pskip-gtest"
+if [[ -n "$GTEST_TASK" ]]; then
+    if [[ "$GTEST_TASK" == :* ]]; then
+        GRADLE_CMD="./gradlew -PCI -PkeepJFRs $GTEST_TASK"
+    else
+        GRADLE_CMD="./gradlew -PCI -PkeepJFRs :ddprof-lib:gtest${CONFIG_CAPITALIZED}_${GTEST_TASK}"
+    fi
+else
+    GRADLE_CMD="./gradlew -PCI -PkeepJFRs :ddprof-test:test${CONFIG_CAPITALIZED}"
+    if [[ -n "$TESTS" ]]; then
+        # No need for quotes around $TESTS - Gradle property values don't require quoting
+        GRADLE_CMD="$GRADLE_CMD -Ptests=$TESTS"
+    fi
+    if ! $GTEST_ENABLED; then
+        GRADLE_CMD="$GRADLE_CMD -Pskip-gtest"
+    fi
 fi
 # On aarch64 glibc, TSan needs clang-17's embedded runtime (supports 48-bit VMA).
 # GCC 11's libtsan is linked by default but only knows 39-bit VMA, causing a crash.
@@ -495,40 +527,40 @@ if [[ "$CONFIG" == "tsan" ]] && [[ "$ARCH" == "aarch64" ]] && [[ "$LIBC" == "gli
     NEEDS_PRIVILEGED=true
 fi
 
-# Build Docker run command base
-DOCKER_CMD="docker run --rm"
+# Build container run command base
+CONTAINER_CMD="$CONTAINER_RUNTIME run --rm"
 if $SHELL_MODE; then
-    DOCKER_CMD="$DOCKER_CMD -it --init --ulimit core=-1 --cap-add=SYS_PTRACE"
+    CONTAINER_CMD="$CONTAINER_CMD -it --init --ulimit core=-1 --cap-add=SYS_PTRACE"
 fi
 if $NEEDS_PRIVILEGED; then
-    DOCKER_CMD="$DOCKER_CMD --privileged"
+    CONTAINER_CMD="$CONTAINER_CMD --privileged"
 fi
-DOCKER_CMD="$DOCKER_CMD $DOCKER_PLATFORM"
-DOCKER_CMD="$DOCKER_CMD -e LIBC=$LIBC"
-DOCKER_CMD="$DOCKER_CMD -e SANITIZER=$CONFIG"
-DOCKER_CMD="$DOCKER_CMD -e TEST_CONFIGURATION=$LIBC/${JDK_VERSION}-$CONFIG-$ARCH"
-DOCKER_CMD="$DOCKER_CMD -e GRADLE_USER_HOME=/gradle-cache"
+CONTAINER_CMD="$CONTAINER_CMD $CONTAINER_PLATFORM"
+CONTAINER_CMD="$CONTAINER_CMD -e LIBC=$LIBC"
+CONTAINER_CMD="$CONTAINER_CMD -e SANITIZER=$CONFIG"
+CONTAINER_CMD="$CONTAINER_CMD -e TEST_CONFIGURATION=$LIBC/${JDK_VERSION}-$CONFIG-$ARCH"
+CONTAINER_CMD="$CONTAINER_CMD -e GRADLE_USER_HOME=/gradle-cache"
 
 if $MOUNT_MODE; then
     # Mount mode: use local repo directly (faster, but may have stale artifacts)
-    DOCKER_CMD="$DOCKER_CMD -v \"$PROJECT_ROOT\":/workspace"
-    DOCKER_CMD="$DOCKER_CMD $IMAGE_NAME"
+    CONTAINER_CMD="$CONTAINER_CMD -v \"$PROJECT_ROOT\":/workspace"
+    CONTAINER_CMD="$CONTAINER_CMD $IMAGE_NAME"
 
     if $SHELL_MODE; then
-        CONTAINER_CMD="/bin/bash"
+        SHELL_CMD="/bin/bash"
     else
-        CONTAINER_CMD="${SYSCTL_PREP}${GRADLE_CMD}"
+        SHELL_CMD="${SYSCTL_PREP}${GRADLE_CMD}"
     fi
 
     echo ""
     echo ">>> Running in container (mount mode)..."
-    echo ">>> Command: $CONTAINER_CMD"
-    eval "$DOCKER_CMD /bin/bash -c '$CONTAINER_CMD'"
+    echo ">>> Command: $SHELL_CMD"
+    eval "$CONTAINER_CMD /bin/bash -c '$SHELL_CMD'"
 else
     # Clone mode: shallow clone from mounted local repo for clean builds (default)
     # Mount the local repo as source, then clone from it to /workspace
-    DOCKER_CMD="$DOCKER_CMD -v \"$PROJECT_ROOT\":/source:ro"
-    DOCKER_CMD="$DOCKER_CMD $IMAGE_NAME"
+    CONTAINER_CMD="$CONTAINER_CMD -v \"$PROJECT_ROOT\":/source:ro"
+    CONTAINER_CMD="$CONTAINER_CMD $IMAGE_NAME"
 
     # Build clone and test command - clone from local mounted source
     if $SHELL_MODE; then
@@ -540,5 +572,5 @@ else
     echo ""
     echo ">>> Running in container (clone mode)..."
     echo ">>> Cloning from local source to /workspace"
-    eval "$DOCKER_CMD /bin/bash -c '$CLONE_CMD'"
+    eval "$CONTAINER_CMD /bin/bash -c '$CLONE_CMD'"
 fi

--- a/utils/run-containers-tests.sh
+++ b/utils/run-containers-tests.sh
@@ -2,7 +2,7 @@
 # Copyright 2026, Datadog, Inc
 #
 # Run tests in containers with various OS/libc/JDK combinations (similar to CI)
-# Defaults to Podman; set CONTAINER_RUNTIME=docker to use Docker.
+# Defaults to Podman; use --container=docker to use Docker.
 # Uses two-level container image caching:
 #   1. Base image with OS + build tools (java-profiler-base:<libc>-<arch>)
 #   2. JDK-specific image on top (java-profiler-test:<libc>-jdk<version>-<arch>)
@@ -12,6 +12,7 @@
 #   --jdk=8|11|17|21|25|8-j9|11-j9|17-j9|21-j9|17-graal|21-graal|25-graal  (default: 21)
 #   --arch=x64|aarch64       (default: auto-detect)
 #   --config=debug|release|asan|tsan   (default: debug)
+#   --container=podman|docker  (default: podman)
 #   --tests="TestPattern"    (optional, specific test to run)
 #   --gtest                  (enable C++ gtests, disabled by default)
 #   --gtest-task=Task        (run one C++ gtest task; accepts elfparser_ut or :ddprof-lib:gtestAsan_elfparser_ut)
@@ -146,7 +147,7 @@ get_j9_jdk_url() {
 }
 
 usage() {
-    head -n 21 "$0" | tail -n 18
+    head -n 23 "$0" | tail -n 20
     exit 0
 }
 
@@ -167,6 +168,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --config=*)
             CONFIG="${1#*=}"
+            shift
+            ;;
+        --container=*)
+            CONTAINER_RUNTIME="${1#*=}"
             shift
             ;;
         --tests=*)
@@ -229,6 +234,11 @@ if [[ "$CONFIG" != "debug" && "$CONFIG" != "release" && "$CONFIG" != "asan" && "
     exit 1
 fi
 
+if [[ "$CONTAINER_RUNTIME" != "podman" && "$CONTAINER_RUNTIME" != "docker" ]]; then
+    echo "Error: --container must be 'podman' or 'docker'"
+    exit 1
+fi
+
 if [[ -n "$GTEST_TASK" && -n "$TESTS" ]]; then
     echo "Error: --tests cannot be combined with --gtest-task"
     exit 1
@@ -236,7 +246,7 @@ fi
 
 if ! command -v "$CONTAINER_RUNTIME" >/dev/null 2>&1; then
     echo "Error: container runtime '$CONTAINER_RUNTIME' not found"
-    echo "Set CONTAINER_RUNTIME to override, e.g. CONTAINER_RUNTIME=docker $0 ..."
+    echo "Use --container to select the runtime, e.g. $0 --container=docker ..."
     exit 1
 fi
 


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->

- It switches from Docker to Podman as the main container runtime.
- It adds a new optional flag `gtest-task` to execute only a specific gtest test.
- It fixes a package name (`libclang-rt-dev` is not present).
- It renames `utils/run-docker-tests.sh` to `utils/run-containers-tests.sh`.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

Switch from Docker to Podman as default container runtime to avoid license issues.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

- default container runtime can still be overwritten using the environment variable `CONTAINER_RUNTIME`

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

Execute `./utils/run-containers-tests.sh` with different configurations:
- `./utils/run-containers-tests.sh --libc=glibc --jdk=21 --arch=x64 --config=asan --mount`
- `./utils/run-containers-tests.sh --libc=glibc --jdk=21 --config=asan --mount --gtest-task=elfparser_ut`

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [JIRA-15016]

Unsure? Have a question? Request a review!
