### PR TITLE
fix(build): link vmStructs inline definitions in assertion-enabled builds

### DIFF
--- a/ddprof-lib/src/main/cpp/hotspot/hotspotStackFrame_aarch64.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotStackFrame_aarch64.cpp
@@ -8,6 +8,10 @@
 
 #include <string.h>
 #include "hotspot/hotspotStackFrame.h"
+// The VMNMethod accessors used below are inline in vmStructs.h and assert via crashProtectionActive()
+// / cast_to(), both of which are defined in vmStructs.inline.h. Without this include, assertion-enabled
+// builds (the gtest targets) leave those symbols unresolved at link time.
+#include "hotspot/vmStructs.inline.h"
 
 static inline bool isSTP(instruction_t insn) {
     // stp  xn, xm, [sp, #-imm]!

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotStackFrame_x64.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotStackFrame_x64.cpp
@@ -8,6 +8,9 @@
 
 #include <string.h>
 #include "hotspot/hotspotStackFrame.h"
+// See the note in hotspotStackFrame_aarch64.cpp: the VMNMethod accessors need vmStructs.inline.h
+// for crashProtectionActive() / cast_to() so assertion-enabled builds link.
+#include "hotspot/vmStructs.inline.h"
 
 __attribute__((no_sanitize("address"))) bool HotspotStackFrame::unwindStub(instruction_t* entry, const char* name, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     instruction_t* ip = (instruction_t*)pc;

--- a/ddprof-lib/src/main/cpp/vmEntry.cpp
+++ b/ddprof-lib/src/main/cpp/vmEntry.cpp
@@ -18,7 +18,10 @@
 #include "os.h"
 #include "profiler.h"
 #include "safeAccess.h"
-#include "hotspot/vmStructs.h"
+// Pulls in vmStructs.h plus the definitions of crashProtectionActive()/cast_to() that its inline
+// accessors odr-use here; the light vmStructs.h alone leaves those unresolved in assertion-enabled
+// builds (see the note in hotspotStackFrame_aarch64.cpp).
+#include "hotspot/vmStructs.inline.h"
 #include "hotspot/jitCodeCache.h"
 #include <atomic>
 #include <dlfcn.h>


### PR DESCRIPTION
## Problem

`crashProtectionActive()` and `cast_to()` are declared `inline` in `vmStructs.h` — where the `VMNMethod` / `cast` accessors odr-use them inside `assert(...)` — but they are *defined* only in `vmStructs.inline.h`. A translation unit that includes the light `vmStructs.h` without the `.inline.h` counterpart therefore odr-uses those inline functions with no visible definition.

- In `NDEBUG` builds the asserts compile out, so the main release `.so` links fine.
- The **gtest targets keep assertions on**, so `crashProtectionActive()` is left unresolved at link time.

It surfaces first on `hotspotStackFrame_aarch64.o` (on x86_64 the reference is optimized away, so CI stayed green), which breaks **every aarch64 gtest link** — e.g.:

```
Undefined symbols for architecture arm64:
  "crashProtectionActive()", referenced from:
      VM::initProfilerBridge(...) in vmEntry.o
      HotspotStackFrame::unwindCompiled(...) in hotspotStackFrame_aarch64.o
      ...
ld: symbol(s) not found for architecture arm64
```

This is independent of any feature work — it reproduces on a clean `main`.

## Fix

Include `vmStructs.inline.h` in the TUs that odr-use the accessors (`hotspotStackFrame_aarch64.cpp`, `hotspotStackFrame_x64.cpp`, `vmEntry.cpp`), matching the codebase's existing `.h` / `.inline.h` split. `vmEntry.cpp`'s now-redundant direct `vmStructs.h` include is dropped since `.inline.h` pulls it in.

## Verification

`./gradlew :ddprof-lib:buildGtestRelease` now links (previously failed on arm64); confirmed on macOS/aarch64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)