### PR TITLE
fix(test): reduce ASAN wall-clock rate in BoundMethodHandleProfilerTest to avoid OOM

### DIFF
--- a/ddprof-test/src/test/java/com/datadoghq/profiler/metadata/BoundMethodHandleProfilerTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/metadata/BoundMethodHandleProfilerTest.java
@@ -15,7 +15,13 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 public class BoundMethodHandleProfilerTest extends AbstractProfilerTest {
     @Override
     protected String getProfilerCommand() {
-        return Platform.isJ9() ? "wall=100ms" : "wall=100us";
+        if (Platform.isJ9()) {
+            return "wall=100ms";
+        }
+        // wall=100us is ~10k samples/s. Under ASAN the workload runs for minutes,
+        // producing a JFR too large for JMC to load into the 512MB test heap. Sampling
+        // 10x coarser cuts both the recording size and the SIGVTALRM overhead.
+        return isAsan() ? "wall=1ms" : "wall=100us";
     }
 
     @Test
@@ -26,8 +32,10 @@ public class BoundMethodHandleProfilerTest extends AbstractProfilerTest {
         assumeFalse(Platform.isAarch64() && Platform.isMusl() && !Platform.isJavaVersionAtLeast(11)); // aarch64 + musl + jdk 8 will crash very often
         registerCurrentThreadForWallClockProfiling();
         // Reduce workload on aarch64+asan: ASAN slows each invocation enough that the test
-        // takes 3+ minutes, generating a 56MB JFR that OOMs the 512MB test-runner heap.
-        int numBoundMethodHandles = isAsan() && Platform.isAarch64() ? 1_000 : 10_000;
+        // takes 3+ minutes, generating a JFR that OOMs the 512MB test-runner heap. Combined
+        // with the coarser wall rate in getProfilerCommand(), 500 keeps the recording small
+        // while still generating enough bound-method-handle classes to sample.
+        int numBoundMethodHandles = isAsan() && Platform.isAarch64() ? 500 : 10_000;
         int x = generateBoundMethodHandles(numBoundMethodHandles);
         assertTrue(x != 0);
         stopProfiler();


### PR DESCRIPTION
## Problem
`BoundMethodHandleProfilerTest` fails on aarch64 under `:ddprof-test:testAsan` — it runs very long and OOMs.

## Root cause
The test samples at `wall=100us` (~10k samples/s). Under ASAN the bound-method-handle workload runs for minutes, and because wall-clock sampling is **time-based**, a slower aarch64 CI runner accumulates a huge number of `datadog.MethodSample` events for the same workload. `verifyEvents()` then loads the entire recording into a JMC object model inside the 512MB ASAN test heap (`-Xmx512m`), which OOMs — or the multi-minute runtime trips the CI job timeout.

The pre-existing 1000-handle aarch64 workaround was fragile because reducing the work count only partly reduces runtime; it doesn't decouple sample count from runner speed.

## Fix
- Coarsen sampling to `wall=1ms` under ASAN (10× fewer samples, independent of runner speed).
- Drop the aarch64+asan workload from 1000 → 500 handles for margin.

## Verification (on aarch64)
| Config | `datadog.MethodSample` events | Result |
|---|---|---|
| Pre-fix (`wall=100us`, 1000) | 57,735 | passed here (CI runner OOMs) |
| Fixed (`wall=1ms`, 500) | 275 | passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)