### PR TITLE
fix(ci): trigger fuzz job on scheduled pipeline

### DIFF
--- a/.gitlab/fuzzing/.gitlab-ci.yml
+++ b/.gitlab/fuzzing/.gitlab-ci.yml
@@ -14,7 +14,7 @@ fuzz_infra:
     DDSIGN_ID_TOKEN:
       aud: image-integrity
   rules:
-    - if: $NIGHTLY_BUILD == "true"
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
     - when: manual
   before_script:
     - apt-get update -qq && apt-get install -y -qq curl unzip jq

--- a/.gitlab/fuzzing/.gitlab-ci.yml
+++ b/.gitlab/fuzzing/.gitlab-ci.yml
@@ -14,7 +14,7 @@ fuzz_infra:
     DDSIGN_ID_TOKEN:
       aud: image-integrity
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $RUN_FUZZ == "true"'
     - when: manual
   before_script:
     - apt-get update -qq && apt-get install -y -qq curl unzip jq


### PR DESCRIPTION
I used the wrong variable in the previous PR, it should be on the schedueld pipeline and not the NIGHTLY_BUILD one.

Variable value coming from https://docs.gitlab.com/ci/jobs/job_rules/#ci_pipeline_source-predefined-variable

**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->
Fix the scheduled fuzz test

**Motivation**:
<!-- What inspired you to submit this pull request? -->
Fuzz every night

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [ ] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
