### PR TITLE
fix: avoid eager string alloc in setContextAttributesByIdAndBytes validation

### DIFF
--- a/ddprof-lib/src/main/java/com/datadoghq/profiler/ThreadContext.java
+++ b/ddprof-lib/src/main/java/com/datadoghq/profiler/ThreadContext.java
@@ -385,8 +385,10 @@ public final class ThreadContext {
         // the record detached (valid=0) after an exception unwinds past attach().
         for (int i = 0; i < len; i++) {
             if (constantIds[i] > 0) {
-                byte[] bytes = Objects.requireNonNull(utf8[i], "utf8[" + i + "]");
-                if (bytes.length > MAX_VALUE_BYTES) {
+                if (utf8[i] == null) {
+                    throw new NullPointerException("utf8[" + i + "]");
+                }
+                if (utf8[i].length > MAX_VALUE_BYTES) {
                     throw new IllegalArgumentException("utf8[" + i + "].length exceeds MAX_VALUE_BYTES");
                 }
             }


### PR DESCRIPTION
## What does this PR do?

Replace `Objects.requireNonNull(utf8[i], "utf8[" + i + "]")` with a plain null check so the string concatenation only happens when actually throwing. The original form evaluated the message argument eagerly on every loop iteration — including all non-null cases in the happy path — allocating a string per slot per call.

## Motivation

`setContextAttributesByIdAndBytes` is a hot-path method (vthread mount/unmount reapply). Allocation in its validation loop defeats the purpose of the allocation-free API.

## Test plan

- [ ] Existing `TagContextTest` covers the validation path (null slot throws NPE, oversized bytes throws IAE)
- [ ] No behaviour change: semantics are identical — NPE with the same message, same condition