### PR TITLE
test: coarsen ASan sampling rate/workload to stop nightly heap OOMs

### DIFF
--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/CTimerSamplerTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/CTimerSamplerTest.java
@@ -72,6 +72,10 @@ public class CTimerSamplerTest extends CStackAwareAbstractProfilerTest {
 
     @Override
     protected String getProfilerCommand() {
-        return "cpu=100us,event=ctimer";
+        // cpu=100us signal-based sampling is much more expensive under ASAN (the signal
+        // handler itself is ASAN-instrumented), which can inflate the sample count and,
+        // via the per-sample stack-trace materialization above, the test heap. Sample
+        // coarser under ASAN.
+        return isAsan() ? "cpu=1ms,event=ctimer" : "cpu=100us,event=ctimer";
     }
 }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/LightweightContextCpuTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/LightweightContextCpuTest.java
@@ -79,6 +79,9 @@ public class LightweightContextCpuTest extends AbstractProfilerTest {
 
     @Override
     protected String getProfilerCommand() {
-        return "cpu=100us,lightweight=yes";
+        // cpu=100us signal-based sampling is much more expensive under ASAN (the signal
+        // handler itself is ASAN-instrumented), which can inflate the sample count and,
+        // via the per-sample accessor calls above, the test heap. Sample coarser under ASAN.
+        return isAsan() ? "cpu=1ms,lightweight=yes" : "cpu=100us,lightweight=yes";
     }
 }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/VtableReceiverFrameTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/VtableReceiverFrameTest.java
@@ -18,10 +18,7 @@ public class VtableReceiverFrameTest extends AbstractProfilerTest {
 
     @Override
     protected String getProfilerCommand() {
-        // cpu=1ms sampling over the fixed workload below still produces an ASAN-scaled
-        // number of samples (signal handling is slower under ASAN), and every sample's
-        // stack trace is materialized below, so sample coarser under ASAN.
-        return isAsan() ? "cpu=10ms" : "cpu=1ms";
+        return "cpu=1ms";
     }
 
     abstract static class Shape {
@@ -44,11 +41,7 @@ public class VtableReceiverFrameTest extends AbstractProfilerTest {
 
     private int profiledWork(Shape... shapes) {
         int result = 0;
-        // Reduce workload under ASAN: combined with the coarser sampling rate above, this
-        // bounds the number of samples (and thus the stack-trace strings materialized
-        // below) regardless of how much ASAN slows down signal handling.
-        int iterations = isAsan() ? 1_000_000 : 10_000_000;
-        for (int i = 0; i < iterations; i++) {
+        for (int i = 0; i < 10_000_000; i++) {
             for (Shape shape : shapes) {
                 result += shape.area();
             }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/VtableReceiverFrameTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/VtableReceiverFrameTest.java
@@ -18,7 +18,10 @@ public class VtableReceiverFrameTest extends AbstractProfilerTest {
 
     @Override
     protected String getProfilerCommand() {
-        return "cpu=1ms";
+        // cpu=1ms sampling over the fixed workload below still produces an ASAN-scaled
+        // number of samples (signal handling is slower under ASAN), and every sample's
+        // stack trace is materialized below, so sample coarser under ASAN.
+        return isAsan() ? "cpu=10ms" : "cpu=1ms";
     }
 
     abstract static class Shape {
@@ -41,7 +44,11 @@ public class VtableReceiverFrameTest extends AbstractProfilerTest {
 
     private int profiledWork(Shape... shapes) {
         int result = 0;
-        for (int i = 0; i < 10_000_000; i++) {
+        // Reduce workload under ASAN: combined with the coarser sampling rate above, this
+        // bounds the number of samples (and thus the stack-trace strings materialized
+        // below) regardless of how much ASAN slows down signal handling.
+        int iterations = isAsan() ? 1_000_000 : 10_000_000;
+        for (int i = 0; i < iterations; i++) {
             for (Shape shape : shapes) {
                 result += shape.area();
             }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/metadata/MetadataNormalisationTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/metadata/MetadataNormalisationTest.java
@@ -27,14 +27,18 @@ public class MetadataNormalisationTest extends AbstractProfilerTest {
         Method arrayListAdd = ArrayList.class.getDeclaredMethod("add", Object.class);
         Constructor<?> linkedListConstructor = LinkedList.class.getConstructor();
         Method linkedListAdd = LinkedList.class.getDeclaredMethod("add", Object.class);
-        // need to invoke enough times to result in generation of accessors and to record some cpu time
+        // need to invoke enough times to result in generation of accessors and to record some cpu time.
+        // Under ASAN, cpu=100us sampling combined with this fixed iteration count produces a much
+        // larger sample set (stack-trace signal handling is slower under ASAN), and every sample's
+        // stack trace is materialized below, so reduce the iteration count to bound the sample count.
+        int iterations = isAsan() ? 10_000 : 100_000;
         int count = 0;
-        for (int i = 0; i < 100_000; i++) {
+        for (int i = 0; i < iterations; i++) {
             Object list = arrayListConstructor.newInstance();
             arrayListAdd.invoke(list, "element");
             count += ((List<?>) list).size();
         }
-        for (int i = 0; i < 100_000; i++) {
+        for (int i = 0; i < iterations; i++) {
             Object list = linkedListConstructor.newInstance();
             linkedListAdd.invoke(list, "element");
             count += ((List<?>) list).size();
@@ -63,6 +67,6 @@ public class MetadataNormalisationTest extends AbstractProfilerTest {
 
     @Override
     protected String getProfilerCommand() {
-        return "cpu=100us";
+        return isAsan() ? "cpu=1ms" : "cpu=100us";
     }
 }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/MegamorphicCallTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/MegamorphicCallTest.java
@@ -20,7 +20,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class MegamorphicCallTest extends AbstractProfilerTest {
     @Override
     protected String getProfilerCommand() {
-        return "wall=100us";
+        // wall=100us over the fixed workload below is ~10k samples/s. Under ASAN each
+        // invocation is much slower, so the same fixed-rate sampling over a much longer
+        // wall-clock duration produces hundreds of thousands of samples, and stack-trace
+        // stringification of all of them (below) OOMs the test-runner heap. Sample 10x
+        // coarser under ASAN, combined with a smaller workload, to bound the sample count.
+        return isAsan() ? "wall=1ms" : "wall=100us";
     }
 
     private static int calculation() {
@@ -60,9 +65,9 @@ public class MegamorphicCallTest extends AbstractProfilerTest {
         }
     }
 
-    private int profiledWork(Calculator... calculators) {
+    private int profiledWork(int iterations, Calculator... calculators) {
         int result = 0;
-        for (int i = 0; i < 1_000_000; i++) {
+        for (int i = 0; i < iterations; i++) {
             for (Calculator calculator : calculators) {
                 result += calculator.calculate();
             }
@@ -74,7 +79,11 @@ public class MegamorphicCallTest extends AbstractProfilerTest {
     public void testITableStubs() {
         Assumptions.assumeFalse(Platform.isZing() || Platform.isJ9());
         registerCurrentThreadForWallClockProfiling();
-        int result = profiledWork(new Calculator1(), new Calculator2(), new Calculator3());
+        // Reduce workload under ASAN: combined with the coarser wall rate above, this
+        // bounds the number of samples (and thus the stack-trace strings materialized
+        // below) regardless of how much ASAN slows down each invocation.
+        int iterations = isAsan() ? 100_000 : 1_000_000;
+        int result = profiledWork(iterations, new Calculator1(), new Calculator2(), new Calculator3());
         System.err.println(result);
         stopProfiler();
         IItemCollection events = verifyEvents("datadog.MethodSample");


### PR DESCRIPTION
**What does this PR do?**:
Coarsens the CPU/wall sampling interval and shrinks the driven workload, under ASan only, in four tests that were producing an unbounded number of profiler samples under ASan and then materializing a `String` stack trace for every single one of them:

- `MegamorphicCallTest` (`wall=100us` → `wall=1ms`; 1M → 100k iterations)
- `MetadataNormalisationTest` (`cpu=100us` → `cpu=1ms`; 100k → 10k iterations)
- `CTimerSamplerTest` (`cpu=100us` → `cpu=1ms`)
- `LightweightContextCpuTest` (`cpu=100us` → `cpu=1ms`)

Non-ASan behavior/rates are unchanged.

`VtableReceiverFrameTest` was initially included in this set but the change was reverted after review ([discussion](https://github.com/DataDog/java-profiler/pull/653#discussion_r3570012797)): it was never observed failing in CI, already sampled at a coarser `cpu=1ms`, and drives pure-Java virtual dispatch that ASan doesn't meaningfully slow down — stacking a 10x coarser interval with a 10x smaller workload risked starving its narrow `.vtable stub()`/`vtable_receiver` pattern search instead of fixing a real problem.

**Motivation**:
Nightly `test-linux-glibc-aarch64 (*, asan)` runs have been failing deterministically with `Java heap space` in the Gradle test executor for at least 4 consecutive nights (e.g. run [29223441349](https://github.com/DataDog/java-profiler/actions/runs/29223441349)), always breaking at `MegamorphicCallTest.testITableStubs()`.

Root cause: these tests use a very tight, fixed signal-based sampling interval (e.g. `wall=100us`) over a workload bounded by a fixed iteration count rather than a fixed wall-clock duration. Under ASan, signal handling itself is instrumented and much slower, so the same fixed-rate sampler collects a disproportionately larger number of samples (242,177 in the confirmed failing run) — and each test then builds a Java `String` stack trace for every sample to search for a substring, which exhausts the ASan test JVM's `-Xmx1024m` heap.

Two prior fixes (#632 forkEvery, #640 raising `-Xmx` 512m→1024m) only widened the margin without bounding the sample count, so the flake persisted. This applies the pattern already established for `BoundMethodHandleProfilerTest` (#630/#533): sample coarser and shrink the workload specifically under `isAsan()`.

I audited every other test using a similarly tight sampling interval; the four listed above are the ones confirmed or strongly suspected to combine a tight interval, an iteration-bounded (not time-bounded) workload, and full per-sample materialization, without a countervailing reason (like `VtableReceiverFrameTest`'s) to leave them alone.

**Additional Notes**:
N/A

**How to test the change?**:
Ran `:ddprof-test:compileTestJava` to confirm the changes compile; the actual regression only reproduces under ASan on aarch64 in CI, so the real validation is the next few nightly `Nightly Sanitized Run` executions no longer failing with `Java heap space`.

**For Datadog employees**:
- [x] This PR doesn't touch any of that.
- [ ] JIRA: N/A (ad hoc investigation, no ticket filed)

Unsure? Have a question? Request a review!