### PR TITLE
Gate FrameType::isRawPointer on ENCODED_MASK and HotSpot

### DIFF
--- a/ddprof-lib/src/main/cpp/frame.h
+++ b/ddprof-lib/src/main/cpp/frame.h
@@ -79,11 +79,13 @@ public:
     return (FrameTypeId)((bci >> TYPE_SHIFT) & FRAME_TYPE_MASK);
   }
 
-  // Raw pointers only exist on HotSpot (see hotspotSupport.cpp fillFrameRaw).
-  // On other VMs an unencoded, VM-supplied bci can coincidentally have bit 30
-  // set; that must not be mistaken for our raw-pointer encoding.
+  // Raw pointers only exist on HotSpot (see hotspotSupport.cpp fillFrameRaw),
+  // and RAW_POINTER_MASK is only ever set by encode(..., rawPointer=true),
+  // which unconditionally also sets ENCODED_MASK. Requiring both HotSpot and
+  // ENCODED_MASK prevents a raw, VM-supplied ASGCT BCI from false-positiving
+  // just because it happens to have bit 30 set.
   static inline bool isRawPointer(int bci) {
-    return VM::isHotspot() && bci > 0 && (bci & RAW_POINTER_MASK) != 0;
+    return VM::isHotspot() && (bci > 0 && (bci & ENCODED_MASK) != 0 && (bci & RAW_POINTER_MASK) != 0);
   }
 };
 

--- a/ddprof-lib/src/test/cpp/frame_ut.cpp
+++ b/ddprof-lib/src/test/cpp/frame_ut.cpp
@@ -7,12 +7,27 @@
 #include "../../main/cpp/frame.h"
 #include "../../main/cpp/gtest_crash_handler.h"
 
-// VMTestAccessor — friend of VM, lets tests toggle VM::isHotspot() since
-// isRawPointer() now gates on it (raw pointers only exist on HotSpot).
+// Test-only friend accessor for VM internals. It exists solely so these unit
+// tests can exercise the VM-specific raw-pointer path in FrameType and must
+// never be reused from production code.
 class VMTestAccessor {
 public:
     static bool getHotspot() { return VM::_hotspot; }
     static void setHotspot(bool v) { VM::_hotspot = v; }
+};
+
+class VMHotspotGuard {
+private:
+    bool _saved;
+
+public:
+    explicit VMHotspotGuard(bool hotspot) : _saved(VMTestAccessor::getHotspot()) {
+        VMTestAccessor::setHotspot(hotspot);
+    }
+
+    ~VMHotspotGuard() {
+        VMTestAccessor::setHotspot(_saved);
+    }
 };
 
 static constexpr char FRAME_TEST_NAME[] = "FrameTest";
@@ -150,26 +165,22 @@ TEST(FrameTypeIsRawPointerTest, FalseForEncodedWithoutFlag) {
 TEST(FrameTypeIsRawPointerTest, TrueWhenBit30IsSetOnHotspot) {
     // Manually set the raw-pointer flag (bit 30) on an encoded value.
     // Raw pointers only exist on HotSpot, so isRawPointer() must be gated on it.
-    bool saved = VMTestAccessor::getHotspot();
-    VMTestAccessor::setHotspot(true);
+    VMHotspotGuard hotspot(true);
     int base = FrameType::encode(FRAME_JIT_COMPILED, 0);
     int withFlag = base | (1 << 30);
     EXPECT_TRUE(FrameType::isRawPointer(withFlag))
         << "isRawPointer() must be true when bit 30 is set, value is positive, and VM is HotSpot";
-    VMTestAccessor::setHotspot(saved);
 }
 
 TEST(FrameTypeIsRawPointerTest, FalseWhenBit30IsSetOnNonHotspot) {
     // Non-HotSpot VMs can coincidentally produce an unencoded bci with bit 30
     // set (e.g. OpenJ9's raw AsyncGetCallTrace output); that must not be
     // mistaken for HotSpot's raw-pointer encoding.
-    bool saved = VMTestAccessor::getHotspot();
-    VMTestAccessor::setHotspot(false);
+    VMHotspotGuard hotspot(false);
     int base = FrameType::encode(FRAME_JIT_COMPILED, 0);
     int withFlag = base | (1 << 30);
     EXPECT_FALSE(FrameType::isRawPointer(withFlag))
         << "isRawPointer() must be false when VM is not HotSpot, even with bit 30 set";
-    VMTestAccessor::setHotspot(saved);
 }
 
 TEST(FrameTypeIsRawPointerTest, FalseWithOnlyBit30SetOnNegative) {
@@ -178,4 +189,17 @@ TEST(FrameTypeIsRawPointerTest, FalseWithOnlyBit30SetOnNegative) {
     int negativeWithBit30 = static_cast<int>(0xC0000000u); // bits 31 and 30 set → negative
     EXPECT_LT(negativeWithBit30, 0);
     EXPECT_FALSE(FrameType::isRawPointer(negativeWithBit30));
+}
+
+TEST(FrameTypeIsRawPointerTest, FalseForRawAsgctBciWithBit30SetButNoEncodedMarker) {
+    // Regression test: a raw, unencoded ASGCT BCI (bit 20 / ENCODED_MASK not set)
+    // that incidentally has bit 30 set must NOT be reported as a raw pointer.
+    // Such values occur on non-HotSpot VMs (e.g. J9), which never call encode()
+    // and therefore never set ENCODED_MASK; only encode(..., rawPointer=true)
+    // (HotSpot-only, per its own assert) is allowed to set RAW_POINTER_MASK.
+    int rawAsgctBciWithBit30 = 1 << 30;
+    VMHotspotGuard hotspot(true);
+    EXPECT_FALSE(FrameType::isRawPointer(rawAsgctBciWithBit30))
+        << "isRawPointer() must require ENCODED_MASK (bit 20) before trusting bit 30, "
+        << "otherwise raw ASGCT BCIs that never went through encode() can false-positive";
 }


### PR DESCRIPTION
**What does this PR do?**:
Requires `ENCODED_MASK` (bit 20) in addition to the HotSpot check before
`FrameType::isRawPointer()` trusts `RAW_POINTER_MASK` (bit 30).

**Motivation**:
`RAW_POINTER_MASK` is only ever set by `encode(..., rawPointer=true)`, which
unconditionally also sets `ENCODED_MASK`. Without the `ENCODED_MASK` check, a
raw, unencoded ASGCT BCI that incidentally has bit 30 set (observed on
non-HotSpot VMs such as J9) could false-positive as a raw pointer even
though it never went through `encode()`. This was split out of PR #644 per
review feedback, since it's an independent, unrelated production fix.

**Additional Notes**:
Split out of #644 (chaos-tooling debugging surfaced this bug incidentally;
the fix has nothing to do with that PR's antagonist/harness work).

**How to test the change?**:
- `./gradlew :ddprof-lib:gtestDebug_frame_ut` - new/updated `FrameType`
  regression tests (`FalseWhenBit30IsSetOnNonHotspot`,
  `FalseForRawAsgctBciWithBit30SetButNoEncodedMarker`) cover the false-positive
  this closes.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!

🤖 Generated with [Claude Code](https://claude.com/claude-code)