### PR TITLE
fix(chaos): rate-limit tight-loop antagonists to prevent long-run OOM

### DIFF
--- a/ddprof-stresstest/src/chaos/java/com/datadoghq/profiler/chaos/ClassLoaderChurnAntagonist.java
+++ b/ddprof-stresstest/src/chaos/java/com/datadoghq/profiler/chaos/ClassLoaderChurnAntagonist.java
@@ -77,6 +77,14 @@ public final class ClassLoaderChurnAntagonist implements Antagonist {
                 // transient; JVM crash is the signal we watch for
             }
             // loader + klass go out of scope here.
+            // Pace class loading so old-gen GC can reclaim ClassLoader
+            // instances before they accumulate across a long run.
+            try {
+                Thread.sleep(1L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
         }
     }
 

--- a/ddprof-stresstest/src/chaos/java/com/datadoghq/profiler/chaos/HiddenClassChurnAntagonist.java
+++ b/ddprof-stresstest/src/chaos/java/com/datadoghq/profiler/chaos/HiddenClassChurnAntagonist.java
@@ -102,6 +102,14 @@ public final class HiddenClassChurnAntagonist implements Antagonist {
             } catch (Throwable t) {
                 // transient; JVM crash is the signal we watch for
             }
+            // Pace hidden-class generation so the GC can evict unloaded
+            // classes before they accumulate across a long run.
+            try {
+                Thread.sleep(1L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
         }
     }
 

--- a/ddprof-stresstest/src/chaos/java/com/datadoghq/profiler/chaos/WeakRefWaveAntagonist.java
+++ b/ddprof-stresstest/src/chaos/java/com/datadoghq/profiler/chaos/WeakRefWaveAntagonist.java
@@ -31,6 +31,7 @@ public final class WeakRefWaveAntagonist implements Antagonist {
 
     private static final int WAVE_SIZE = 10_000;
     private static final int[] OBJECT_SIZES = {64, 256, 1_024, 4_096};
+    private static final long INTER_WAVE_MS = 200L;
 
     private volatile boolean running;
     private Thread waveDriver;
@@ -100,6 +101,15 @@ public final class WeakRefWaveAntagonist implements Antagonist {
 
             // Replace shared reference; weakRefs goes out of scope
             currentWave = new ArrayList<WeakReference<byte[]>>();
+
+            // Pause between waves so concurrent GC can reclaim without being
+            // overwhelmed by back-to-back System.gc() calls.
+            try {
+                Thread.sleep(INTER_WAVE_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
**What does this PR do?**:
Adds inter-iteration sleeps to three chaos antagonists that ran in tight loops without yielding, causing Java heap OOM after ~1 hour in the scheduled reliability/chaos CI cell.

**Motivation**:
The chaos harness was failing with `java.lang.OutOfMemoryError: Java heap space` after ~59 minutes. Root cause: `WeakRefWaveAntagonist.waveLoop()` calls `System.gc()` in a tight loop with no pause between waves. Each forced full-GC is a stop-the-world pause during which `ThreadChurnAntagonist` (64 threads/5ms), `DumpStormAntagonist` (96 threads), and `AllocStormAntagonist` keep accumulating objects. Over time this degrades into GC thrashing and exhausts the 2GB heap.

Two secondary contributors also ran with no inter-iteration sleep: `ClassLoaderChurnAntagonist` and `HiddenClassChurnAntagonist` both define unique classes in tight loops; ClassLoaders require old-gen GC to collect and can accumulate faster than the GC can reclaim them.

Changes:
- `WeakRefWaveAntagonist`: 200ms sleep after each wave — gives G1's concurrent markers time to work between forced full GCs
- `ClassLoaderChurnAntagonist`: 1ms sleep per iteration — enough for old-gen to keep up with ClassLoader churn
- `HiddenClassChurnAntagonist`: 1ms sleep per iteration — same reason

The `System.gc()` call is preserved; only the pathological back-to-back cadence is fixed.

**Additional Notes**:
No profiler code changed. This is purely a chaos harness fix.

**How to test the change?**:
The scheduled reliability/chaos CI pipeline will exercise this. The harness should now complete the full duration (RUNTIME seconds) without OOM.

**For Datadog employees**:
- [x] This PR doesn't touch any of that.
- [ ] JIRA: N/A — no ticket, direct chaos harness fix