### PR TITLE
fix(fuzzer): fix link failure, UBSan in fuzz targets, add ASan log capture

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -191,6 +191,13 @@ jobs:
           name: signal-safety-violation-glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64
           path: /tmp/signal-safety-violation.txt
           if-no-files-found: ignore
+      - name: Upload ASan logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure() && matrix.config == 'asan'
+        with:
+          name: asan-logs-glibc-${{ matrix.java_version }}-amd64
+          path: /tmp/asan.log.*
+          if-no-files-found: ignore
 
   test-linux-musl-amd64:
     needs: [cache-jdks, filter-musl-configs]
@@ -316,6 +323,13 @@ jobs:
         with:
           name: signal-safety-violation-musl-${{ matrix.java_version }}-${{ matrix.config }}-amd64
           path: /tmp/signal-safety-violation.txt
+          if-no-files-found: ignore
+      - name: Upload ASan logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure() && matrix.config == 'asan'
+        with:
+          name: asan-logs-musl-${{ matrix.java_version }}-amd64
+          path: /tmp/asan.log.*
           if-no-files-found: ignore
 
   test-linux-glibc-aarch64:
@@ -495,6 +509,13 @@ jobs:
           name: signal-safety-violation-glibc-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
           path: /tmp/signal-safety-violation.txt
           if-no-files-found: ignore
+      - name: Upload ASan logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure() && matrix.config == 'asan'
+        with:
+          name: asan-logs-glibc-${{ matrix.java_version }}-aarch64
+          path: /tmp/asan.log.*
+          if-no-files-found: ignore
 
   test-linux-musl-aarch64:
      needs: [cache-jdks, filter-musl-configs]
@@ -598,4 +619,11 @@ jobs:
          with:
            name: signal-safety-violation-musl-${{ matrix.java_version }}-${{ matrix.config }}-aarch64
            path: /tmp/signal-safety-violation.txt
+           if-no-files-found: ignore
+       - name: Upload ASan logs
+         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+         if: failure() && matrix.config == 'asan'
+         with:
+           name: asan-logs-musl-${{ matrix.java_version }}-aarch64
+           path: /tmp/asan.log.*
            if-no-files-found: ignore

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/config/ConfigurationPresets.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/config/ConfigurationPresets.kt
@@ -211,7 +211,7 @@ object ConfigurationPresets {
                 if (libasan != null) {
                     config.testEnvironment.apply {
                         put("LD_PRELOAD", libasan)
-                        put("ASAN_OPTIONS", "allocator_may_return_null=1:unwind_abort_on_malloc=1:use_sigaltstack=0:detect_stack_use_after_return=0:handle_segv=0:halt_on_error=0:abort_on_error=0:print_stacktrace=1:symbolize=1:suppressions=$rootDir/gradle/sanitizers/asan.supp")
+                        put("ASAN_OPTIONS", "allocator_may_return_null=1:unwind_abort_on_malloc=1:use_sigaltstack=0:detect_stack_use_after_return=0:handle_segv=0:halt_on_error=0:abort_on_error=0:print_stacktrace=1:symbolize=1:log_path=/tmp/asan.log:suppressions=$rootDir/gradle/sanitizers/asan.supp")
                         put("UBSAN_OPTIONS", "halt_on_error=0:abort_on_error=0:print_stacktrace=1:suppressions=$rootDir/gradle/sanitizers/ubsan.supp")
                         put("LSAN_OPTIONS", "detect_leaks=0")
                     }

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/config/ConfigurationPresets.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/config/ConfigurationPresets.kt
@@ -215,6 +215,18 @@ object ConfigurationPresets {
                         put("UBSAN_OPTIONS", "halt_on_error=0:abort_on_error=0:print_stacktrace=1:suppressions=$rootDir/gradle/sanitizers/ubsan.supp")
                         put("LSAN_OPTIONS", "detect_leaks=0")
                     }
+                    // JDK 25's G1GC reserves heap virtual address space starting just below 2 GB
+                    // (0x7fff7000), which is exactly where ASan needs to mmap its shadow bytes
+                    // [0x7fff7000-0x10007fff7fff].  Force the heap to a very low base address so
+                    // the entire JVM footprint (heap + class space + code cache) stays well below
+                    // the shadow range and the two regions no longer conflict.
+                    if (PlatformUtils.testJvmMajorVersion() >= 25) {
+                        config.testJvmArgs.addAll(listOf(
+                            "-XX:HeapBaseMinAddress=0x4000000",
+                            "-Xmx512m",
+                            "-XX:CompressedClassSpaceSize=256m"
+                        ))
+                    }
                 }
             }
             Platform.MACOS -> {

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/model/BuildConfiguration.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/model/BuildConfiguration.kt
@@ -15,6 +15,7 @@ abstract class BuildConfiguration @Inject constructor(
     abstract val compilerArgs: ListProperty<String>
     abstract val linkerArgs: ListProperty<String>
     abstract val testEnvironment: MapProperty<String, String>
+    abstract val testJvmArgs: ListProperty<String>
     abstract val active: Property<Boolean>
 
     override fun getName(): String = configName
@@ -23,6 +24,7 @@ abstract class BuildConfiguration @Inject constructor(
         // Default to active unless overridden
         active.convention(true)
         testEnvironment.convention(emptyMap())
+        testJvmArgs.convention(emptyList())
     }
 
     fun isActiveFor(targetPlatform: Platform, targetArch: Architecture): Boolean {

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/util/PlatformUtils.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/util/PlatformUtils.kt
@@ -367,4 +367,24 @@ object PlatformUtils {
             false
         }
     }
+
+    /**
+     * Returns the major version of the test JVM (e.g. 8, 11, 17, 21, 25).
+     * Returns 0 if the version cannot be determined.
+     */
+    fun testJvmMajorVersion(): Int {
+        val javaHome = testJavaHome()
+        return try {
+            val process = ProcessBuilder("$javaHome/bin/java", "-version")
+                .redirectErrorStream(true)
+                .start()
+            val output = process.inputStream.bufferedReader().readText()
+            process.waitFor(10, TimeUnit.SECONDS)
+            // version line: java version "1.8.0_xxx" or java version "21.0.x" etc.
+            val match = Regex("""version "(?:1\.)?(\d+)""").find(output)
+            match?.groupValues?.get(1)?.toIntOrNull() ?: 0
+        } catch (_: Exception) {
+            0
+        }
+    }
 }

--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/profiler/ProfilerTestPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/profiler/ProfilerTestPlugin.kt
@@ -111,6 +111,7 @@ class ProfilerTestPlugin : Plugin<Project> {
         val testClasspath: FileCollection,
         val standardJvmArgs: List<String>,
         val extraJvmArgs: List<String>,
+        val configJvmArgs: List<String>,
         val systemProperties: Map<String, String>,
         val environmentVariables: Map<String, String>
     )
@@ -164,6 +165,7 @@ class ProfilerTestPlugin : Plugin<Project> {
             testClasspath = testClasspath,
             standardJvmArgs = extension.standardJvmArgs.get(),
             extraJvmArgs = extension.extraJvmArgs.get(),
+            configJvmArgs = config.testJvmArgs.get(),
             systemProperties = systemProps,
             environmentVariables = envVars
         )
@@ -247,6 +249,7 @@ class ProfilerTestPlugin : Plugin<Project> {
                 }
 
                 allArgs.addAll(testConfig.extraJvmArgs)
+                allArgs.addAll(testConfig.configJvmArgs)
                 testTask.jvmArgs(allArgs)
             }
 
@@ -303,6 +306,7 @@ class ProfilerTestPlugin : Plugin<Project> {
                     allArgs.add("-Djava.library.path=${extension.nativeLibDir.get().asFile.absolutePath}")
                 }
                 allArgs.addAll(testConfig.extraJvmArgs)
+                allArgs.addAll(testConfig.configJvmArgs)
 
                 // System properties
                 testConfig.systemProperties.forEach { (key, value) ->

--- a/ddprof-lib/src/main/cpp/buffers.h
+++ b/ddprof-lib/src/main/cpp/buffers.h
@@ -80,6 +80,7 @@ public:
     _data[_offset++] = v;
   }
 
+  __attribute__((no_sanitize("undefined")))
   __attribute__((no_sanitize("bounds")))
   void put16(short v) {
     assert(_offset + 2 < limit());

--- a/ddprof-lib/src/main/cpp/callTraceStorage.h
+++ b/ddprof-lib/src/main/cpp/callTraceStorage.h
@@ -34,7 +34,7 @@ public:
     // Reserved trace ID for dropped samples due to contention
     // Real trace IDs are generated as (instance_id << 32) | slot, where instance_id starts from 1
     // Any ID with 0 in upper 32 bits is guaranteed to not clash with real trace IDs
-    static const u64 DROPPED_TRACE_ID = 1ULL;
+    static constexpr u64 DROPPED_TRACE_ID = 1ULL;
     
     // Static dropped trace object that appears in JFR constant pool
     static CallTrace* getDroppedTrace();


### PR DESCRIPTION
**What does this PR do?**:
Fixes fuzz-CI failures and the JDK 25 ASan shadow-memory conflict.

1. **`callTraceStorage.h`** — `static const u64 DROPPED_TRACE_ID` changed to `static constexpr`. The fuzz target passes it by `const u64&` to `unordered_set::find`, which ODR-uses it. `static const` (non-`constexpr`) requires an out-of-class definition in that case; `static constexpr` is implicitly inline in C++17 and needs none. The linker error was: `undefined reference to CallTraceStorage::DROPPED_TRACE_ID`.

2. **`buffers.h`** — Added `__attribute__((no_sanitize("undefined")))` to `put16`. It does an unaligned `short*` store to a byte array (same pattern as `put32`, which already carries this annotation with a comment). UBSan reported: `store to misaligned address for type 'short', which requires 2 byte alignment`.

3. **`ConfigurationPresets.kt`** — Added `log_path=/tmp/asan.log` to `ASAN_OPTIONS` for the `asan` config. ASan writes one file per PID (`/tmp/asan.log.<pid>`), preserving output even when the JVM exits abruptly before Gradle captures stderr.

4. **`test_workflow.yml`** — Added `Upload ASan logs` artifact steps to all four test jobs (glibc/musl × amd64/aarch64), conditioned on `failure() && matrix.config == 'asan'` with `if-no-files-found: ignore`. This makes the actual ASan report available as a downloadable artifact on `testAsan` failures.

5. **JDK 25 ASan shadow-memory conflict** — The ASan log captured by change 4 revealed that JDK 25's G1GC reserves heap virtual address space starting just below 2 GB (`0x7fff7000`), which is exactly where ASan needs to mmap its shadow bytes `[0x7fff7000–0x10007fff7fff]`. ASan aborts with *"Shadow memory range interleaves with an existing memory mapping"* before any test runs.

   Fix: for JDK ≥ 25 ASan tests, add JVM flags that force the heap to a low base address so the entire JVM footprint stays below the shadow range:
   - `-XX:HeapBaseMinAddress=0x4000000` (64 MB) — moves G1GC's heap reservation far below 2 GB
   - `-Xmx512m` — bounds total heap size so it doesn't grow back into the shadow range
   - `-XX:CompressedClassSpaceSize=256m` — keeps class space from pushing the total over 2 GB

   Infrastructure: added `testJvmArgs: ListProperty<String>` to `BuildConfiguration`, a `testJvmMajorVersion()` helper to `PlatformUtils`, and wiring through `ProfilerTestPlugin` so both the `Test` task and the musl `Exec` task paths pick up the args. Detection runs once at Gradle configuration time via `java -version`.

**Motivation**:
The `fuzz` CI job was failing with a linker error. The `buffers` fuzzer was hitting a UBSan error. The `testAsan` job on JDK 25 was aborting before any test ran because ASan could not initialise its shadow memory — a JDK 25-specific regression introduced by G1GC's new heap placement strategy.

**How to test the change?**:
- CI: the `fuzz` job should link and run both fuzz targets without UBSan errors.
- CI: `test-linux-glibc-amd64 (25, asan)` and `test-linux-glibc-aarch64 (25, asan)` pass (previously failing with shadow-memory abort, now green).
- CI: on any future `testAsan` failure, an `asan-logs-*` artifact will appear in the run.

**For Datadog employees**:
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]