### PR TITLE
ci: fix codeql-action version mismatch between init and analyze

### DIFF
--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -85,4 +85,4 @@ jobs:
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
       - run: ./gradlew -x test assembleReleaseJar
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3


### PR DESCRIPTION
## Summary
- The `Perform CodeQL Analysis` step was pinned to `github/codeql-action/analyze` v4.36.2, while the `Initialize CodeQL` step used v4.36.3, causing CI to fail with `Loaded a configuration file for version '4.36.3', but running version '4.36.2'`.
- Bumps `analyze` to the same version (v4.36.3, SHA `54f647b7e1bb85c95cddabcd46b0c578ec92bc1a`) as `init`.

See failing run: https://github.com/DataDog/java-profiler/actions/runs/28864245144/job/85610173034?pr=631

## Test plan
- [ ] Confirm the `codeql` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)