### PR TITLE
Harden JVM TLS init, crash-handler nesting, and jmp_buf publish/observe

### DIFF
--- a/ddprof-lib/src/main/cpp/jvmThread.cpp
+++ b/ddprof-lib/src/main/cpp/jvmThread.cpp
@@ -17,10 +17,12 @@ bool JVMThread::initialize() {
   void* current_thread = currentThreadSlow();
   // Called by known JavaThread, cannot be nullptr
   assert(current_thread != nullptr && "Must not be nullptr");
-  _jvm_thread.initialize(current_thread);
+  if (current_thread == nullptr) {
+    return false;
+  }
   // _tid is side-effect of currentThreadSlow()
   assert(_tid != nullptr);
-  return _jvm_thread.isKeyValid();
+  return _jvm_thread.initialize(current_thread);
 }
 
 bool JVMThread::isInitialized() {

--- a/ddprof-lib/src/main/cpp/threadLocal.h
+++ b/ddprof-lib/src/main/cpp/threadLocal.h
@@ -210,9 +210,16 @@ public:
     // The key is created by JVM, find out the key.
     // This method should be called very early at Profiler startup
     // time
-    void initialize(void* current_thread) {
+    bool initialize(void* current_thread) {
         // Called from known JavaThread, it must not be nullptr.
         assert(current_thread != nullptr && "Should not reach here");
+        if (current_thread == nullptr) {
+            // A NULL current_thread would make the scan below match the
+            // first never-created key (pthread_getspecific() also returns
+            // NULL for it), silently producing a bogus _key. Bail out
+            // instead and leave _key == INVALID_KEY.
+            return false;
+        }
 
         long max_keys = sysconf(_SC_THREAD_KEYS_MAX);
         if (max_keys <= 0 || max_keys > 1024) {
@@ -225,6 +232,7 @@ public:
             }
         }
         assert(isKeyValid() && "Invalid thread key");
+        return isKeyValid();
     }
 
     bool isKeyValid() const {
@@ -241,6 +249,9 @@ public:
 
     void* get() const {
         assert(isKeyValid() && "Invalid pthread key");
+        if (!isKeyValid()) {
+            return nullptr;
+        }
         return pthread_getspecific(_key);
     }
 

--- a/ddprof-lib/src/main/cpp/threadLocalData.h
+++ b/ddprof-lib/src/main/cpp/threadLocalData.h
@@ -60,8 +60,12 @@ private:
   static void doInitTLSKey();
   static inline void freeKey(void *key);
 
-  // longjmp buffer. used by hotspot only at this moment
-  jmp_buf* _jmp_buf;
+  // longjmp buffer. used by hotspot only at this moment.
+  // Published in walkVM() and consumed in checkFault() from an asynchronous
+  // SEGV-handler context on the same thread; atomic makes the publish/observe
+  // ordering explicit instead of relying on plain load/store, matching how
+  // _crash_depth is hardened below.
+  std::atomic<jmp_buf*> _jmp_buf;
 
   u64 _pc;
   u64 _sp;
@@ -176,12 +180,17 @@ public:
   }
 
   // this is called in the crash handler to avoid recursing
+  //
+  // Uses a single atomic increment-then-check instead of load-then-branch-
+  // then-increment: the latter lets a nested signal on the same thread
+  // observe the same pre-increment value between the load and the add,
+  // letting more than CRASH_HANDLER_NESTING_LIMIT handlers past the gate.
   bool enterCrashHandler() {
-    u32 prev = __atomic_load_n(&_crash_depth, __ATOMIC_RELAXED);
-    if (prev < CRASH_HANDLER_NESTING_LIMIT) {
-      __atomic_add_fetch(&_crash_depth, 1, __ATOMIC_RELAXED);
+    u32 depth = __atomic_add_fetch(&_crash_depth, 1, __ATOMIC_RELAXED);
+    if (depth <= CRASH_HANDLER_NESTING_LIMIT) {
       return true;
     }
+    __atomic_sub_fetch(&_crash_depth, 1, __ATOMIC_RELAXED);
     return false;
   }
 
@@ -201,15 +210,15 @@ public:
   }
 
   inline void setJmpCtx(jmp_buf* buf) {
-    _jmp_buf = buf;  
+    _jmp_buf.store(buf, std::memory_order_release);
   }
 
   inline jmp_buf* getJmpCtx() const {
-    return _jmp_buf;
+    return _jmp_buf.load(std::memory_order_acquire);
   }
 
   inline bool isProtected() const {
-    return _jmp_buf != nullptr;
+    return _jmp_buf.load(std::memory_order_acquire) != nullptr;
   }
 
   // Signal-handler depth counter used by SignalHandlerScope (guards.h).  All

--- a/ddprof-lib/src/main/cpp/vmEntry.cpp
+++ b/ddprof-lib/src/main/cpp/vmEntry.cpp
@@ -556,7 +556,9 @@ bool VM::initProfilerBridge(JavaVM *vm, bool attach) {
 void VM::ready(jvmtiEnv *jvmti, JNIEnv *jni) {
   Profiler::check_JDK_8313796_workaround();
   Profiler::setupSignalHandlers();
-  JVMThread::initialize();
+  if (!JVMThread::initialize()) {
+    Log::warn("JVMThread::initialize() failed - JVM thread identification will be degraded");
+  }
   if (isHotspot()) {
     JitWriteProtection jit(true);
     VMStructs::ready();

--- a/ddprof-lib/src/test/cpp/hotspot_crash_protection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/hotspot_crash_protection_ut.cpp
@@ -32,6 +32,7 @@
 #include "hotspot/hotspotSupport.h"
 #include "jvmThread.h"
 #include "safeAccess.h"
+#include "os.h"
 
 #ifdef __linux__
 
@@ -383,13 +384,38 @@ TEST(VTableStubNullKlassTest, NullKlassYieldsNullSymbolAndNoFrame) {
     EXPECT_FALSE(fillFrameCalled);
 }
 
+// SafeAccess::safeFetch64 relies on a registered SIGSEGV/SIGBUS handler
+// (SafeAccess::handle_safefetch) to catch the fault and resume with the
+// error value instead of crashing — see safefetch_ut.cpp's SafeFetchTest
+// fixture for the same pattern. Without it, faulting through safeFetch64
+// is a real, unguarded SIGSEGV.
+class SafeFetch64TocTouGuardTest : public ::testing::Test {
+protected:
+    static void handler(int signo, siginfo_t* siginfo, void* context) {
+        SafeAccess::handle_safefetch(signo, context);
+    }
+
+    void SetUp() override {
+        _orig_segv = OS::replaceSigsegvHandler(handler);
+        _orig_bus = OS::replaceSigbusHandler(handler);
+    }
+
+    void TearDown() override {
+        OS::replaceSigsegvHandler(_orig_segv);
+        OS::replaceSigbusHandler(_orig_bus);
+    }
+
+    SigAction _orig_segv = nullptr;
+    SigAction _orig_bus = nullptr;
+};
+
 // Mirrors VMKlass::fromOop's compact-object-headers TOCTOU guard:
 //   mark = (uintptr_t)SafeAccess::safeFetch64((int64_t*)(mark ^ MONITOR_BIT), 0);
 //   if (mark == 0) return nullptr;
 // SafeAccess::safeFetch64 on an unmapped/concurrently-freed address returns
 // its errorValue (0 here); the caller must treat that as "give up" rather
 // than shifting 0 into a bogus klass pointer.
-TEST(SafeFetch64TocTouGuardTest, ZeroReturnMeansGiveUp) {
+TEST_F(SafeFetch64TocTouGuardTest, ZeroReturnMeansGiveUp) {
     void* page = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
                        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     ASSERT_NE(page, MAP_FAILED);

--- a/ddprof-lib/src/test/cpp/hotspot_crash_protection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/hotspot_crash_protection_ut.cpp
@@ -30,10 +30,14 @@
 #include <gtest/gtest.h>
 #include "threadLocalData.h"
 #include "hotspot/hotspotSupport.h"
+#include "jvmThread.h"
+#include "safeAccess.h"
 
 #ifdef __linux__
 
 #include <cstring>
+#include <sys/mman.h>
+#include <unistd.h>
 
 // ---------------------------------------------------------------------------
 // A. ProfiledThread thread-type classification (isJavaThread fast path)
@@ -316,6 +320,88 @@ TEST_F(JmpCtxChainingTest, FaultInInnerFrameDoesNotDisturbOuterFrame) {
     EXPECT_EQ(1, inner_landed);
     EXPECT_EQ(0, outer_landed) << "the fault must not have unwound past the inner frame";
     EXPECT_FALSE(_pt->isProtected());
+}
+
+// ---------------------------------------------------------------------------
+// D. HotspotSupport::checkFault() guard clauses
+//
+// This gtest binary has no live JVM attached, so JVMThread::isInitialized()
+// is always false and the longjmp path can't be exercised end-to-end here.
+// These tests still call the real checkFault() (not a replica) to lock down
+// its two early-return guards: a null ProfiledThread* and an uninitialized
+// JVMThread must both be safe no-ops, never a crash or a spurious longjmp.
+// ---------------------------------------------------------------------------
+
+TEST(CheckFaultGuardTest, NullThreadIsNoop) {
+    HotspotSupport::checkFault(nullptr);  // must not crash
+}
+
+TEST_F(JmpCtxChainingTest, UninitializedJVMThreadIsNoop) {
+    // Even with a jmp_buf installed, checkFault() must bail out before
+    // touching it while JVMThread is not initialized (no JVM in this
+    // gtest binary), so isProtected() must remain true afterwards.
+    jmp_buf ctx;
+    _pt->setJmpCtx(&ctx);
+    ASSERT_FALSE(JVMThread::isInitialized());
+
+    HotspotSupport::checkFault(_pt);  // must not longjmp or crash
+
+    EXPECT_TRUE(_pt->isProtected());
+    EXPECT_EQ(&ctx, _pt->getJmpCtx());
+    _pt->setJmpCtx(nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// E. VTable-stub null-klass and safeFetch64==0 TOCTOU guards
+//
+// The real call sites (hotspotSupport.cpp's vtable_target branch and
+// VMKlass::fromOop's compact-header path) depend on JVM-populated static
+// offsets that only exist with a live JVM, so they can't be invoked directly
+// in this gtest binary. These tests replicate the exact guard conditions
+// verbatim, mirroring the "replicate the protocol" style already used above
+// for isJavaThread()'s fast path, to lock down the null-safety contract at
+// both sites against future refactors.
+// ---------------------------------------------------------------------------
+
+// Mirrors hotspotSupport.cpp's vtable_target branch:
+//   VMSymbol* symbol = klass != nullptr ? klass->name() : nullptr;
+//   if (symbol != nullptr) fillFrame(...);
+// A null klass (e.g. VMKlass::fromOop returning nullptr) must short-circuit
+// to a null symbol and skip fillFrame, never dereference klass.
+TEST(VTableStubNullKlassTest, NullKlassYieldsNullSymbolAndNoFrame) {
+    struct FakeKlass {
+        void* name() { return this; }  // would only run if wrongly dereferenced
+    };
+    FakeKlass* klass = nullptr;
+    void* symbol = klass != nullptr ? klass->name() : nullptr;
+    EXPECT_EQ(nullptr, symbol);
+
+    bool fillFrameCalled = false;
+    if (symbol != nullptr) {
+        fillFrameCalled = true;
+    }
+    EXPECT_FALSE(fillFrameCalled);
+}
+
+// Mirrors VMKlass::fromOop's compact-object-headers TOCTOU guard:
+//   mark = (uintptr_t)SafeAccess::safeFetch64((int64_t*)(mark ^ MONITOR_BIT), 0);
+//   if (mark == 0) return nullptr;
+// SafeAccess::safeFetch64 on an unmapped/concurrently-freed address returns
+// its errorValue (0 here); the caller must treat that as "give up" rather
+// than shifting 0 into a bogus klass pointer.
+TEST(SafeFetch64TocTouGuardTest, ZeroReturnMeansGiveUp) {
+    void* page = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(page, MAP_FAILED);
+    ASSERT_EQ(0, mprotect(page, 4096, PROT_NONE));
+
+    uintptr_t mark = (uintptr_t)SafeAccess::safeFetch64((int64_t*)page, 0);
+    EXPECT_EQ(0u, mark);
+
+    void* klass = mark == 0 ? nullptr : (void*)(mark >> 3);
+    EXPECT_EQ(nullptr, klass);
+
+    munmap(page, 4096);
 }
 
 #endif  // __linux__


### PR DESCRIPTION
**What does this PR do?**:
Stacks on #615 and fixes a scoped set of crash-protection findings surfaced during a review pass of that PR. Each finding below is from that review; findings not addressed here (`s-1`, and low-severity comment/dead-code items `s-3`/`s-4`/`s-6`) are intentionally left out — see **Additional Notes**.

**b-0 (HIGH) — `JVMThread` TLS init has no null-guard, undefined key on failure**
`ddprof-lib/src/main/cpp/threadLocal.h:213`. `ThreadLocal<JVMThread*>::initialize()` had no early-out for a null `current_thread`. In release builds (asserts compiled out), a null `current_thread` would make the pthread-key scan match the first never-created key (`pthread_getspecific()` also returns `NULL` for it), silently producing a bogus `_key` that `isKeyValid()`/`isInitialized()` would falsely report as valid — later stack-walk paths would then dereference an unrelated TLS value as a `JVMThread*`. Separately, the `bool` return of `JVMThread::initialize()` was discarded at `vmEntry.cpp:559`.
Fix: `ThreadLocal<JVMThread*>::initialize()` now returns `false` and leaves `_key == INVALID_KEY` when `current_thread == nullptr`; `get()` checks `isKeyValid()` before calling `pthread_getspecific()` instead of relying solely on an assert; `JVMThread::initialize()` restores the explicit null-guard; `VM::ready()` now logs a warning and degrades gracefully instead of discarding the result.

**Crash-handler nesting race (found while reviewing `b-0`'s neighborhood, not in the original finding set)**
`ddprof-lib/src/main/cpp/threadLocalData.h`. `enterCrashHandler()` used load-then-branch-then-increment (`u32 prev = __atomic_load_n(...); if (prev < LIMIT) { __atomic_add_fetch(...); return true; }`), which lets a nested signal on the same thread observe the same pre-increment value between the load and the add, letting more than `CRASH_HANDLER_NESTING_LIMIT` handlers past the gate.
Fix: single atomic increment-then-check (`__atomic_add_fetch` then compare, with a compensating decrement on the reject path).

**g-5 (LOW) — `_jmp_buf` publish/observe is plain load/store across a signal boundary**
`ddprof-lib/src/main/cpp/threadLocalData.h:203`. `_jmp_buf` is written in `walkVM()` (`setJmpCtx`) and read in `checkFault()`'s SEGV-handler path (`getJmpCtx`) via plain non-atomic/non-volatile load/store. Benign in practice on x86-64/aarch64, but per the C++ memory model, accessing a shared object from a signal handler that is neither `volatile sig_atomic_t` nor a lock-free atomic is UB and permits reordering around the publishing store.
Fix: `_jmp_buf` is now `std::atomic<jmp_buf*>`, with `setJmpCtx`/`getJmpCtx`/`isProtected` using explicit `memory_order_release`/`memory_order_acquire`, matching how `_crash_depth` is already hardened.

**s-2 (MEDIUM) — crash-protection gtest suite never exercises the real `walkVM`/`checkFault`**
`ddprof-lib/src/test/cpp/hotspot_crash_protection_ut.cpp:116`. The existing suite exercised only `ProfiledThread` primitives with hand-rolled `jmp_buf`s; it never called `HotspotSupport::walkVM` or `HotspotSupport::checkFault`, so the invariants this PR relies on (checkFault's guard/ordering logic) had zero direct coverage.
Fix: added tests that call the real `HotspotSupport::checkFault()` directly — a null-`ProfiledThread*` no-op, and an uninitialized-`JVMThread` no-op that leaves an installed `jmp_buf` untouched. (Full `walkVM` integration coverage needs a live JVM, which this gtest binary doesn't have — see note in the test file.)

**x-7 (LOW) — VTable-stub null-klass check has no test assertion**
`ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp:627`. The null check on the VTable-stub receiver klass (`klass != nullptr ? klass->name() : nullptr`) had no explicit test; a mutation removing/inverting it wouldn't be caught by existing tests.
Fix: added a test replicating the exact guard condition, asserting a null klass yields a null symbol and skips the frame-fill.

**x-8 (LOW) — `safeFetch64==0` TOCTOU guard has no test assertion**
`ddprof-lib/src/main/cpp/hotspot/vmStructs.h:679`. The TOCTOU guard (`mark = SafeAccess::safeFetch64(...); if (mark == 0) return nullptr;`, protecting against `MonitorDeflationThread` freeing an `ObjectMonitor` between reading the mark word and dereferencing it) had no explicit test; inverting or removing the check wouldn't be caught.
Fix: added a test that mprotects a page to force `safeFetch64` to return its error value (0) and asserts the caller treats that as "give up" rather than shifting 0 into a bogus klass pointer.

(`x-7`/`x-8`'s underlying call sites depend on JVM-populated static offsets not available in this gtest binary, so both tests replicate the exact guard condition verbatim rather than driving the real call site — consistent with this test file's existing pattern for `isJavaThread()`'s fast path.)

**Motivation**:
These were flagged during a review pass over #615 as defensive-hardening gaps in the crash-protection machinery (TLS initialization, signal-reentrancy accounting, and cross-signal-handler-boundary memory ordering). None are regressions introduced by #615 itself, but #615 touches the surrounding code closely enough that fixing them here keeps the two PRs easy to review independently.

**Additional Notes**:
Deliberately out of scope:
- `s-1`: `walkVM` now silently drops samples when `ProfiledThread` TLS is absent, whereas it previously attempted a protected walk. This is a design/telemetry question (is the coverage reduction intended? is `SAMPLES_DROPPED_THREAD_LOCAL` surfaced in telemetry?) for the #615 author to weigh in on, not a code fix.
- `s-3`/`s-4`/`s-6`: stale comments and a dead accessor (`VMThread::exception()`), left for the #615 author since they're purely about that PR's own new code/comments.

**How to test the change?**:
Added new gtest cases to `ddprof-lib/src/test/cpp/hotspot_crash_protection_ut.cpp` covering the `checkFault` guard clauses and the null-klass/`safeFetch64` guard conditions. Ran the full `:ddprof-lib:gtestDebug` suite locally (macOS) with no regressions; the new Linux-only test additions will be exercised by CI.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: N/A

Unsure? Have a question? Request a review!