### PR TITLE
build-logic: link sanitizer runtime for the fuzzer shared lib

### DIFF
--- a/build-logic/conventions/src/main/kotlin/com/datadoghq/native/config/ConfigurationPresets.kt
+++ b/build-logic/conventions/src/main/kotlin/com/datadoghq/native/config/ConfigurationPresets.kt
@@ -51,7 +51,7 @@ object ConfigurationPresets {
                 configureTsan(this, currentPlatform, currentArch, version, rootDir, compiler)
             }
             register("fuzzer") {
-                configureFuzzer(this, currentPlatform, currentArch, version, rootDir)
+                configureFuzzer(this, currentPlatform, currentArch, version, rootDir, compiler)
             }
         }
 
@@ -313,7 +313,8 @@ object ConfigurationPresets {
         platform: Platform,
         architecture: Architecture,
         version: String,
-        rootDir: File
+        rootDir: File,
+        compiler: String = "gcc"
     ) {
         config.platform.set(platform)
         config.architecture.set(architecture)
@@ -339,7 +340,28 @@ object ConfigurationPresets {
         when (platform) {
             Platform.LINUX -> {
                 config.compilerArgs.set(fuzzerCompilerArgs + commonLinuxCompilerArgs(version))
-                config.linkerArgs.set(commonLinuxLinkerArgs() + fuzzerLinkerArgs)
+
+                // commonLinuxLinkerArgs() carries -Wl,-z,defs, which forbids the
+                // undefined __asan_*/__ubsan_* symbols the instrumented objects
+                // reference. -fsanitize=address only links the runtime into
+                // executables, not shared libraries, so the fuzzer .so needs the
+                // runtime linked explicitly — same treatment (and rationale) as the
+                // asan config. On clang this resolves both __asan_* and __ubsan_*
+                // from one clang_rt.asan runtime; on gcc it adds -lubsan.
+                val libasan = PlatformUtils.locateLibasan(compiler)
+                val fuzzerRuntimeArgs = if (libasan != null) {
+                    val asanLibDir = File(libasan).parent
+                    val asanLibName = File(libasan).nameWithoutExtension.removePrefix("lib")
+                    val ubsanLibs = if (asanLibName.startsWith("clang_rt")) emptyList()
+                                    else listOf("-lubsan")
+                    listOf("-L$asanLibDir", "-l$asanLibName",
+                           "-Wl,-rpath,$asanLibDir") +
+                    ubsanLibs +
+                    fuzzerLinkerArgs
+                } else {
+                    fuzzerLinkerArgs
+                }
+                config.linkerArgs.set(commonLinuxLinkerArgs() + fuzzerRuntimeArgs)
 
                 config.testEnvironment.apply {
                     put("ASAN_OPTIONS", "allocator_may_return_null=1:detect_stack_use_after_return=0:handle_segv=0:abort_on_error=1:symbolize=1:suppressions=$rootDir/gradle/sanitizers/asan.supp")


### PR DESCRIPTION
## What

`configureFuzzer` now links the sanitizer runtime into the fuzzer shared library on Linux, mirroring the existing `configureAsan` treatment. The detected compiler is threaded through so the right runtime is chosen (clang: `-lclang_rt.asan-<arch>`, which also supplies UBSan symbols; gcc: `-lasan` + `-lubsan`).

## Why

`commonLinuxLinkerArgs()` includes `-Wl,-z,defs`, which forbids undefined symbols in the output. The fuzzer objects are compiled with `-fsanitize=address,undefined`, so they reference `__asan_*`/`__ubsan_*` — but `-fsanitize=address` only links the sanitizer runtime into **executables**, not shared libraries. The fuzzer `.so` is therefore left with undefined `__asan_*`/`__ubsan_*` and the link fails under `-z defs`:

```
/usr/bin/ld: wallClock.o: undefined reference to `__ubsan_handle_type_mismatch_v1_abort'
/usr/bin/ld: wallClock.o: undefined reference to `__asan_report_load4'
clang++: error: linker command failed with exit code 1
```

The `asan` config already solves exactly this via `locateLibasan`; this change applies the same, already-proven pattern to the fuzzer config.

## Why CI didn't catch it

The publish/build path passes `--exclude-task compileFuzzer` (`.gitlab/scripts/deploy.sh`) and the build job only assembles `:ddprof-lib:assembleReleaseJar`, so the fuzzer is never linked in CI. The bug only surfaces on a local build that links **all** active configs — e.g. `publishToMavenLocal` on a clang box where `hasFuzzer()` is true (non-musl, clang with libFuzzer).

## Scope / risk

- Low-risk: mirrors the existing asan linker logic; when no runtime is located the behavior is unchanged (falls back to the prior `fuzzerLinkerArgs`).
- The macOS branch is untouched.
- CI's `--exclude-task compileFuzzer` is left in place (it still saves build time); this change just makes the fuzzer link *work* when it is built.

## Testing

`./gradlew ddprof-lib:linkFuzzer` succeeds on a clang Linux box (`Successfully linked libjavaProfiler.so`). Before this change it failed at link with the undefined `__asan_*`/`__ubsan_*` references above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)