### PR TITLE
ci: add least-privilege STS policy for benchmarking-platform PR comments

### DIFF
--- a/.github/chainguard/benchmarking-platform-reports.ci.sts.yaml
+++ b/.github/chainguard/benchmarking-platform-reports.ci.sts.yaml
@@ -1,0 +1,15 @@
+# Allow the benchmarking-platform GitLab CI to back-report results to PRs only.
+#
+# Scoped deliberately narrower than async-profiler-build.ci: the BP project lives
+# in a separate repository, so it is granted *only* the permissions needed to
+# upsert a result comment on a java-profiler PR — never contents: write.
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/apm-reliability/benchmarking-platform:ref_type:branch:ref:.*"
+
+permissions:
+  # issues: write covers creating/updating comments on a PR (the PR comment lives
+  # on the issues/comments endpoint); pull_requests: read is enough to resolve the
+  # open PR for a branch. No contents access is granted.
+  issues: write
+  pull_requests: read


### PR DESCRIPTION
**What does this PR do?**:

Adds a dedicated, least-privilege dd-octo-sts trust policy
(`benchmarking-platform-reports.ci`) that lets the benchmarking-platform GitLab CI
project mint a short-lived token to upsert a result comment on a java-profiler PR.
The new policy grants only `issues: write` + `pull_requests: read` — no contents access.

**Motivation**:

dd-octo-sts reads trust policies from the repository's **default branch**, not the PR
branch. The reliability benchmark pipeline runs in the benchmarking-platform GitLab
project, whose OIDC subject (`project_path:DataDog/apm-reliability/benchmarking-platform:...`)
had no matching policy, so the token exchange failed with `HTTP 403 permission denied`
and the results comment was silently skipped.

The obvious shortcut — adding the BP project to the existing `async-profiler-build.ci`
policy — was rejected because that policy grants `contents: write`. Matching the
separate BP repository there would let any BP branch pipeline mint a token able to
modify java-profiler repository contents, far beyond posting a comment. Instead this
PR adds a separate policy scoped to the BP project with only the comment permissions.

**Additional Notes**:

Permissions are the minimum the comment script needs: `GET /pulls` (pull_requests:read)
to resolve the open PR, and `GET`/`POST`/`PATCH` on issue comments (issues:write) to
upsert the comment. `async-profiler-build.ci` is left unchanged.

**How to test the change?**:

Trigger the reliability benchmark pipeline from a java-profiler PR. Once this policy is
on `main`, the benchmarking-platform `post-pr-comment` job exchanges its OIDC token via
`benchmarking-platform-reports.ci` and upserts the benchmark-results comment instead of
logging the 403.

**For Datadog employees**:
- [x] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [ ] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
