### PR TITLE
fix(octo-sts): grant pull_requests:write so GitLab CI can post PR comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,9 @@ unless the change does not modify code (e.g. only modifies docs, comments).
 
 **For Datadog employees**:
 - [ ] If this PR touches code that signs or publishes builds or packages, or handles
-  credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
+  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
+  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
+  `bewaire` also runs automatically on every PR.
 - [ ] This PR doesn't touch any of that.
 - [ ] JIRA: [JIRA-XXXX]
 

--- a/.github/chainguard/async-profiler-build.ci.sts.yaml
+++ b/.github/chainguard/async-profiler-build.ci.sts.yaml
@@ -6,4 +6,7 @@ subject_pattern: "project_path:DataDog/java-profiler:ref_type:branch:ref:.*"
 permissions:
   contents: write
   issues: write
-  pull_requests: read
+  # write (not read) is required to post comments on pull requests via the
+  # issues/comments endpoint — GitLab CI back-reports benchmark & reliability
+  # results to the PR (see .gitlab/scripts/upsert-github-pr-comment.sh).
+  pull_requests: write


### PR DESCRIPTION
**What does this PR do?**:

1. Changes the `async-profiler-build.ci` Octo-STS trust policy permission `pull_requests` from `read` to `write`.
2. Updates the PR template to drop the defunct `@DataDog/security-design-and-guidance` handle and reference the current security-review process.

**Motivation**:

GitLab CI back-reports benchmark and reliability/chaos results to the PR by upserting a comment via the GitHub REST API (`POST /repos/DataDog/java-profiler/issues/{n}/comments`, see `.gitlab/scripts/upsert-github-pr-comment.sh`). Because the target issue is a pull request, that endpoint requires `pull_requests: write`. With `read`, the call fails:

```
HTTP 403 {"message":"Resource not accessible by integration"}
```

The PR-lookup and comment-list (read) calls succeed; only the write fails. The GitHub Actions path already works because its policy (`self.pr-comment`) grants `pull_requests: write`.

Octo-STS evaluates trust policies from the repository's default branch, so this must land on `main` before the GitLab commenters can post. Split out from #589 so it can merge independently and unblock back-reporting.

**Additional Notes**:

The policy already grants `contents: write` and `issues: write`; this only widens `pull_requests` from read to write, consistent with its stated purpose ("manage issues").

Security review: per the current Change Review Policy, `bewaire` runs automatically on this PR. This change touches an Octo-STS credential policy — for explicit sign-off run the `dd:platform-security-review` skill or file the PSEC review form (https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715). The old `@DataDog/security-design-and-guidance` team is defunct (404) and is not a collaborator on this repo, so it cannot be requested as a reviewer.

**How to test the change?**:

After merge, a GitLab pipeline on an open PR runs the benchmark/reliability comment jobs; `post-benchmarks-pr-comment` / `post-reliability-pr-comment` should post a PR comment instead of returning HTTP 403.

**For Datadog employees**:
- [x] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a security review (bewaire auto-runs; `dd:platform-security-review` / PSEC form available for explicit sign-off).
- [ ] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]