### PR TITLE
Fix crash at thread exit

### DIFF
--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -151,6 +151,11 @@ void run_with_cleanup(func_start_routine routine, void* params,
         // should a future/variant glibc ever return from it.
         __builtin_unreachable();
     }
+    // Callers must not have a pending pthread_cancel when they enter
+    // run_with_cleanup: a cancellation arriving between __sigsetjmp returning
+    // and __pthread_register_cancel below would unwind this frame before
+    // cancel_buf is registered, silently skipping cleanup_fn.  All current
+    // callers are JVM/native start routines with no pending cancellation.
     __pthread_register_cancel(&cancel_buf);
     routine(params);
     __pthread_unregister_cancel(&cancel_buf);
@@ -344,7 +349,7 @@ static int pthread_create_hook_spec(pthread_t* thread,
 
 // Wrapper around the real start routine.
 // See comments for start_routine_wrapper_spec() for details
-__attribute__((visibility("hidden")))
+__attribute__((visibility("hidden"), no_stack_protector))
 static void* start_routine_wrapper(void* args) {
     RoutineInfo* thr = (RoutineInfo*)args;
     func_start_routine routine;

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -15,6 +15,7 @@
 #include <dlfcn.h>
 #include <mutex>
 #include <limits.h>
+#include <setjmp.h>
 #include <string.h>
 #include <stdlib.h>
 

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -205,6 +205,17 @@ int pthread_create_wrapped_for_test(pthread_t* thread,
     }
     return ret;
 }
+
+// Variant that passes the production cleanup_unregister as the cleanup function.
+// Exercises the full chain: start_routine_for_test → run_with_cleanup →
+// cleanup_unregister → Profiler::unregisterThread + ProfiledThread::release.
+// Profiler::unregisterThread is null-safe under UNIT_TEST (see profiler.cpp).
+int pthread_create_with_cleanup_unregister_for_test(pthread_t* thread,
+                                                    func_start_routine routine,
+                                                    void* params) {
+    return pthread_create_wrapped_for_test(thread, routine, params,
+                                           cleanup_unregister, nullptr);
+}
 #endif  // UNIT_TEST
 
 #ifdef __aarch64__

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -73,6 +73,73 @@ static void unregister_and_release(int tid) {
     ProfiledThread::release();
 }
 
+// pthread_cleanup_push callback for thread wrappers.
+// Fires when the wrapped routine calls pthread_exit() or the thread is
+// canceled.  Kept noinline so its stack frame (which may hold a SignalBlocker
+// via unregister_and_release) lives outside the DEOPT-corruption zone of the
+// caller on musl/aarch64, and so that the SignalBlocker's sigset_t does not
+// appear in the caller's frame on platforms with stack-protector canaries.
+__attribute__((noinline))
+static void cleanup_unregister(void*) {
+    unregister_and_release(ProfiledThread::currentTid());
+}
+
+// Thread-cleanup wrapper that avoids the static-libgcc / forced-unwind crash.
+//
+// The crash: on glibc, pthread_cleanup_push in C++ mode expands to
+// __pthread_cleanup_class (RAII), which adds a cleanup entry to the LSDA of
+// this frame.  When libjavaProfiler.so is built with -static-libgcc, the
+// embedded __gxx_personality_v0 is called by the dynamic libgcc_s.so.1's
+// _Unwind_ForcedUnwind.  The two libgcc versions have incompatible
+// _Unwind_Context layouts; calling _Unwind_SetGR (which happens when the
+// personality finds a cleanup action) with a cross-version context triggers
+// the cold/error path, which calls abort().
+//
+// The fix: use __pthread_register_cancel / __pthread_unregister_cancel
+// directly — the same thing the C macro form of pthread_cleanup_push does.
+// This registers cleanup via a setjmp buffer in a runtime linked-list, NOT
+// via an LSDA destructor.  _Unwind_ForcedUnwind's stop function
+// (__pthread_unwind_stop) handles the cleanup without ever calling
+// __gxx_personality_v0 for this frame, so _Unwind_SetGR is never called and
+// the cross-version incompatibility is never triggered.
+//
+// On musl: pthread_cleanup_push already uses the C/setjmp form (no RAII),
+// and pthread_exit does not use _Unwind_ForcedUnwind, so there is no issue.
+// The __GLIBC__ guard keeps the musl path unchanged.
+#ifdef __GLIBC__
+// On glibc, <pthread.h> declares __pthread_register_cancel etc. only inside
+// the C (non-C++) conditional, so they're invisible in C++ code.  Redeclare
+// them with extern "C" so we can call them directly without the header guard.
+extern "C" {
+    extern void __pthread_register_cancel(__pthread_unwind_buf_t*);
+    extern void __pthread_unregister_cancel(__pthread_unwind_buf_t*);
+    [[noreturn]] extern void __pthread_unwind_next(__pthread_unwind_buf_t*);
+}
+#endif
+
+__attribute__((noinline, no_stack_protector))
+static void run_with_cleanup(func_start_routine routine, void* params) {
+#ifdef __GLIBC__
+    __pthread_unwind_buf_t cancel_buf;
+    if (__builtin_expect(
+            __sigsetjmp((struct __jmp_buf_tag*)(void*)cancel_buf.__cancel_jmp_buf, 0), 0)) {
+        // Reached via longjmp from glibc's stop function when pthread_exit
+        // (or cancellation) fires.  Run cleanup and continue unwinding.
+        cleanup_unregister(nullptr);
+        __pthread_unwind_next(&cancel_buf);
+    }
+    __pthread_register_cancel(&cancel_buf);
+    routine(params);
+    __pthread_unregister_cancel(&cancel_buf);
+    cleanup_unregister(nullptr);
+#else
+    // musl / non-glibc: pthread_cleanup_push uses the C/setjmp form, no RAII.
+    pthread_cleanup_push(cleanup_unregister, nullptr);
+    routine(params);
+    pthread_cleanup_pop(1);
+#endif
+}
+
 #ifdef __aarch64__
 // Delete RoutineInfo with profiling signals blocked to prevent ASAN
 // allocator lock reentrancy. Kept noinline so SignalBlocker's sigset_t
@@ -97,29 +164,6 @@ static void init_tls_and_register() {
         pt->startInitWindow();
     }
     Profiler::registerThread(ProfiledThread::currentTid());
-}
-
-// pthread_cleanup_push callback for start_routine_wrapper_spec.
-// Fires when the wrapped routine calls pthread_exit() or the thread is
-// canceled.  Kept noinline so its stack frame (which may hold a SignalBlocker
-// via unregister_and_release) lives outside the DEOPT-corruption zone of
-// start_routine_wrapper_spec.
-__attribute__((noinline))
-static void cleanup_unregister(void*) {
-    unregister_and_release(ProfiledThread::currentTid());
-}
-
-// pthread_cleanup_push declares `struct __ptcb` in the caller's frame.  If that
-// frame is start_routine_wrapper_spec, the structure sits inside the ~224-byte
-// DEOPT-corruption zone and pthread_cleanup_pop(1) would invoke a clobbered
-// function pointer.  This noinline + no_stack_protector helper hoists the
-// cleanup-handler frame out of the corruption zone — its own frame lives
-// safely above start_routine_wrapper_spec's.
-__attribute__((noinline, no_stack_protector))
-static void run_with_musl_cleanup(func_start_routine routine, void* params) {
-    pthread_cleanup_push(cleanup_unregister, nullptr);
-    routine(params);
-    pthread_cleanup_pop(1);
 }
 
 // Wrapper around the real start routine.
@@ -172,9 +216,9 @@ static void* start_routine_wrapper_spec(void* args) {
     delete_routine_info(thr);
     init_tls_and_register();
     // cleanup_unregister fires on pthread_exit() or cancellation from within
-    // routine(params).  The push/pop pair lives inside run_with_musl_cleanup so
+    // routine(params).  The push/pop pair lives inside run_with_cleanup so
     // that `struct __ptcb` does not land in this frame's DEOPT-corruption zone.
-    run_with_musl_cleanup(routine, params);
+    run_with_cleanup(routine, params);
     // pthread_exit instead of 'return': the saved LR in this frame is corrupted
     // by DEOPT PACKING; returning would jump to a garbage address.
     pthread_exit(nullptr);
@@ -227,13 +271,8 @@ static void* start_routine_wrapper(void* args) {
         ProfiledThread::currentSignalSafe()->startInitWindow();
         Profiler::registerThread(ProfiledThread::currentTid());
     }
-    // RAII cleanup: reads tid from TLS in the destructor (same rationale as
-    // start_routine_wrapper_spec: avoids storing state on a potentially corruptible frame).
-    // unregister_and_release() wraps the two calls under SignalBlocker (PROF-14603).
-    struct Cleanup {
-        ~Cleanup() { unregister_and_release(ProfiledThread::currentTid()); }
-    } cleanup;
-    routine(params);
+    // Use POSIX cleanup instead of C++ RAII to handle pthread_exit(): see run_with_cleanup.
+    run_with_cleanup(routine, params);
     return nullptr;
 }
 

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -129,16 +129,27 @@ void run_with_cleanup(func_start_routine routine, void* params,
     static_assert(offsetof(__pthread_unwind_buf_t, __cancel_jmp_buf) == 0 &&
                   sizeof(cancel_buf.__cancel_jmp_buf[0]) == offsetof(struct __jmp_buf_tag, __saved_mask),
                   "glibc __pthread_unwind_buf_t inner layout incompatible with struct __jmp_buf_tag");
-    // Uses __sigsetjmp/longjmp which only intercepts _Unwind_ForcedUnwind, but not
-    // regular C++ exception from routine(params), which should be handled by JVM
+    // __sigsetjmp/longjmp only intercepts _Unwind_ForcedUnwind (pthread_exit /
+    // cancellation).  routine(params) must NOT throw a regular C++ exception
+    // across this boundary: an escaping exception would skip both
+    // __pthread_unregister_cancel and cleanup_fn below, leaking the thread
+    // registration and leaving cancel_buf linked against this (unwound) frame.
+    // We cannot defend with a try/catch here — a handler frame adds an LSDA
+    // action, which is exactly what triggers the static-libgcc abort this
+    // function exists to avoid.  Production routines are JVM/native start
+    // routines that handle their own exceptions and do not throw across here.
     if (__builtin_expect(
-            // set __sigsetjmp's savemask=0 (the second parameter, noting that the signal mask is NOT 
+            // set __sigsetjmp's savemask=0 (the second parameter, noting that the signal mask is NOT
             // saved/restored, which is correct because the cancel mechanism does not depend on signal mask state.
             __sigsetjmp((struct __jmp_buf_tag*)(void*)cancel_buf.__cancel_jmp_buf, 0), 0)) {
         // Reached via longjmp from glibc's stop function when pthread_exit
         // (or cancellation) fires.  Run cleanup and continue unwinding.
         cleanup_fn(cleanup_arg);
         __pthread_unwind_next(&cancel_buf);
+        // __pthread_unwind_next is [[noreturn]]; this fails loudly rather than
+        // falling through into __pthread_register_cancel on a torn-down frame
+        // should a future/variant glibc ever return from it.
+        __builtin_unreachable();
     }
     __pthread_register_cancel(&cancel_buf);
     routine(params);
@@ -300,9 +311,14 @@ static void* start_routine_wrapper_spec(void* args) {
     run_with_cleanup(routine, params, cleanup_unregister, nullptr);
     // pthread_exit instead of 'return': the saved LR in this frame is corrupted
     // by DEOPT PACKING; returning would jump to a garbage address.
-    // cleanup_unregister has already run via run_with_cleanup’s normal return path;
-    // TLS is cleared. pthread_exit triggers a second unwind with no registered cancel
-    // handler — safe because currentSignalSafe() returns null.
+    // cleanup_unregister has already run via run_with_cleanup's normal return
+    // path, so there is no registered cancel handler left.  The forced unwind
+    // raised by pthread_exit walks this frame, but it is safe because no
+    // destructor-bearing local (and hence no LSDA cleanup/handler action) is
+    // live at this call site: __gxx_personality_v0 returns continue-unwind
+    // without ever calling _Unwind_SetGR, avoiding the static-libgcc abort.
+    // WARNING: adding any RAII local with a destructor between run_with_cleanup
+    // and pthread_exit would reintroduce that crash.
     pthread_exit(nullptr);
     __builtin_unreachable();
 }
@@ -354,8 +370,12 @@ static void* start_routine_wrapper(void* args) {
         Profiler::registerThread(ProfiledThread::currentTid());
     }
     // Use POSIX cleanup instead of C++ RAII to handle pthread_exit(): see run_with_cleanup.
+    // cleanup_unregister has already run on run_with_cleanup's normal return path.
+    // The pthread_exit forced unwind is safe here for the same reason as in
+    // start_routine_wrapper_spec: no destructor-bearing local is live at this
+    // call site, so __gxx_personality_v0 never calls _Unwind_SetGR.
     run_with_cleanup(routine, params, cleanup_unregister, nullptr);
-    pthread_exit(nullptr); 
+    pthread_exit(nullptr);
     __builtin_unreachable();
 }
 

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -126,9 +126,9 @@ void run_with_cleanup(func_start_routine routine, void* params,
     // Uses __sigsetjmp/longjmp which only intercepts _Unwind_ForcedUnwind, but not
     // regular C++ exception from routine(params), which should be handled by JVM
     if (__builtin_expect(
-            // set __sigsetjmp's savemask=1 (the second parameter) to match glibc's internal
-            //usage and ensure the signal mask is saved and restored across the setjmp/longjmp pair.
-            __sigsetjmp((struct __jmp_buf_tag*)(void*)cancel_buf.__cancel_jmp_buf, 0), 1)) {
+            // set __sigsetjmp's savemask=0 (the second parameter, noting that the signal mask is NOT 
+            // saved/restored, which is correct because the cancel mechanism does not depend on signal mask state.
+            __sigsetjmp((struct __jmp_buf_tag*)(void*)cancel_buf.__cancel_jmp_buf, 0), 0)) {
         // Reached via longjmp from glibc's stop function when pthread_exit
         // (or cancellation) fires.  Run cleanup and continue unwinding.
         cleanup_fn(cleanup_arg);
@@ -223,10 +223,14 @@ static void* start_routine_wrapper_spec(void* args) {
     init_tls_and_register();
     // cleanup_unregister fires on pthread_exit() or cancellation from within
     // routine(params).  The push/pop pair lives inside run_with_cleanup so
-    // that `struct __ptcb` does not land in this frame's DEOPT-corruption zone.
+    // that __pthread_unwind_buf_t (glibc) / struct __ptcb (musl) does not land
+    // in this frame's DEOPT-corruption zone.
     run_with_cleanup(routine, params, cleanup_unregister, nullptr);
     // pthread_exit instead of 'return': the saved LR in this frame is corrupted
     // by DEOPT PACKING; returning would jump to a garbage address.
+    // cleanup_unregister has already run via run_with_cleanup’s normal return path;
+    // TLS is cleared. pthread_exit triggers a second unwind with no registered cancel
+    // handler — safe because currentSignalSafe() returns null.
     pthread_exit(nullptr);
     __builtin_unreachable();
 }

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -118,24 +118,29 @@ extern "C" {
 }
 #endif
 
-__attribute__((noinline, no_stack_protector))
-static void run_with_cleanup(func_start_routine routine, void* params) {
+__attribute__((visibility("hidden"), noinline, no_stack_protector))
+void run_with_cleanup(func_start_routine routine, void* params,
+                      void (*cleanup_fn)(void*), void* cleanup_arg) {
 #ifdef __GLIBC__
-    __pthread_unwind_buf_t cancel_buf;
+    __pthread_unwind_buf_t cancel_buf = {};
+    // Uses __sigsetjmp/longjmp which only intercepts _Unwind_ForcedUnwind, but not
+    // regular C++ exception from routine(params), which should be handled by JVM
     if (__builtin_expect(
-            __sigsetjmp((struct __jmp_buf_tag*)(void*)cancel_buf.__cancel_jmp_buf, 0), 0)) {
+            // set __sigsetjmp's savemask=1 (the second parameter) to match glibc's internal
+            //usage and ensure the signal mask is saved and restored across the setjmp/longjmp pair.
+            __sigsetjmp((struct __jmp_buf_tag*)(void*)cancel_buf.__cancel_jmp_buf, 0), 1)) {
         // Reached via longjmp from glibc's stop function when pthread_exit
         // (or cancellation) fires.  Run cleanup and continue unwinding.
-        cleanup_unregister(nullptr);
+        cleanup_fn(cleanup_arg);
         __pthread_unwind_next(&cancel_buf);
     }
     __pthread_register_cancel(&cancel_buf);
     routine(params);
     __pthread_unregister_cancel(&cancel_buf);
-    cleanup_unregister(nullptr);
+    cleanup_fn(cleanup_arg);
 #else
     // musl / non-glibc: pthread_cleanup_push uses the C/setjmp form, no RAII.
-    pthread_cleanup_push(cleanup_unregister, nullptr);
+    pthread_cleanup_push(cleanup_fn, cleanup_arg);
     routine(params);
     pthread_cleanup_pop(1);
 #endif
@@ -219,7 +224,7 @@ static void* start_routine_wrapper_spec(void* args) {
     // cleanup_unregister fires on pthread_exit() or cancellation from within
     // routine(params).  The push/pop pair lives inside run_with_cleanup so
     // that `struct __ptcb` does not land in this frame's DEOPT-corruption zone.
-    run_with_cleanup(routine, params);
+    run_with_cleanup(routine, params, cleanup_unregister, nullptr);
     // pthread_exit instead of 'return': the saved LR in this frame is corrupted
     // by DEOPT PACKING; returning would jump to a garbage address.
     pthread_exit(nullptr);
@@ -273,7 +278,7 @@ static void* start_routine_wrapper(void* args) {
         Profiler::registerThread(ProfiledThread::currentTid());
     }
     // Use POSIX cleanup instead of C++ RAII to handle pthread_exit(): see run_with_cleanup.
-    run_with_cleanup(routine, params);
+    run_with_cleanup(routine, params, cleanup_unregister, nullptr);
     return nullptr;
 }
 

--- a/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
+++ b/ddprof-lib/src/main/cpp/libraryPatcher_linux.cpp
@@ -123,6 +123,12 @@ void run_with_cleanup(func_start_routine routine, void* params,
                       void (*cleanup_fn)(void*), void* cleanup_arg) {
 #ifdef __GLIBC__
     __pthread_unwind_buf_t cancel_buf = {};
+    // With savemask=0, __sigsetjmp only writes __jmp_buf + int __mask_was_saved;
+    // it never touches __saved_mask.  The inner struct of __pthread_unwind_buf_t
+    // must cover exactly that writable prefix of struct __jmp_buf_tag.
+    static_assert(offsetof(__pthread_unwind_buf_t, __cancel_jmp_buf) == 0 &&
+                  sizeof(cancel_buf.__cancel_jmp_buf[0]) == offsetof(struct __jmp_buf_tag, __saved_mask),
+                  "glibc __pthread_unwind_buf_t inner layout incompatible with struct __jmp_buf_tag");
     // Uses __sigsetjmp/longjmp which only intercepts _Unwind_ForcedUnwind, but not
     // regular C++ exception from routine(params), which should be handled by JVM
     if (__builtin_expect(
@@ -145,6 +151,61 @@ void run_with_cleanup(func_start_routine routine, void* params,
     pthread_cleanup_pop(1);
 #endif
 }
+
+#ifdef UNIT_TEST
+// Integration test entry point: exercises the full start_routine_wrapper →
+// run_with_cleanup chain without calling Profiler::registerThread or
+// Profiler::unregisterThread, which dereference _cpu_engine/_wall_engine and
+// crash when the profiler is not started (as in gtest).
+//
+// The caller supplies cleanup_fn/cleanup_arg so the test can verify cleanup
+// fires and observe ProfiledThread::release() without coupling to Profiler state.
+//
+// Thread lifecycle:
+//   pthread_create_wrapped_for_test → start_routine_for_test
+//     → ProfiledThread::initCurrentThread()
+//     → run_with_cleanup(routine, params, cleanup_fn, cleanup_arg)
+//     → pthread_exit(nullptr)
+struct WrapperTestCtx {
+    func_start_routine routine;
+    void* params;
+    void (*cleanup_fn)(void*);
+    void* cleanup_arg;
+};
+
+__attribute__((visibility("hidden"), noinline, no_stack_protector))
+static void* start_routine_for_test(void* raw) {
+    auto* ctx = static_cast<WrapperTestCtx*>(raw);
+    func_start_routine routine = ctx->routine;
+    void* params = ctx->params;
+    void (*cleanup_fn)(void*) = ctx->cleanup_fn;
+    void* cleanup_arg = ctx->cleanup_arg;
+    {
+        SignalBlocker blocker;
+        delete ctx;
+        ProfiledThread::initCurrentThread();
+    }
+    run_with_cleanup(routine, params, cleanup_fn, cleanup_arg);
+    pthread_exit(nullptr);
+    __builtin_unreachable();
+}
+
+int pthread_create_wrapped_for_test(pthread_t* thread,
+                                    func_start_routine routine, void* params,
+                                    void (*cleanup_fn)(void*), void* cleanup_arg) {
+    WrapperTestCtx* ctx;
+    {
+        SignalBlocker blocker;
+        ctx = new WrapperTestCtx{routine, params, cleanup_fn, cleanup_arg};
+    }
+    int ret = pthread_create(thread, nullptr, start_routine_for_test, ctx);
+    if (ret != 0) {
+        SignalBlocker blocker;
+        delete ctx;
+    }
+    return ret;
+}
+#endif  // UNIT_TEST
 
 #ifdef __aarch64__
 // Delete RoutineInfo with profiling signals blocked to prevent ASAN
@@ -283,7 +344,8 @@ static void* start_routine_wrapper(void* args) {
     }
     // Use POSIX cleanup instead of C++ RAII to handle pthread_exit(): see run_with_cleanup.
     run_with_cleanup(routine, params, cleanup_unregister, nullptr);
-    return nullptr;
+    pthread_exit(nullptr); 
+    __builtin_unreachable();
 }
 
 static int pthread_create_hook(pthread_t* thread,

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -147,14 +147,12 @@ void Profiler::resetUnregisterObservableForTest() {
 
 void Profiler::unregisterThread(int tid) {
 #ifdef UNIT_TEST
-    // In gtest, _cpu_engine/_wall_engine are null (profiler not started).
-    // Record the tid so integration tests can verify the call happened without
-    // crashing on the null engine dereference.  This bypasses the real engine
-    // unregister path entirely, so that path is covered only by JVM-level tests,
-    // not by these gtests.  UNIT_TEST is defined solely for the gtest binaries
-    // (see GtestTaskBuilder); the shipped library never compiles this branch.
+    // Record the tid so integration tests can observe that unregisterThread
+    // was called with the correct thread id.
     g_test_last_unregistered_tid.store(tid, std::memory_order_relaxed);
-    return;
+    // In gtest, the profiler may not be started (_instance == nullptr).
+    // Skip the engine calls in that case rather than bypassing them entirely.
+    if (_instance == nullptr) return;
 #endif
   _instance->_cpu_engine->unregisterThread(tid);
   _instance->_wall_engine->unregisterThread(tid);

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -147,12 +147,14 @@ void Profiler::resetUnregisterObservableForTest() {
 
 void Profiler::unregisterThread(int tid) {
 #ifdef UNIT_TEST
-    // Record the tid so integration tests can observe that unregisterThread
-    // was called with the correct thread id.
+    // In gtest, _cpu_engine/_wall_engine are null (profiler not started).
+    // Record the tid so integration tests can verify the call happened without
+    // crashing on the null engine dereference.  This bypasses the real engine
+    // unregister path entirely, so that path is covered only by JVM-level tests,
+    // not by these gtests.  UNIT_TEST is defined solely for the gtest binaries
+    // (see GtestTaskBuilder); the shipped library never compiles this branch.
     g_test_last_unregistered_tid.store(tid, std::memory_order_relaxed);
-    // In gtest, the profiler may not be started (_instance == nullptr).
-    // Skip the engine calls in that case rather than bypassing them entirely.
-    if (_instance == nullptr) return;
+    return;
 #endif
   _instance->_cpu_engine->unregisterThread(tid);
   _instance->_wall_engine->unregisterThread(tid);

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -149,7 +149,10 @@ void Profiler::unregisterThread(int tid) {
 #ifdef UNIT_TEST
     // In gtest, _cpu_engine/_wall_engine are null (profiler not started).
     // Record the tid so integration tests can verify the call happened without
-    // crashing on the null engine dereference.
+    // crashing on the null engine dereference.  This bypasses the real engine
+    // unregister path entirely, so that path is covered only by JVM-level tests,
+    // not by these gtests.  UNIT_TEST is defined solely for the gtest binaries
+    // (see GtestTaskBuilder); the shipped library never compiles this branch.
     g_test_last_unregistered_tid.store(tid, std::memory_order_relaxed);
     return;
 #endif

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -134,7 +134,25 @@ int Profiler::registerThread(int tid) {
   return _instance->_cpu_engine->registerThread(tid) |
          _instance->_wall_engine->registerThread(tid);
 }
+#ifdef UNIT_TEST
+static std::atomic<int> g_test_last_unregistered_tid{-1};
+
+int Profiler::lastUnregisteredTidForTest() {
+    return g_test_last_unregistered_tid.load(std::memory_order_relaxed);
+}
+void Profiler::resetUnregisterObservableForTest() {
+    g_test_last_unregistered_tid.store(-1, std::memory_order_relaxed);
+}
+#endif
+
 void Profiler::unregisterThread(int tid) {
+#ifdef UNIT_TEST
+    // In gtest, _cpu_engine/_wall_engine are null (profiler not started).
+    // Record the tid so integration tests can verify the call happened without
+    // crashing on the null engine dereference.
+    g_test_last_unregistered_tid.store(tid, std::memory_order_relaxed);
+    return;
+#endif
   _instance->_cpu_engine->unregisterThread(tid);
   _instance->_wall_engine->unregisterThread(tid);
 }

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -403,6 +403,15 @@ public:
   static int registerThread(int tid);
   static void unregisterThread(int tid);
 
+#ifdef UNIT_TEST
+  // Returns the tid most recently passed to unregisterThread(), or -1 if it
+  // has never been called (or since the last resetUnregisterObservableForTest).
+  // Used by integration tests to assert that cleanup_unregister wired
+  // Profiler::unregisterThread correctly without needing live engine instances.
+  static int  lastUnregisteredTidForTest();
+  static void resetUnregisterObservableForTest();
+#endif
+
 
   static void JNICALL ThreadStart(jvmtiEnv *jvmti, JNIEnv *jni,
                                   jthread thread) {

--- a/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
+++ b/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
@@ -47,6 +47,7 @@
 
 #include <atomic>
 #include <pthread.h>
+#include <setjmp.h>
 #include <unistd.h>
 
 // ===========================================================================

--- a/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
+++ b/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
@@ -171,6 +171,60 @@ TEST(ForcedUnwindTest, CleanupCallbackRunsOnPthreadExit) {
     EXPECT_EQ(reinterpret_cast<void*>(42), retval);
 }
 
+// ---------------------------------------------------------------------------
+
+static std::atomic<int> g_nr_cleanup_count{0};
+static std::atomic<bool> g_nr_past_run{false};
+
+static void* nr_routine(void*) { return nullptr; }
+
+static void nr_cleanup(void*) {
+    g_nr_cleanup_count.fetch_add(1, std::memory_order_relaxed);
+}
+
+static void* nr_thread(void*) {
+    g_nr_cleanup_count.store(0, std::memory_order_relaxed);
+    g_nr_past_run.store(false, std::memory_order_relaxed);
+    run_with_cleanup(nr_routine, nullptr, nr_cleanup, nullptr);
+    g_nr_past_run.store(true, std::memory_order_relaxed);
+    // Spin with a cancellation point so the main thread can probe whether
+    // __pthread_unregister_cancel took effect after run_with_cleanup returned.
+    while (true) {
+        pthread_testcancel();
+        usleep(50);
+    }
+}
+
+// Normal-return path (matches start_routine_wrapper on non-aarch64 glibc):
+// cleanup_fn is called once AND __pthread_unregister_cancel removes the buf.
+// Removing either call on this path is detected:
+//   - no cleanup_fn             → g_nr_cleanup_count stays 0
+//   - no __pthread_unregister_cancel → post-return cancel longjmps into the
+//     freed cancel_buf (UB: crash or g_nr_cleanup_count becomes 2)
+TEST(ForcedUnwindTest, CleanupCalledExactlyOnceOnNormalReturn) {
+    pthread_t t;
+    ASSERT_EQ(0, pthread_create(&t, nullptr, nr_thread, nullptr));
+
+    while (!g_nr_past_run.load(std::memory_order_relaxed)) {
+        usleep(100);
+    }
+    EXPECT_EQ(1, g_nr_cleanup_count.load())
+        << "cleanup_fn must be called once on the normal-return path of run_with_cleanup";
+
+    // Cancel the spinning thread.  If __pthread_unregister_cancel was not
+    // called, glibc still holds a pointer to run_with_cleanup's freed
+    // cancel_buf; the cancel would longjmp into garbage and either crash or
+    // fire nr_cleanup a second time (count == 2).
+    pthread_cancel(t);
+    void* retval;
+    ASSERT_EQ(0, pthread_join(t, &retval));
+
+    EXPECT_EQ(1, g_nr_cleanup_count.load())
+        << "__pthread_unregister_cancel must remove the buf so the "
+           "post-return cancel does not re-fire cleanup_fn";
+    EXPECT_EQ(PTHREAD_CANCELED, retval);
+}
+
 #endif  // __GLIBC__
 
 // ===========================================================================

--- a/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
+++ b/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
@@ -434,9 +434,11 @@ TEST(ForcedUnwindTest, CleanupCalledExactlyOnceOnNormalReturn) {
 // no-op cleanup, would leave the unit tests passing but fail these tests.
 // ===========================================================================
 
-// Test entry point declared in libraryPatcher_linux.cpp under #ifdef UNIT_TEST.
+// Test entry points declared in libraryPatcher_linux.cpp under #ifdef UNIT_TEST.
 extern "C++" int pthread_create_wrapped_for_test(
     pthread_t*, void* (*)(void*), void*, void (*)(void*), void*);
+extern "C++" int pthread_create_with_cleanup_unregister_for_test(
+    pthread_t*, void* (*)(void*), void*);
 
 // ---------------------------------------------------------------------------
 
@@ -512,6 +514,76 @@ TEST(ForcedUnwindTest, WrapperReleasesProfiledThreadOnPthreadExit) {
     EXPECT_TRUE(g_int_exit_released.load())
         << "ProfiledThread::release() must complete inside the wrapper cleanup";
     EXPECT_EQ(reinterpret_cast<void*>(99), retval);
+}
+
+// ---------------------------------------------------------------------------
+// Production-cleanup integration: cleanup_unregister calls
+// Profiler::unregisterThread with the wrapped thread's TID.
+// Replacing unregister_and_release with a bare ProfiledThread::release() would
+// leave WrapperReleasesProfiledThreadOnCancel/PthreadExit passing but fail here.
+
+#include "profiler.h"
+
+static std::atomic<int> g_int_prod_cancel_tid{-1};
+
+static void* int_prod_cancel_spin(void*) {
+    g_int_prod_cancel_tid.store(ProfiledThread::currentTid(),
+                                std::memory_order_relaxed);
+    while (true) {
+        pthread_testcancel();
+        usleep(100);
+    }
+}
+
+// Integration: cleanup_unregister calls Profiler::unregisterThread(tid) on cancel.
+TEST(ForcedUnwindTest, WrapperCallsProfilerUnregisterOnCancel) {
+    g_int_prod_cancel_tid.store(-1, std::memory_order_relaxed);
+    Profiler::resetUnregisterObservableForTest();
+
+    pthread_t t;
+    ASSERT_EQ(0, pthread_create_with_cleanup_unregister_for_test(
+        &t, int_prod_cancel_spin, nullptr));
+
+    while (g_int_prod_cancel_tid.load(std::memory_order_relaxed) == -1) {
+        usleep(100);
+    }
+    const int expected_tid = g_int_prod_cancel_tid.load(std::memory_order_relaxed);
+
+    pthread_cancel(t);
+    void* retval;
+    ASSERT_EQ(0, pthread_join(t, &retval));
+
+    EXPECT_EQ(expected_tid, Profiler::lastUnregisteredTidForTest())
+        << "cleanup_unregister must call Profiler::unregisterThread(tid) on cancel";
+    EXPECT_EQ(PTHREAD_CANCELED, retval);
+}
+
+// ---------------------------------------------------------------------------
+
+static std::atomic<int> g_int_prod_exit_tid{-1};
+
+static void* int_prod_exit_fn(void*) {
+    g_int_prod_exit_tid.store(ProfiledThread::currentTid(),
+                               std::memory_order_relaxed);
+    pthread_exit(reinterpret_cast<void*>(55));
+}
+
+// Integration: cleanup_unregister calls Profiler::unregisterThread(tid) on pthread_exit.
+TEST(ForcedUnwindTest, WrapperCallsProfilerUnregisterOnPthreadExit) {
+    g_int_prod_exit_tid.store(-1, std::memory_order_relaxed);
+    Profiler::resetUnregisterObservableForTest();
+
+    pthread_t t;
+    ASSERT_EQ(0, pthread_create_with_cleanup_unregister_for_test(
+        &t, int_prod_exit_fn, nullptr));
+
+    void* retval;
+    ASSERT_EQ(0, pthread_join(t, &retval));
+
+    EXPECT_EQ(g_int_prod_exit_tid.load(std::memory_order_relaxed),
+              Profiler::lastUnregisteredTidForTest())
+        << "cleanup_unregister must call Profiler::unregisterThread(tid) on pthread_exit";
+    EXPECT_EQ(reinterpret_cast<void*>(55), retval);
 }
 
 #endif  // __linux__

--- a/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
+++ b/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
@@ -31,10 +31,10 @@
  *             so there is no incompatibility issue.
  *
  * These tests verify the per-platform cleanup path:
- *   glibc  – __pthread_register_cancel callback fires on pthread_cancel and
- *             pthread_exit.
- *   musl   – pthread_cleanup_push callback fires on pthread_cancel and
- *             pthread_exit.
+ *   glibc  – __pthread_register_cancel callback fires on pthread_cancel,
+ *             pthread_exit, and normal routine return.
+ *   musl   – run_with_cleanup (pthread_cleanup_push/pop) callback fires on
+ *             pthread_cancel, pthread_exit, and normal routine return.
  * A shared test verifies ProfiledThread::release() is safe to call from the
  * chosen cleanup path.
  */
@@ -50,13 +50,15 @@
 #include <setjmp.h>
 #include <unistd.h>
 
+// Production function under test — defined in libraryPatcher_linux.cpp.
+// Declared here (outside any platform guard) because run_with_cleanup is built
+// on both glibc and musl; each platform's tests call it directly.
+extern "C++" void run_with_cleanup(void* (*)(void*), void*, void(*)(void*), void*);
+
 // ===========================================================================
 // glibc path: __pthread_register_cancel / __pthread_unregister_cancel tests
 // ===========================================================================
 #ifdef __GLIBC__
-
-// Production function under test — defined in libraryPatcher_linux.cpp.
-extern "C++" void run_with_cleanup(void* (*)(void*), void*, void(*)(void*), void*);
 
 // ---------------------------------------------------------------------------
 
@@ -193,6 +195,7 @@ static void* nr_thread(void*) {
         pthread_testcancel();
         usleep(50);
     }
+    __builtin_unreachable();
 }
 
 // Normal-return path (matches start_routine_wrapper on non-aarch64 glibc):
@@ -201,6 +204,8 @@ static void* nr_thread(void*) {
 //   - no cleanup_fn             → g_nr_cleanup_count stays 0
 //   - no __pthread_unregister_cancel → post-return cancel longjmps into the
 //     freed cancel_buf (UB: crash or g_nr_cleanup_count becomes 2)
+// Note: under ASAN/MSAN the UAF detection path (count==2) is not guaranteed — 
+// a crash is also acceptable evidence.
 TEST(ForcedUnwindTest, CleanupCalledExactlyOnceOnNormalReturn) {
     pthread_t t;
     ASSERT_EQ(0, pthread_create(&t, nullptr, nr_thread, nullptr));
@@ -225,34 +230,78 @@ TEST(ForcedUnwindTest, CleanupCalledExactlyOnceOnNormalReturn) {
     EXPECT_EQ(PTHREAD_CANCELED, retval);
 }
 
+// ---------------------------------------------------------------------------
+
+static std::atomic<bool> g_pt_nr_called{false};
+static std::atomic<bool> g_pt_nr_release_called{false};
+
+static void* pt_nr_routine(void*) { return nullptr; }
+
+static void pt_nr_cleanup(void*) {
+    g_pt_nr_called.store(true, std::memory_order_relaxed);
+    ProfiledThread::release();
+    g_pt_nr_release_called.store(true, std::memory_order_relaxed);
+}
+
+static void* pt_nr_thread(void*) {
+    g_pt_nr_called.store(false, std::memory_order_relaxed);
+    g_pt_nr_release_called.store(false, std::memory_order_relaxed);
+    ProfiledThread::initCurrentThread();
+    run_with_cleanup(pt_nr_routine, nullptr, pt_nr_cleanup, nullptr);
+    return reinterpret_cast<void*>(77);
+}
+
+// Regression (glibc): cleanup_fn fires and ProfiledThread is released when
+// routine returns normally.  This is the start_routine_wrapper path for
+// threads that finish naturally (no cancel, no pthread_exit).
+// Removing cleanup_fn(cleanup_arg) after __pthread_unregister_cancel leaves
+// g_pt_nr_called false and leaks the ProfiledThread entry.
+TEST(ForcedUnwindTest, ProfiledThreadReleasedOnNormalReturn) {
+    pthread_t t;
+    ASSERT_EQ(0, pthread_create(&t, nullptr, pt_nr_thread, nullptr));
+
+    void* retval;
+    ASSERT_EQ(0, pthread_join(t, &retval));
+
+    EXPECT_TRUE(g_pt_nr_called.load())
+        << "cleanup_fn must be called on the normal-return path";
+    EXPECT_TRUE(g_pt_nr_release_called.load())
+        << "ProfiledThread::release() must complete on the normal-return path";
+    EXPECT_EQ(reinterpret_cast<void*>(77), retval);
+}
+
 #endif  // __GLIBC__
 
 // ===========================================================================
-// musl (non-glibc) path: pthread_cleanup_push/pop callback tests
+// musl (non-glibc) path: run_with_cleanup (pthread_cleanup_push/pop) tests
 // ===========================================================================
 #ifndef __GLIBC__
 
-static std::atomic<bool> g_c_cancel_called{false};
+// ---------------------------------------------------------------------------
 
-static void c_cleanup_cancel(void*) {
-    g_c_cancel_called.store(true, std::memory_order_relaxed);
+static std::atomic<bool> g_m_cancel_called{false};
+
+static void m_cancel_cleanup(void*) {
+    g_m_cancel_called.store(true, std::memory_order_relaxed);
 }
 
-static void* c_cleanup_cancel_thread(void*) {
-    g_c_cancel_called.store(false, std::memory_order_relaxed);
-    pthread_cleanup_push(c_cleanup_cancel, nullptr);
+static void* m_cancel_spin(void*) {
     while (true) {
         pthread_testcancel();
         usleep(100);
     }
-    pthread_cleanup_pop(0);
+}
+
+static void* m_cancel_thread(void*) {
+    g_m_cancel_called.store(false, std::memory_order_relaxed);
+    run_with_cleanup(m_cancel_spin, nullptr, m_cancel_cleanup, nullptr);
     return nullptr;
 }
 
-// Regression (musl): C-style pthread_cleanup_push callback fires on pthread_cancel.
+// musl: run_with_cleanup cleanup fires on pthread_cancel.
 TEST(ForcedUnwindTest, CleanupCallbackRunsOnPthreadCancel) {
     pthread_t t;
-    ASSERT_EQ(0, pthread_create(&t, nullptr, c_cleanup_cancel_thread, nullptr));
+    ASSERT_EQ(0, pthread_create(&t, nullptr, m_cancel_thread, nullptr));
 
     usleep(5000);
     pthread_cancel(t);
@@ -260,76 +309,72 @@ TEST(ForcedUnwindTest, CleanupCallbackRunsOnPthreadCancel) {
     void* retval;
     ASSERT_EQ(0, pthread_join(t, &retval));
 
-    EXPECT_TRUE(g_c_cancel_called.load())
-        << "pthread_cleanup_push callback must run during pthread_cancel on musl";
+    EXPECT_TRUE(g_m_cancel_called.load())
+        << "run_with_cleanup cleanup must fire during pthread_cancel on musl";
     EXPECT_EQ(PTHREAD_CANCELED, retval);
 }
 
 // ---------------------------------------------------------------------------
 
-static std::atomic<bool> g_c_exit_called{false};
+static std::atomic<bool> g_m_exit_called{false};
 
-static void c_cleanup_exit(void*) {
-    g_c_exit_called.store(true, std::memory_order_relaxed);
+static void m_exit_cleanup(void*) {
+    g_m_exit_called.store(true, std::memory_order_relaxed);
 }
 
-static void* c_cleanup_exit_thread(void*) {
-    g_c_exit_called.store(false, std::memory_order_relaxed);
-    pthread_cleanup_push(c_cleanup_exit, nullptr);
+static void* m_exit_fn(void*) {
     pthread_exit(reinterpret_cast<void*>(42));
-    pthread_cleanup_pop(0);
+}
+
+static void* m_exit_thread(void*) {
+    g_m_exit_called.store(false, std::memory_order_relaxed);
+    run_with_cleanup(m_exit_fn, nullptr, m_exit_cleanup, nullptr);
     return nullptr;
 }
 
-// Regression (musl): C-style pthread_cleanup_push callback fires on pthread_exit.
+// musl: run_with_cleanup cleanup fires on pthread_exit.
 TEST(ForcedUnwindTest, CleanupCallbackRunsOnPthreadExit) {
     pthread_t t;
-    ASSERT_EQ(0, pthread_create(&t, nullptr, c_cleanup_exit_thread, nullptr));
+    ASSERT_EQ(0, pthread_create(&t, nullptr, m_exit_thread, nullptr));
 
     void* retval;
     ASSERT_EQ(0, pthread_join(t, &retval));
 
-    EXPECT_TRUE(g_c_exit_called.load())
-        << "pthread_cleanup_push callback must run during pthread_exit on musl";
+    EXPECT_TRUE(g_m_exit_called.load())
+        << "run_with_cleanup cleanup must fire during pthread_exit on musl";
     EXPECT_EQ(reinterpret_cast<void*>(42), retval);
 }
 
 // ---------------------------------------------------------------------------
 
-static std::atomic<bool> g_c_pt_called{false};
-static std::atomic<bool> g_c_pt_release_called{false};
+static std::atomic<bool> g_m_pt_called{false};
+static std::atomic<bool> g_m_pt_release_called{false};
 
-static void profiled_c_cleanup(void* arg) {
-    int tid = *static_cast<int*>(arg);
-    (void)tid;
-    g_c_pt_called.store(true, std::memory_order_relaxed);
+static void m_profiled_cleanup(void*) {
+    g_m_pt_called.store(true, std::memory_order_relaxed);
     ProfiledThread::release();
-    g_c_pt_release_called.store(true, std::memory_order_relaxed);
+    g_m_pt_release_called.store(true, std::memory_order_relaxed);
 }
 
-static int g_c_pt_tid;
-
-static void* profiled_c_cancel_thread(void*) {
-    g_c_pt_called.store(false, std::memory_order_relaxed);
-    g_c_pt_release_called.store(false, std::memory_order_relaxed);
-
-    ProfiledThread::initCurrentThread();
-    g_c_pt_tid = ProfiledThread::currentTid();
-
-    pthread_cleanup_push(profiled_c_cleanup, &g_c_pt_tid);
+static void* m_profiled_spin(void*) {
     while (true) {
         pthread_testcancel();
         usleep(100);
     }
-    pthread_cleanup_pop(0);
+}
+
+static void* m_profiled_cancel_thread(void*) {
+    g_m_pt_called.store(false, std::memory_order_relaxed);
+    g_m_pt_release_called.store(false, std::memory_order_relaxed);
+    ProfiledThread::initCurrentThread();
+    run_with_cleanup(m_profiled_spin, nullptr, m_profiled_cleanup, nullptr);
     return nullptr;
 }
 
-// Regression (musl): pthread_cleanup_push pattern with ProfiledThread lifecycle
-// survives pthread_cancel.
+// musl: ProfiledThread lifecycle survives pthread_cancel via run_with_cleanup.
 TEST(ForcedUnwindTest, ProfiledThreadReleasedOnForcedUnwind) {
     pthread_t t;
-    ASSERT_EQ(0, pthread_create(&t, nullptr, profiled_c_cancel_thread, nullptr));
+    ASSERT_EQ(0, pthread_create(&t, nullptr, m_profiled_cancel_thread, nullptr));
 
     usleep(5000);
     pthread_cancel(t);
@@ -337,13 +382,136 @@ TEST(ForcedUnwindTest, ProfiledThreadReleasedOnForcedUnwind) {
     void* retval;
     ASSERT_EQ(0, pthread_join(t, &retval));
 
-    EXPECT_TRUE(g_c_pt_called.load())
-        << "C cleanup callback must run when thread is cancelled";
-    EXPECT_TRUE(g_c_pt_release_called.load())
-        << "ProfiledThread::release() must complete inside the C cleanup callback";
+    EXPECT_TRUE(g_m_pt_called.load())
+        << "Cleanup callback must run when thread is cancelled";
+    EXPECT_TRUE(g_m_pt_release_called.load())
+        << "ProfiledThread::release() must complete inside the cleanup callback";
     EXPECT_EQ(PTHREAD_CANCELED, retval);
 }
 
+// ---------------------------------------------------------------------------
+
+static std::atomic<int> g_m_nr_count{0};
+
+static void* m_nr_routine(void*) { return nullptr; }
+
+static void m_nr_cleanup(void*) {
+    g_m_nr_count.fetch_add(1, std::memory_order_relaxed);
+}
+
+static void* m_nr_thread(void*) {
+    g_m_nr_count.store(0, std::memory_order_relaxed);
+    run_with_cleanup(m_nr_routine, nullptr, m_nr_cleanup, nullptr);
+    return reinterpret_cast<void*>(77);
+}
+
+// musl: normal-return path calls cleanup exactly once via pthread_cleanup_pop(1).
+// Removing the pop or changing pop(1) to pop(0) leaves count at 0.
+TEST(ForcedUnwindTest, CleanupCalledExactlyOnceOnNormalReturn) {
+    pthread_t t;
+    ASSERT_EQ(0, pthread_create(&t, nullptr, m_nr_thread, nullptr));
+
+    void* retval;
+    ASSERT_EQ(0, pthread_join(t, &retval));
+
+    EXPECT_EQ(1, g_m_nr_count.load())
+        << "cleanup_fn must be called once via pthread_cleanup_pop(1) on the normal-return path";
+    EXPECT_EQ(reinterpret_cast<void*>(77), retval);
+}
+
 #endif  // !__GLIBC__
+
+// ===========================================================================
+// Integration tests: start_routine_for_test → run_with_cleanup chain
+//
+// These tests exercise the full path that start_routine_wrapper takes in
+// production (init TLS → run_with_cleanup → cleanup on cancel/exit), without
+// the Profiler::registerThread/unregisterThread calls that require a live
+// profiler instance.  Profiler registration is tested separately; these tests
+// cover the wiring between the wrapper and run_with_cleanup.
+//
+// Removing run_with_cleanup from start_routine_wrapper, or wiring it to a
+// no-op cleanup, would leave the unit tests passing but fail these tests.
+// ===========================================================================
+
+// Test entry point declared in libraryPatcher_linux.cpp under #ifdef UNIT_TEST.
+extern "C++" int pthread_create_wrapped_for_test(
+    pthread_t*, void* (*)(void*), void*, void (*)(void*), void*);
+
+// ---------------------------------------------------------------------------
+
+static std::atomic<bool> g_int_cancel_called{false};
+static std::atomic<bool> g_int_cancel_released{false};
+
+static void int_cancel_cleanup(void*) {
+    g_int_cancel_called.store(true, std::memory_order_relaxed);
+    ProfiledThread::release();
+    g_int_cancel_released.store(true, std::memory_order_relaxed);
+}
+
+static void* int_cancel_spin(void*) {
+    while (true) {
+        pthread_testcancel();
+        usleep(100);
+    }
+}
+
+// Integration: start_routine_for_test → run_with_cleanup → cleanup fires and
+// ProfiledThread is released on pthread_cancel.
+TEST(ForcedUnwindTest, WrapperReleasesProfiledThreadOnCancel) {
+    g_int_cancel_called.store(false, std::memory_order_relaxed);
+    g_int_cancel_released.store(false, std::memory_order_relaxed);
+
+    pthread_t t;
+    ASSERT_EQ(0, pthread_create_wrapped_for_test(
+        &t, int_cancel_spin, nullptr, int_cancel_cleanup, nullptr));
+
+    usleep(5000);
+    pthread_cancel(t);
+
+    void* retval;
+    ASSERT_EQ(0, pthread_join(t, &retval));
+
+    EXPECT_TRUE(g_int_cancel_called.load())
+        << "run_with_cleanup cleanup must fire when wrapped thread is cancelled";
+    EXPECT_TRUE(g_int_cancel_released.load())
+        << "ProfiledThread::release() must complete inside the wrapper cleanup";
+    EXPECT_EQ(PTHREAD_CANCELED, retval);
+}
+
+// ---------------------------------------------------------------------------
+
+static std::atomic<bool> g_int_exit_called{false};
+static std::atomic<bool> g_int_exit_released{false};
+
+static void int_exit_cleanup(void*) {
+    g_int_exit_called.store(true, std::memory_order_relaxed);
+    ProfiledThread::release();
+    g_int_exit_released.store(true, std::memory_order_relaxed);
+}
+
+static void* int_exit_fn(void*) {
+    pthread_exit(reinterpret_cast<void*>(99));
+}
+
+// Integration: start_routine_for_test → run_with_cleanup → cleanup fires and
+// ProfiledThread is released on pthread_exit.
+TEST(ForcedUnwindTest, WrapperReleasesProfiledThreadOnPthreadExit) {
+    g_int_exit_called.store(false, std::memory_order_relaxed);
+    g_int_exit_released.store(false, std::memory_order_relaxed);
+
+    pthread_t t;
+    ASSERT_EQ(0, pthread_create_wrapped_for_test(
+        &t, int_exit_fn, nullptr, int_exit_cleanup, nullptr));
+
+    void* retval;
+    ASSERT_EQ(0, pthread_join(t, &retval));
+
+    EXPECT_TRUE(g_int_exit_called.load())
+        << "run_with_cleanup cleanup must fire when wrapped thread calls pthread_exit";
+    EXPECT_TRUE(g_int_exit_released.load())
+        << "ProfiledThread::release() must complete inside the wrapper cleanup";
+    EXPECT_EQ(reinterpret_cast<void*>(99), retval);
+}
 
 #endif  // __linux__

--- a/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
+++ b/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
@@ -2,26 +2,39 @@
  * Copyright 2026, Datadog, Inc.
  * SPDX-License-Identifier: Apache-2.0
  *
- * Regression test for SCP-1154: IBM J9 JVM crash in start_routine_wrapper.
+ * Regression test for the static-libgcc / forced-unwind incompatibility in
+ * start_routine_wrapper (libraryPatcher_linux.cpp).
  *
- * Root cause: pthread_cleanup_push in C++ mode on glibc creates
- * __pthread_cleanup_class with an implicitly-noexcept destructor.  When IBM
- * J9's thread teardown raises _Unwind_ForcedUnwind (via libgcc), the C++
- * runtime calls std::terminate() because the forced-unwind exception exits a
- * noexcept-bounded destructor.
+ * Root cause: when libjavaProfiler.so is built with -static-libgcc, its
+ * embedded __gxx_personality_v0 is called by the dynamic libgcc_s.so.1's
+ * _Unwind_ForcedUnwind (triggered by pthread_exit / pthread_cancel).  The two
+ * libgcc versions have incompatible _Unwind_Context layouts; calling
+ * _Unwind_SetGR with a cross-version context triggers _Unwind_SetGR.cold,
+ * which calls abort().  The same crash affects any gtest binary that is also
+ * built with -static-libgcc.
+ *
+ * C++ RAII destructors (struct Cleanup { ~Cleanup() {...} }) add cleanup
+ * entries to the LSDA, which cause __gxx_personality_v0 to call _Unwind_SetGR
+ * → crash.  The pthread_cleanup_push C++ macro (__pthread_cleanup_class RAII)
+ * has the same problem.
  *
  * Cleanup strategy (matches libraryPatcher_linux.cpp):
- *   - glibc: RAII struct destructor.  Glibc's personality function handles
- *     forced-unwind correctly for user-defined destructors; IBM J9's forced-
- *     unwind also invokes personality functions.
- *   - musl:  pthread_cleanup_push/pop (C-style callback).  musl's signal-based
- *     thread cancellation invokes registered C callbacks but does NOT run C++
- *     destructors.
+ *   - glibc:  Use __pthread_register_cancel / __pthread_unregister_cancel
+ *             directly (the same mechanism the C form of pthread_cleanup_push
+ *             uses).  This registers cleanup via a setjmp buffer in a runtime
+ *             linked-list, NOT in the LSDA.  _Unwind_ForcedUnwind's stop
+ *             function (__pthread_unwind_stop) handles the cleanup without
+ *             ever calling __gxx_personality_v0 for the registered frame, so
+ *             _Unwind_SetGR is never called and no crash occurs.
+ *   - musl:   pthread_cleanup_push already uses the C/setjmp form (no RAII).
+ *             pthread_exit on musl does not use _Unwind_ForcedUnwind at all,
+ *             so there is no incompatibility issue.
  *
  * These tests verify the per-platform cleanup path:
- *   glibc  – RAII destructor fires on pthread_cancel and pthread_exit.
+ *   glibc  – __pthread_register_cancel callback fires on pthread_cancel and
+ *             pthread_exit.
  *   musl   – pthread_cleanup_push callback fires on pthread_cancel and
- *            pthread_exit.
+ *             pthread_exit.
  * A shared test verifies ProfiledThread::release() is safe to call from the
  * chosen cleanup path.
  */
@@ -37,28 +50,60 @@
 #include <unistd.h>
 
 // ===========================================================================
-// glibc path: RAII destructor tests
+// glibc path: __pthread_register_cancel / __pthread_unregister_cancel tests
 // ===========================================================================
 #ifdef __GLIBC__
 
+// Redeclare glibc internals (hidden behind #ifndef __cplusplus in <pthread.h>).
+extern "C" {
+    extern void __pthread_register_cancel(__pthread_unwind_buf_t*);
+    extern void __pthread_unregister_cancel(__pthread_unwind_buf_t*);
+    [[noreturn]] extern void __pthread_unwind_next(__pthread_unwind_buf_t*);
+}
+
+// Helper: run `fn(arg)` with a glibc C-form cleanup handler that calls
+// `cleanup(cleanup_arg)` if the thread is canceled or calls pthread_exit
+// before fn returns.  Mirrors run_with_cleanup in libraryPatcher_linux.cpp.
+static void run_with_cancel_handler(
+        void (*fn)(void*), void* arg,
+        void (*cleanup)(void*), void* cleanup_arg) {
+    __pthread_unwind_buf_t cancel_buf;
+    if (__builtin_expect(
+            __sigsetjmp((struct __jmp_buf_tag*)(void*)cancel_buf.__cancel_jmp_buf, 0), 0)) {
+        cleanup(cleanup_arg);
+        __pthread_unwind_next(&cancel_buf);
+    }
+    __pthread_register_cancel(&cancel_buf);
+    fn(arg);
+    __pthread_unregister_cancel(&cancel_buf);
+    cleanup(cleanup_arg);
+}
+
+// ---------------------------------------------------------------------------
+
 static std::atomic<bool> g_bare_cleanup_called{false};
 
-static void* bare_raii_cancel_thread(void*) {
-    g_bare_cleanup_called.store(false, std::memory_order_relaxed);
-    struct Cleanup {
-        ~Cleanup() { g_bare_cleanup_called.store(true, std::memory_order_relaxed); }
-    } cleanup;
+static void bare_cleanup(void*) {
+    g_bare_cleanup_called.store(true, std::memory_order_relaxed);
+}
+
+static void bare_spin(void*) {
     while (true) {
         pthread_testcancel();
         usleep(100);
     }
+}
+
+static void* bare_cancel_thread(void*) {
+    g_bare_cleanup_called.store(false, std::memory_order_relaxed);
+    run_with_cancel_handler(bare_spin, nullptr, bare_cleanup, nullptr);
     return nullptr;
 }
 
-// Regression (glibc): RAII destructor fires on pthread_cancel.
-TEST(ForcedUnwindTest, RaiiDestructorRunsOnPthreadCancel) {
+// Regression (glibc): __pthread_register_cancel callback fires on pthread_cancel.
+TEST(ForcedUnwindTest, CleanupCallbackRunsOnPthreadCancel) {
     pthread_t t;
-    ASSERT_EQ(0, pthread_create(&t, nullptr, bare_raii_cancel_thread, nullptr));
+    ASSERT_EQ(0, pthread_create(&t, nullptr, bare_cancel_thread, nullptr));
 
     usleep(5000);
     pthread_cancel(t);
@@ -67,7 +112,7 @@ TEST(ForcedUnwindTest, RaiiDestructorRunsOnPthreadCancel) {
     ASSERT_EQ(0, pthread_join(t, &retval));
 
     EXPECT_TRUE(g_bare_cleanup_called.load())
-        << "RAII destructor must run during pthread_cancel forced unwind";
+        << "__pthread_register_cancel callback must run during pthread_cancel";
     EXPECT_EQ(PTHREAD_CANCELED, retval);
 }
 
@@ -76,32 +121,32 @@ TEST(ForcedUnwindTest, RaiiDestructorRunsOnPthreadCancel) {
 static std::atomic<bool> g_pt_cleanup_called{false};
 static std::atomic<bool> g_pt_release_called{false};
 
-static void* profiled_raii_cancel_thread(void*) {
-    g_pt_cleanup_called.store(false, std::memory_order_relaxed);
-    g_pt_release_called.store(false, std::memory_order_relaxed);
+static void profiled_cleanup(void*) {
+    g_pt_cleanup_called.store(true, std::memory_order_relaxed);
+    ProfiledThread::release();
+    g_pt_release_called.store(true, std::memory_order_relaxed);
+}
 
-    ProfiledThread::initCurrentThread();
-
-    struct Cleanup {
-        ~Cleanup() {
-            g_pt_cleanup_called.store(true, std::memory_order_relaxed);
-            ProfiledThread::release();
-            g_pt_release_called.store(true, std::memory_order_relaxed);
-        }
-    } cleanup;
-
+static void profiled_spin(void*) {
     while (true) {
         pthread_testcancel();
         usleep(100);
     }
+}
+
+static void* profiled_cancel_thread(void*) {
+    g_pt_cleanup_called.store(false, std::memory_order_relaxed);
+    g_pt_release_called.store(false, std::memory_order_relaxed);
+    ProfiledThread::initCurrentThread();
+    run_with_cancel_handler(profiled_spin, nullptr, profiled_cleanup, nullptr);
     return nullptr;
 }
 
-// Regression (glibc): RAII pattern with ProfiledThread lifecycle survives
-// pthread_cancel without terminate().
+// Regression (glibc): ProfiledThread lifecycle survives pthread_cancel without
+// abort() from _Unwind_SetGR.cold (the static-libgcc / libgcc_s.so.1 clash).
 TEST(ForcedUnwindTest, ProfiledThreadReleasedOnForcedUnwind) {
     pthread_t t;
-    ASSERT_EQ(0, pthread_create(&t, nullptr, profiled_raii_cancel_thread, nullptr));
+    ASSERT_EQ(0, pthread_create(&t, nullptr, profiled_cancel_thread, nullptr));
 
     usleep(5000);
     pthread_cancel(t);
@@ -110,9 +155,9 @@ TEST(ForcedUnwindTest, ProfiledThreadReleasedOnForcedUnwind) {
     ASSERT_EQ(0, pthread_join(t, &retval));
 
     EXPECT_TRUE(g_pt_cleanup_called.load())
-        << "RAII destructor must run when thread is cancelled";
+        << "Cleanup callback must run when thread is cancelled";
     EXPECT_TRUE(g_pt_release_called.load())
-        << "ProfiledThread::release() must complete inside the RAII destructor";
+        << "ProfiledThread::release() must complete inside the cleanup callback";
     EXPECT_EQ(PTHREAD_CANCELED, retval);
 }
 
@@ -120,25 +165,30 @@ TEST(ForcedUnwindTest, ProfiledThreadReleasedOnForcedUnwind) {
 
 static std::atomic<bool> g_exit_cleanup_called{false};
 
-static void* raii_pthread_exit_thread(void*) {
-    g_exit_cleanup_called.store(false, std::memory_order_relaxed);
-    struct Cleanup {
-        ~Cleanup() { g_exit_cleanup_called.store(true, std::memory_order_relaxed); }
-    } cleanup;
+static void exit_cleanup(void*) {
+    g_exit_cleanup_called.store(true, std::memory_order_relaxed);
+}
+
+static void exit_fn(void*) {
     pthread_exit(reinterpret_cast<void*>(42));
+}
+
+static void* exit_thread(void*) {
+    g_exit_cleanup_called.store(false, std::memory_order_relaxed);
+    run_with_cancel_handler(exit_fn, nullptr, exit_cleanup, nullptr);
     return nullptr;
 }
 
-// Regression (glibc): RAII destructor fires on pthread_exit.
-TEST(ForcedUnwindTest, RaiiDestructorRunsOnPthreadExit) {
+// Regression (glibc): __pthread_register_cancel callback fires on pthread_exit.
+TEST(ForcedUnwindTest, CleanupCallbackRunsOnPthreadExit) {
     pthread_t t;
-    ASSERT_EQ(0, pthread_create(&t, nullptr, raii_pthread_exit_thread, nullptr));
+    ASSERT_EQ(0, pthread_create(&t, nullptr, exit_thread, nullptr));
 
     void* retval;
     ASSERT_EQ(0, pthread_join(t, &retval));
 
     EXPECT_TRUE(g_exit_cleanup_called.load())
-        << "RAII destructor must also run during pthread_exit";
+        << "__pthread_register_cancel callback must also run during pthread_exit";
     EXPECT_EQ(reinterpret_cast<void*>(42), retval);
 }
 

--- a/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
+++ b/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
@@ -55,30 +55,8 @@
 // ===========================================================================
 #ifdef __GLIBC__
 
-// Redeclare glibc internals (hidden behind #ifndef __cplusplus in <pthread.h>).
-extern "C" {
-    extern void __pthread_register_cancel(__pthread_unwind_buf_t*);
-    extern void __pthread_unregister_cancel(__pthread_unwind_buf_t*);
-    [[noreturn]] extern void __pthread_unwind_next(__pthread_unwind_buf_t*);
-}
-
-// Helper: run `fn(arg)` with a glibc C-form cleanup handler that calls
-// `cleanup(cleanup_arg)` if the thread is canceled or calls pthread_exit
-// before fn returns.  Mirrors run_with_cleanup in libraryPatcher_linux.cpp.
-static void run_with_cancel_handler(
-        void (*fn)(void*), void* arg,
-        void (*cleanup)(void*), void* cleanup_arg) {
-    __pthread_unwind_buf_t cancel_buf;
-    if (__builtin_expect(
-            __sigsetjmp((struct __jmp_buf_tag*)(void*)cancel_buf.__cancel_jmp_buf, 0), 0)) {
-        cleanup(cleanup_arg);
-        __pthread_unwind_next(&cancel_buf);
-    }
-    __pthread_register_cancel(&cancel_buf);
-    fn(arg);
-    __pthread_unregister_cancel(&cancel_buf);
-    cleanup(cleanup_arg);
-}
+// Production function under test — defined in libraryPatcher_linux.cpp.
+extern "C++" void run_with_cleanup(void* (*)(void*), void*, void(*)(void*), void*);
 
 // ---------------------------------------------------------------------------
 
@@ -88,7 +66,7 @@ static void bare_cleanup(void*) {
     g_bare_cleanup_called.store(true, std::memory_order_relaxed);
 }
 
-static void bare_spin(void*) {
+static void* bare_spin(void*) {
     while (true) {
         pthread_testcancel();
         usleep(100);
@@ -97,7 +75,7 @@ static void bare_spin(void*) {
 
 static void* bare_cancel_thread(void*) {
     g_bare_cleanup_called.store(false, std::memory_order_relaxed);
-    run_with_cancel_handler(bare_spin, nullptr, bare_cleanup, nullptr);
+    run_with_cleanup(bare_spin, nullptr, bare_cleanup, nullptr);
     return nullptr;
 }
 
@@ -128,7 +106,7 @@ static void profiled_cleanup(void*) {
     g_pt_release_called.store(true, std::memory_order_relaxed);
 }
 
-static void profiled_spin(void*) {
+static void* profiled_spin(void*) {
     while (true) {
         pthread_testcancel();
         usleep(100);
@@ -139,7 +117,7 @@ static void* profiled_cancel_thread(void*) {
     g_pt_cleanup_called.store(false, std::memory_order_relaxed);
     g_pt_release_called.store(false, std::memory_order_relaxed);
     ProfiledThread::initCurrentThread();
-    run_with_cancel_handler(profiled_spin, nullptr, profiled_cleanup, nullptr);
+    run_with_cleanup(profiled_spin, nullptr, profiled_cleanup, nullptr);
     return nullptr;
 }
 
@@ -170,13 +148,13 @@ static void exit_cleanup(void*) {
     g_exit_cleanup_called.store(true, std::memory_order_relaxed);
 }
 
-static void exit_fn(void*) {
+static void* exit_fn(void*) {
     pthread_exit(reinterpret_cast<void*>(42));
 }
 
 static void* exit_thread(void*) {
     g_exit_cleanup_called.store(false, std::memory_order_relaxed);
-    run_with_cancel_handler(exit_fn, nullptr, exit_cleanup, nullptr);
+    run_with_cleanup(exit_fn, nullptr, exit_cleanup, nullptr);
     return nullptr;
 }
 

--- a/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
+++ b/ddprof-lib/src/test/cpp/forced_unwind_ut.cpp
@@ -200,12 +200,14 @@ static void* nr_thread(void*) {
 
 // Normal-return path (matches start_routine_wrapper on non-aarch64 glibc):
 // cleanup_fn is called once AND __pthread_unregister_cancel removes the buf.
-// Removing either call on this path is detected:
-//   - no cleanup_fn             → g_nr_cleanup_count stays 0
+//   - no cleanup_fn → g_nr_cleanup_count stays 0 (deterministically detected
+//     by the count==1 assertion below).
 //   - no __pthread_unregister_cancel → post-return cancel longjmps into the
-//     freed cancel_buf (UB: crash or g_nr_cleanup_count becomes 2)
-// Note: under ASAN/MSAN the UAF detection path (count==2) is not guaranteed — 
-// a crash is also acceptable evidence.
+//     freed cancel_buf.  This is best-effort detection only: the resulting UB
+//     may crash, re-fire cleanup (count==2), or — depending on stack contents,
+//     and especially under ASAN/MSAN — do neither and pass.  Do NOT rely on
+//     this as a deterministic mutation detector for the unregister call; the
+//     guaranteed coverage here is the positive count==1 assertion.
 TEST(ForcedUnwindTest, CleanupCalledExactlyOnceOnNormalReturn) {
     pthread_t t;
     ASSERT_EQ(0, pthread_create(&t, nullptr, nr_thread, nullptr));

--- a/ddprof-lib/src/test/cpp/stress_callTraceStorage.cpp
+++ b/ddprof-lib/src/test/cpp/stress_callTraceStorage.cpp
@@ -2034,17 +2034,19 @@ TEST_F(StressTestSuite, HashTableSpinWaitEdgeCasesTest) {
 // correctness across expansion boundaries independently of memory ordering;
 // it catches logic regressions in all build configurations.
 TEST_F(StressTestSuite, FindCallTraceAtomicReadRaceTest) {
+
+#define HAS_ASAN 0
 #if defined(__SANITIZE_THREAD__)
-    #define USE_ASAN 1
-#else
-    #if defined(__has_feature)
-        #if __has_feature(thread_sanitizer)
-            #define USA_ASAN 1
-        #endif
+    #undef HAS_ASAN
+    #define HAS_ASAN 1
+#elif defined(__has_feature)
+    #if __has_feature(thread_sanitizer)
+        #undef HAS_ASAN
+        #define HAS_ASAN 1
     #endif
 #endif
 
-#if !USA_ASAN
+#if !HAS_ASAN
     GTEST_SKIP() << "TSan-only race regression: re-run with -fsanitize=thread";
 #endif
 

--- a/ddprof-lib/src/test/cpp/stress_callTraceStorage.cpp
+++ b/ddprof-lib/src/test/cpp/stress_callTraceStorage.cpp
@@ -2034,7 +2034,17 @@ TEST_F(StressTestSuite, HashTableSpinWaitEdgeCasesTest) {
 // correctness across expansion boundaries independently of memory ordering;
 // it catches logic regressions in all build configurations.
 TEST_F(StressTestSuite, FindCallTraceAtomicReadRaceTest) {
-#if !defined(__SANITIZE_THREAD__) && !(defined(__has_feature) && __has_feature(thread_sanitizer))
+#if defined(__SANITIZE_THREAD__)
+    #define USE_ASAN 1
+#else
+    #if defined(__has_feature)
+        #if __has_feature(thread_sanitizer)
+            #define USA_ASAN 1
+        #endif
+    #endif
+#endif
+
+#if !USA_ASAN
     GTEST_SKIP() << "TSan-only race regression: re-run with -fsanitize=thread";
 #endif
 

--- a/ddprof-lib/src/test/cpp/stress_callTraceStorage.cpp
+++ b/ddprof-lib/src/test/cpp/stress_callTraceStorage.cpp
@@ -2035,18 +2035,18 @@ TEST_F(StressTestSuite, HashTableSpinWaitEdgeCasesTest) {
 // it catches logic regressions in all build configurations.
 TEST_F(StressTestSuite, FindCallTraceAtomicReadRaceTest) {
 
-#define HAS_ASAN 0
+#define HAS_TSAN 0
 #if defined(__SANITIZE_THREAD__)
-    #undef HAS_ASAN
-    #define HAS_ASAN 1
+    #undef HAS_TSAN
+    #define HAS_TSAN 1
 #elif defined(__has_feature)
     #if __has_feature(thread_sanitizer)
-        #undef HAS_ASAN
-        #define HAS_ASAN 1
+        #undef HAS_TSAN
+        #define HAS_TSAN 1
     #endif
 #endif
 
-#if !HAS_ASAN
+#if !HAS_TSAN
     GTEST_SKIP() << "TSan-only race regression: re-run with -fsanitize=thread";
 #endif
 

--- a/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <pthread.h>
 #include <signal.h>
+#include <setjmp.h>
 #include <unistd.h>
 #include <vector>
 

--- a/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
@@ -279,7 +279,7 @@ static std::atomic<bool> g_t07_release_ran{false};
 //
 // Signal handler save/restore is done manually (plain struct sigaction, no
 // destructor) so there is nothing in the LSDA for this frame.
-static void *t07_body(void *) {
+__attribute__((noinline, no_stack_protector)) static void *t07_body(void *) {
   g_t07_cleanup_ran.store(false, std::memory_order_relaxed);
   g_t07_release_ran.store(false, std::memory_order_relaxed);
 
@@ -291,7 +291,7 @@ static void *t07_body(void *) {
 
   ProfiledThread::initCurrentThread();
 
-  __pthread_unwind_buf_t cancel_buf;
+  __pthread_unwind_buf_t cancel_buf = {};
   if (__builtin_expect(
           __sigsetjmp((struct __jmp_buf_tag*)(void*)cancel_buf.__cancel_jmp_buf, 0), 0)) {
     // Restore handler before continuing forced unwind (no RAII to do it for us).

--- a/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
@@ -308,10 +308,6 @@ __attribute__((noinline, no_stack_protector)) static void *t07_body(void *) {
     pthread_testcancel();
     usleep(100);
   }
-  __pthread_unregister_cancel(&cancel_buf);
-  sigaction(SIGVTALRM, &old_sa_vtalrm, nullptr);
-  ProfiledThread::release();
-  return nullptr;
 }
 
 #else  // !__GLIBC__ — musl: cancellation runs C cleanup callbacks

--- a/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
@@ -22,11 +22,20 @@
 #include "thread.h"
 
 #include <atomic>
-#include <cxxabi.h>
 #include <pthread.h>
 #include <signal.h>
 #include <unistd.h>
 #include <vector>
+
+#ifdef __GLIBC__
+// <pthread.h> declares these only inside the C (non-C++) conditional.
+// Redeclare with extern "C" so we can call them directly from C++ code.
+extern "C" {
+    extern void __pthread_register_cancel(__pthread_unwind_buf_t*);
+    extern void __pthread_unregister_cancel(__pthread_unwind_buf_t*);
+    [[noreturn]] extern void __pthread_unwind_next(__pthread_unwind_buf_t*);
+}
+#endif
 
 // Sentinel value meaning "handler has not run yet" — distinct from both nullptr
 // (not registered) and any real ProfiledThread address.
@@ -255,27 +264,51 @@ static std::atomic<bool> g_t07_release_ran{false};
 
 #ifdef __GLIBC__
 
+// t07 uses __pthread_register_cancel for cleanup (same as run_with_cleanup in
+// libraryPatcher_linux.cpp).  Two constraints follow from the static-libgcc /
+// libgcc_s.so.1 incompatibility:
+//
+// 1. No C++ RAII objects with destructors in this frame.  After the longjmp
+//    from glibc's stop function, __pthread_unwind_next calls _Unwind_ForcedUnwind
+//    again to continue unwinding through this frame.  Any LSDA cleanup entry
+//    (e.g. SigGuard, std::unique_ptr) would make __gxx_personality_v0 call
+//    _Unwind_SetGR with a cross-version context → abort().
+//
+// 2. No try/catch: handler frames also add LSDA entries, same problem.
+//
+// Signal handler save/restore is done manually (plain struct sigaction, no
+// destructor) so there is nothing in the LSDA for this frame.
 static void *t07_body(void *) {
   g_t07_cleanup_ran.store(false, std::memory_order_relaxed);
   g_t07_release_ran.store(false, std::memory_order_relaxed);
 
-  SigGuard guard(SIGVTALRM);
+  // Save and install the signal handler WITHOUT RAII (no destructor = no LSDA
+  // cleanup entry for this frame).
+  struct sigaction old_sa_vtalrm;
+  sigaction(SIGVTALRM, nullptr, &old_sa_vtalrm);
   install_handler(SIGVTALRM, SIG_IGN);
+
   ProfiledThread::initCurrentThread();
 
-  try {
-    // Inject a signal before the cancellation point to exercise the combined path.
-    pthread_kill(pthread_self(), SIGVTALRM);
-    while (true) {
-      pthread_testcancel();
-      usleep(100);
-    }
-  } catch (abi::__forced_unwind &) {
+  __pthread_unwind_buf_t cancel_buf;
+  if (__builtin_expect(
+          __sigsetjmp((struct __jmp_buf_tag*)(void*)cancel_buf.__cancel_jmp_buf, 0), 0)) {
+    // Restore handler before continuing forced unwind (no RAII to do it for us).
+    sigaction(SIGVTALRM, &old_sa_vtalrm, nullptr);
     g_t07_cleanup_ran.store(true, std::memory_order_relaxed);
     ProfiledThread::release();
     g_t07_release_ran.store(true, std::memory_order_relaxed);
-    throw;
+    __pthread_unwind_next(&cancel_buf);
   }
+  __pthread_register_cancel(&cancel_buf);
+  // Inject a signal before the cancellation point to exercise the combined path.
+  pthread_kill(pthread_self(), SIGVTALRM);
+  while (true) {
+    pthread_testcancel();
+    usleep(100);
+  }
+  __pthread_unregister_cancel(&cancel_buf);
+  sigaction(SIGVTALRM, &old_sa_vtalrm, nullptr);
   ProfiledThread::release();
   return nullptr;
 }

--- a/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
@@ -302,6 +302,11 @@ __attribute__((noinline, no_stack_protector)) static void *t07_body(void *) {
     __pthread_unwind_next(&cancel_buf);
   }
   __pthread_register_cancel(&cancel_buf);
+  // No matching __pthread_unregister_cancel: the only legal exit from this body
+  // is the forced unwind raised by pthread_cancel, which longjmps into the
+  // __sigsetjmp branch above and continues via __pthread_unwind_next.  The loop
+  // below never returns normally; if it ever did, cancel_buf would be left
+  // registered against a destroyed frame.
   // Inject a signal before the cancellation point to exercise the combined path.
   pthread_kill(pthread_self(), SIGVTALRM);
   while (true) {

--- a/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
@@ -313,6 +313,10 @@ __attribute__((noinline, no_stack_protector)) static void *t07_body(void *) {
     pthread_testcancel();
     usleep(100);
   }
+  // Must only exit via pthread_cancel above.  If control reaches here, the
+  // frame was not cancelled as expected and cancel_buf is now a dangling
+  // registration — abort rather than corrupt glibc's cleanup list.
+  __builtin_unreachable();
 }
 
 #else  // !__GLIBC__ — musl: cancellation runs C cleanup callbacks


### PR DESCRIPTION
**What does this PR do?**:
Fixed crashes during thread exit cleanup.

**Motivation**:
Improve stability.

**Additional Notes**:
On glibc, pthread_exit and pthread_cancel trigger _Unwind_ForcedUnwind from the dynamic libgcc_s.so.1. When the forced unwind walks a frame belonging to code built with -static-libgcc (both libjavaProfiler.so and the gtest binaries), it calls the static __gxx_personality_v0. The two libgcc versions have incompatible _Unwind_Context layouts. If the personality function finds a cleanup or handler action and calls _Unwind_SetGR, the cold/error path aborts.

Two patterns create LSDA actions that trigger _Unwind_SetGR:

- C++ RAII objects with destructors (struct Cleanup, __pthread_cleanup_class from pthread_cleanup_push in C++ mode, SigGuard)
- try/catch handler frames (catch (abi::__forced_unwind&))

**How to test the change?**:
Three failed tests now passed.
- forced_unwind_ut
- thread_teardown_safety_ut
- DynamicNativeThread

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-15046](https://datadoghq.atlassian.net/browse/PROF-15046)

Unsure? Have a question? Request a review!


[PROF-15046]: https://datadoghq.atlassian.net/browse/PROF-15046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ