### PR TITLE
fix(test): forkEvery for asan Test task to bound cumulative heap growth

### DIFF
--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/profiler/ProfilerTestPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/profiler/ProfilerTestPlugin.kt
@@ -313,12 +313,21 @@ class ProfilerTestPlugin : Plugin<Project> {
 
             // Sanitizer conditions
             when (testConfig.configName) {
-                "asan" -> testTask.onlyIf {
-                    PlatformUtils.locateLibasan() != null &&
-                    // Skip J9+ASAN: OpenJ9 has known GC stack-scanning and defineClass
-                    // race bugs exposed by ASAN timing
-                    // https://github.com/eclipse-openj9/openj9/issues/23514
-                    !PlatformUtils.isTestJvmJ9()
+                "asan" -> {
+                    testTask.onlyIf {
+                        PlatformUtils.locateLibasan() != null &&
+                        // Skip J9+ASAN: OpenJ9 has known GC stack-scanning and defineClass
+                        // race bugs exposed by ASAN timing
+                        // https://github.com/eclipse-openj9/openj9/issues/23514
+                        !PlatformUtils.isTestJvmJ9()
+                    }
+                    // The ASAN test JVM is pinned to -Xmx512m (see ConfigurationPresets.kt)
+                    // to keep the heap below ASan's shadow-memory region. Without forking,
+                    // Gradle reuses one JVM for the whole suite, and per-test allocations
+                    // (JFR recordings, JMC object models) accumulate until it OOMs late in
+                    // the run even though every individual test passes. Restart periodically
+                    // to bound cumulative heap growth.
+                    testTask.setForkEvery(25)
                 }
                 // TSan + JVM integration tests are incompatible: the profiler's signal
                 // handlers (SIGPROF at 1ms) are TSan-instrumented; when a signal fires


### PR DESCRIPTION
## Summary
- `test-linux-glibc-aarch64 (25, asan)` failed with `Java heap space` in run https://github.com/DataDog/java-profiler/actions/runs/28658114523/job/85000253879, even though every individual test in the run passed.
- Root cause: `ddprof-test:testAsan` has no `forkEvery`, so Gradle reuses a single forked JVM for the entire ~100+ class suite. That JVM is pinned to `-Xmx512m` (see `ConfigurationPresets.kt`) to keep the heap below ASan's shadow-memory mapping, an ASLR workaround that can't simply be raised. Per-test allocations (JFR recordings, JMC object models) accumulate across the whole suite until the shared heap runs out, even though no single test is at fault — a similar single-test instance of this was just fixed in #630 for `BoundMethodHandleProfilerTest`, but this run already included that fix and still OOM'd later in the suite.
- Set `forkEvery(25)` on the `asan` `Test` task so the JVM restarts periodically and cumulative heap growth is bounded.

## Test plan
- [ ] Re-run `pre-release-tests / test-linux-glibc-aarch64 (25, asan)` in CI and confirm it completes without the `Java heap space` failure.
- [ ] Spot-check that other asan test tasks (x86_64) still pass with the added JVM restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)