### PR TITLE
Fix artifact upload permissions in musl aarch64 CI job

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -577,8 +577,8 @@ jobs:
          run: |
            # Files created by Docker container may have restrictive permissions
            # that prevent GitHub Actions from reading them during artifact creation
-           sudo chmod -R +r build/ ddprof-test/build/ ddprof-lib/build/ 2>/dev/null || true
-           sudo find build/ ddprof-test/build/ ddprof-lib/build/ -type d -exec chmod +x {} \; 2>/dev/null || true
+           sudo chmod -R +r build/ ddprof-test/build/ ddprof-lib/build/ || true
+           sudo find build/ ddprof-test/build/ ddprof-lib/build/ -type d -exec chmod +x {} \; || true
        - name: Generate Unwinding Report
          if: success() && matrix.config == 'debug'
          run: |
@@ -588,8 +588,8 @@ jobs:
              \"${{ matrix.config }}\" \"${{ env.JAVA_HOME }}\" \"${{ env.JAVA_TEST_HOME }}\"
            "
            # Fix permissions after Docker container execution (both top-level and subproject builds)
-           sudo chmod -R +r build/ ddprof-test/build/ 2>/dev/null || true
-           sudo find build/ ddprof-test/build/ -type d -exec chmod +x {} \; 2>/dev/null || true
+           sudo chmod -R +r build/ ddprof-test/build/ ddprof-lib/build/ || true
+           sudo find build/ ddprof-test/build/ ddprof-lib/build/ -type d -exec chmod +x {} \; || true
        - name: Add Unwinding Report to Job Summary
          if: success() && matrix.config == 'debug' && hashFiles('ddprof-test/build/reports/unwinding-summary.md') != ''
          run: |

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -577,8 +577,8 @@ jobs:
          run: |
            # Files created by Docker container may have restrictive permissions
            # that prevent GitHub Actions from reading them during artifact creation
-           sudo chmod -R +r build/ 2>/dev/null || true
-           sudo find build/ -type d -exec chmod +x {} \; 2>/dev/null || true
+           sudo chmod -R +r build/ ddprof-test/build/ ddprof-lib/build/ 2>/dev/null || true
+           sudo find build/ ddprof-test/build/ ddprof-lib/build/ -type d -exec chmod +x {} \; 2>/dev/null || true
        - name: Generate Unwinding Report
          if: success() && matrix.config == 'debug'
          run: |
@@ -587,9 +587,9 @@ jobs:
              \"${{ github.sha }}\" \"musl/${{ matrix.java_version }}-${{ matrix.config }}-aarch64\" \
              \"${{ matrix.config }}\" \"${{ env.JAVA_HOME }}\" \"${{ env.JAVA_TEST_HOME }}\"
            "
-           # Fix permissions after Docker container execution
-           sudo chmod -R +r ddprof-test/build/reports/ 2>/dev/null || true
-           sudo find ddprof-test/build/reports/ -type d -exec chmod +x {} \; 2>/dev/null || true
+           # Fix permissions after Docker container execution (both top-level and subproject builds)
+           sudo chmod -R +r build/ ddprof-test/build/ 2>/dev/null || true
+           sudo find build/ ddprof-test/build/ -type d -exec chmod +x {} \; 2>/dev/null || true
        - name: Add Unwinding Report to Job Summary
          if: success() && matrix.config == 'debug' && hashFiles('ddprof-test/build/reports/unwinding-summary.md') != ''
          run: |

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -576,9 +576,9 @@ jobs:
          if: always()
          run: |
            # Files created by Docker container may have restrictive permissions
-           # that prevent GitHub Actions from reading them during artifact creation
-           sudo chmod -R +r build/ ddprof-test/build/ ddprof-lib/build/ || true
-           sudo find build/ ddprof-test/build/ ddprof-lib/build/ -type d -exec chmod +x {} \; || true
+           # that prevent GitHub Actions from reading them during artifact creation.
+           # Use a+rX (umask-independent) where X adds execute only to directories.
+           sudo chmod -R a+rX build/ ddprof-test/build/ ddprof-lib/build/ || true
        - name: Generate Unwinding Report
          if: success() && matrix.config == 'debug'
          run: |
@@ -587,9 +587,9 @@ jobs:
              \"${{ github.sha }}\" \"musl/${{ matrix.java_version }}-${{ matrix.config }}-aarch64\" \
              \"${{ matrix.config }}\" \"${{ env.JAVA_HOME }}\" \"${{ env.JAVA_TEST_HOME }}\"
            "
-           # Fix permissions after Docker container execution (both top-level and subproject builds)
-           sudo chmod -R +r build/ ddprof-test/build/ ddprof-lib/build/ || true
-           sudo find build/ ddprof-test/build/ ddprof-lib/build/ -type d -exec chmod +x {} \; || true
+           # Fix permissions after Docker container execution (both top-level and subproject builds).
+           # Use a+rX (umask-independent) where X adds execute only to directories.
+           sudo chmod -R a+rX build/ ddprof-test/build/ ddprof-lib/build/ || true
        - name: Add Unwinding Report to Job Summary
          if: success() && matrix.config == 'debug' && hashFiles('ddprof-test/build/reports/unwinding-summary.md') != ''
          run: |

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -572,6 +572,13 @@ jobs:
              echo "musl-${{ matrix.java_version }}-${{ matrix.config }}-aarch64" >> failures_musl-${{ matrix.java_version }}-${{ matrix.config }}-aarch64.txt
              exit 1
            fi
+       - name: Fix permissions for artifact upload
+         if: always()
+         run: |
+           # Files created by Docker container may have restrictive permissions
+           # that prevent GitHub Actions from reading them during artifact creation
+           sudo chmod -R +r build/ 2>/dev/null || true
+           sudo find build/ -type d -exec chmod +x {} \; 2>/dev/null || true
        - name: Generate Unwinding Report
          if: success() && matrix.config == 'debug'
          run: |
@@ -580,6 +587,9 @@ jobs:
              \"${{ github.sha }}\" \"musl/${{ matrix.java_version }}-${{ matrix.config }}-aarch64\" \
              \"${{ matrix.config }}\" \"${{ env.JAVA_HOME }}\" \"${{ env.JAVA_TEST_HOME }}\"
            "
+           # Fix permissions after Docker container execution
+           sudo chmod -R +r ddprof-test/build/reports/ 2>/dev/null || true
+           sudo find ddprof-test/build/reports/ -type d -exec chmod +x {} \; 2>/dev/null || true
        - name: Add Unwinding Report to Job Summary
          if: success() && matrix.config == 'debug' && hashFiles('ddprof-test/build/reports/unwinding-summary.md') != ''
          run: |


### PR DESCRIPTION
**What does this PR do?**:
Fixes permission denied errors when uploading build artifacts in the test-linux-musl-aarch64 CI job.

**Motivation**:
The Alpine Docker container creates files as root, causing GitHub Actions to fail when trying to read them during artifact zip creation:
```
Error: EACCES: permission denied, open '/home/runner/work/java-profiler/java-profiler/build/reports/problems/problems-report.html'
```

**Additional Notes**:
- Uses `sudo chmod -R a+rX` after Docker execution to ensure files are readable (umask-independent)
- Capital `X` adds execute only to directories, consolidating the previous two-command approach
- Covers all build directories: `build/`, `ddprof-test/build/`, `ddprof-lib/build/`
- Applied after both Test and Generate Unwinding Report steps
- Errors are visible in logs (`|| true` only handles missing paths gracefully)

**How to test the change?**:
Run the test-linux-musl-aarch64 job and verify artifacts upload successfully without permission errors.

**For Datadog employees**:
- [x] This PR doesn't touch any of that.