### PR TITLE
fix(ci): lower aarch64 benchmark memory request to 128Gi cluster limit

### DIFF
--- a/.gitlab/benchmarks/.gitlab-ci.yml
+++ b/.gitlab/benchmarks/.gitlab-ci.yml
@@ -76,8 +76,8 @@ benchmarks-candidate-aarch64:
   tags: ["arch:arm64"]
   image: $BENCHMARK_IMAGE_ARM64
   variables:
-    KUBERNETES_MEMORY_REQUEST: 200Gi
-    KUBERNETES_MEMORY_LIMIT: 200Gi
+    KUBERNETES_MEMORY_REQUEST: 128Gi
+    KUBERNETES_MEMORY_LIMIT: 128Gi
 
 post-benchmarks-pr-comment:
   extends: .retry-config


### PR DESCRIPTION
**What does this PR do?**:
Lowers `KUBERNETES_MEMORY_REQUEST` and `KUBERNETES_MEMORY_LIMIT` for `benchmarks-candidate-aarch64` from 200Gi to 128Gi.

**Motivation**:
All benchmark jobs are failing with:
> Preparation failed: MemoryRequest of 200Gi exceeds the allowed limit of 128Gi.

The 200Gi value was carried over from the original CI migration and presumably reflected the old cluster's limits. The arm64 runner pool now enforces a 128Gi cap.

**Additional Notes**:
The amd64 job has no explicit memory override so it is unaffected.

**How to test the change?**:
Benchmark jobs should no longer fail at preparation. No functional change to benchmark behaviour.

**For Datadog employees**:
- [x] This PR doesn't touch any of that.
- [ ] JIRA: N/A