### PR TITLE
feat(nativemem): categorized native-memory accounting — first cut

### DIFF
--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -53,6 +53,9 @@
   X(CALLTRACE_STORAGE_TRACES, "calltrace_storage_traces")                      \
   X(LINEAR_ALLOCATOR_BYTES, "linear_allocator_bytes")                          \
   X(LINEAR_ALLOCATOR_CHUNKS, "linear_allocator_chunks")                        \
+  X(NATIVE_MEM_LIVE_BYTES, "native_mem_live_bytes")                            \
+  X(NATIVE_MEM_MAX_BYTES, "native_mem_max_bytes")                              \
+  X(NATIVE_MEM_AVG_BYTES, "native_mem_avg_bytes")                              \
   X(THREAD_IDS_COUNT, "thread_ids_count")                                      \
   X(THREAD_NAMES_COUNT, "thread_names_count")                                  \
   X(THREAD_FILTER_PAGES, "thread_filter_pages")                                \

--- a/ddprof-lib/src/main/cpp/dictionary.cpp
+++ b/ddprof-lib/src/main/cpp/dictionary.cpp
@@ -37,6 +37,7 @@ static inline bool keyEquals(const char *candidate, const char *key,
 Dictionary::~Dictionary() {
   clear(_table, _id);
   free(_table);
+  NativeMem::record(NM_DICTIONARY, -(long long)sizeof(DictTable));
   Counters::set(DICTIONARY_BYTES, 0, _id);
   Counters::set(DICTIONARY_PAGES, 0, _id);
 }
@@ -58,6 +59,9 @@ void Dictionary::clear(DictTable *table, int id) {
     DictRow *row = &table->rows[i];
     for (int j = 0; j < CELLS; j++) {
       if (row->keys[j]) {
+        // Keys are null-terminated, so the malloc'd size (length + 1) is
+        // recoverable at free time without tracking it per key.
+        NativeMem::record(NM_DICTIONARY, -(long long)(strlen(row->keys[j]) + 1));
         free(row->keys[j]); // content is zeroed en-mass in the clear() function
       }
     }
@@ -65,6 +69,7 @@ void Dictionary::clear(DictTable *table, int id) {
       clear(row->next, id);
       DictTable *tmp = row->next;
       row->next = NULL;
+      NativeMem::record(NM_DICTIONARY, -(long long)sizeof(DictTable));
       free(tmp);
     }
   }
@@ -110,6 +115,7 @@ unsigned int Dictionary::lookup(const char *key, size_t length, bool for_insert,
         if (__sync_bool_compare_and_swap(&row->keys[c], NULL, new_key)) {
           Counters::increment(DICTIONARY_KEYS, 1, _id);
           Counters::increment(DICTIONARY_KEYS_BYTES, length + 1, _id);
+          NativeMem::record(NM_DICTIONARY, (long long)(length + 1));
           atomicInc(_size);
           return table->index(h % ROWS, c);
         }
@@ -130,6 +136,7 @@ unsigned int Dictionary::lookup(const char *key, size_t length, bool for_insert,
         } else {
           Counters::increment(DICTIONARY_PAGES, 1, _id);
           Counters::increment(DICTIONARY_BYTES, sizeof(DictTable), _id);
+          NativeMem::record(NM_DICTIONARY, (long long)sizeof(DictTable));
         }
       } else {
         return sentinel;

--- a/ddprof-lib/src/main/cpp/dictionary.cpp
+++ b/ddprof-lib/src/main/cpp/dictionary.cpp
@@ -67,17 +67,19 @@ void Dictionary::clear(DictTable *table, int id) {
     for (int j = 0; j < CELLS; j++) {
       if (row->keys[j]) {
         // Keys are null-terminated, so the malloc'd size (length + 1) is
-        // recoverable at free time without tracking it per key.
-        NativeMem::record(NM_DICTIONARY, -(long long)(strlen(row->keys[j]) + 1));
+        // recoverable without tracking it per key. Capture it before free(),
+        // then record after, consistent with the other decrement sites.
+        long long key_bytes = (long long)(strlen(row->keys[j]) + 1);
         free(row->keys[j]); // content is zeroed en-mass in the clear() function
+        NativeMem::record(NM_DICTIONARY, -key_bytes);
       }
     }
     if (row->next != NULL) {
       clear(row->next, id);
       DictTable *tmp = row->next;
       row->next = NULL;
-      NativeMem::record(NM_DICTIONARY, -(long long)sizeof(DictTable));
       free(tmp);
+      NativeMem::record(NM_DICTIONARY, -(long long)sizeof(DictTable));
     }
   }
 }

--- a/ddprof-lib/src/main/cpp/dictionary.cpp
+++ b/ddprof-lib/src/main/cpp/dictionary.cpp
@@ -18,6 +18,7 @@
 #include "arch.h"
 #include "counters.h"
 #include "signalSafety.h"
+#include <cassert>
 #include <climits>
 #include <stdlib.h>
 #include <string.h>
@@ -26,6 +27,12 @@ static inline char *allocateKey(const char *key, size_t length) {
   char *result = (char *)malloc(length + 1);
   memcpy(result, key, length);
   result[length] = 0;
+  // NM_DICTIONARY accounting recovers a freed key's size via strlen at clear()
+  // time, which requires the key to be a NUL-free string of exactly `length`.
+  // Pin that assumption here so a future caller passing an embedded NUL trips in
+  // debug/gtest rather than silently under-counting the free. Stripped under
+  // NDEBUG.
+  assert(strlen(result) == length);
   return result;
 }
 

--- a/ddprof-lib/src/main/cpp/dictionary.h
+++ b/ddprof-lib/src/main/cpp/dictionary.h
@@ -18,6 +18,7 @@
 #define _DICTIONARY_H
 
 #include "counters.h"
+#include "nativeMem.h"
 #include <map>
 #include <stddef.h>
 #include <stdlib.h>
@@ -67,6 +68,7 @@ public:
     _table = (DictTable *)calloc(1, sizeof(DictTable));
     Counters::set(DICTIONARY_PAGES, 1, id);
     Counters::set(DICTIONARY_BYTES, sizeof(DictTable), id);
+    NativeMem::record(NM_DICTIONARY, (long long)sizeof(DictTable));
     _table->base_index = _base_index = 1;
     _size = 0;
   }

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1780,24 +1780,37 @@ void Recording::writeLogLevels(Buffer *buf) {
 }
 
 void Recording::updateNativeMemStats() {
-  // Fold the per-category live gauges into their moving-window averages and
-  // running peaks. This is a sampled max: peaks that rise and fall entirely
-  // between two chunk finishes are not observed. A spike-accurate max would
-  // track the high-water mark at allocation time.
+  // Refresh the moving-window averages and the observed total peak. Per-category
+  // peaks are maintained precisely at allocation time, so they are not sampled
+  // here; the total peak is bracketed instead (see writeNativeMem).
   NativeMem::sample();
 
   // Mirror the totals into the flat counter table so they flow out through the
   // existing counter path (JFR T_DATADOG_COUNTER events and the JNI debug
-  // counters). Per-category values are emitted separately by writeNativeMem().
+  // counters). NATIVE_MEM_MAX_BYTES carries the upper bound on the total peak
+  // (sum of precise per-category peaks); the observed lower bound and the
+  // per-category values are emitted by writeNativeMem().
   Counters::set(NATIVE_MEM_LIVE_BYTES, NativeMem::liveTotal());
   Counters::set(NATIVE_MEM_AVG_BYTES, NativeMem::avgTotal());
   Counters::set(NATIVE_MEM_MAX_BYTES, NativeMem::maxTotal());
 }
 
 void Recording::writeNativeMem(Buffer *buf) {
-  // Emit live/avg/max per category as counter events, reusing the counter event
-  // format with a "<metric>.<category>" name so they land alongside the totals
-  // without needing a dedicated event type or a slot in the counter table.
+  // Emit native-memory stats as counter events, reusing the counter event format
+  // so they land alongside the totals without needing a dedicated event type or
+  // a slot in the counter table.
+  auto emit = [&](const char *label, long long value) {
+    int start = buf->skip(1);
+    buf->putVar64(T_DATADOG_COUNTER);
+    buf->putVar64(_start_ticks);
+    buf->putUtf8(label);
+    buf->putVar64(value);
+    writeEventSizePrefix(buf, start);
+    flushIfNeeded(buf);
+  };
+
+  // Per-category live/avg/max, named "<metric>.<category>". The max here is the
+  // precise per-category peak tracked at allocation time.
   for (int c = 0; c < NM_NUM_CATEGORIES; c++) {
     NativeMemCategory cat = (NativeMemCategory)c;
     const char *name = NativeMem::categoryName(cat);
@@ -1812,15 +1825,14 @@ void Recording::writeNativeMem(Buffer *buf) {
     for (const auto &m : metrics) {
       char label[64];
       snprintf(label, sizeof(label), "%s%s", m.prefix, name);
-      int start = buf->skip(1);
-      buf->putVar64(T_DATADOG_COUNTER);
-      buf->putVar64(_start_ticks);
-      buf->putUtf8(label);
-      buf->putVar64(m.value);
-      writeEventSizePrefix(buf, start);
-      flushIfNeeded(buf);
+      emit(label, m.value);
     }
   }
+
+  // The total peak is bracketed: NATIVE_MEM_MAX_BYTES already carries the upper
+  // bound (sum of precise per-category peaks); here we also emit the observed
+  // lower bound (largest instantaneous total seen at a sampling tick).
+  emit("native_mem_max_observed_total_bytes", NativeMem::maxTotalObserved());
 }
 
 void Recording::writeCounters(Buffer *buf) {

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -1794,7 +1794,7 @@ void Recording::updateNativeMemStats() {
   // Mirror the totals into the flat counter table so they flow out through the
   // existing counter path (JFR T_DATADOG_COUNTER events and the JNI debug
   // counters). NATIVE_MEM_MAX_BYTES carries the upper bound on the total peak
-  // (sum of precise per-category peaks); the observed lower bound and the
+  // (sum of precise per-category peaks); the observed sampled total and the
   // per-category values are emitted by writeNativeMem().
   Counters::set(NATIVE_MEM_LIVE_BYTES, NativeMem::liveTotal());
   Counters::set(NATIVE_MEM_AVG_BYTES, NativeMem::avgTotal());
@@ -1806,6 +1806,13 @@ void Recording::writeNativeMem(Buffer *buf) {
   // so they land alongside the totals without needing a dedicated event type or
   // a slot in the counter table.
   auto emit = [&](const char *label, long long value) {
+    // Clamp to 0 before encoding: the value is serialized as an unsigned varint
+    // (putVar64), so a negative live gauge would emit a huge value and corrupt
+    // the counter stream. avg/max are already non-negative; live is clamped
+    // here to match sample()/liveTotal().
+    if (value < 0) {
+      value = 0;
+    }
     int start = buf->skip(1);
     buf->putVar64(T_DATADOG_COUNTER);
     buf->putVar64(_start_ticks);
@@ -1835,9 +1842,9 @@ void Recording::writeNativeMem(Buffer *buf) {
     }
   }
 
-  // The total peak is bracketed: NATIVE_MEM_MAX_BYTES already carries the upper
-  // bound (sum of precise per-category peaks); here we also emit the observed
-  // lower bound (largest instantaneous total seen at a sampling tick).
+  // NATIVE_MEM_MAX_BYTES already carries the upper bound on the total peak (sum
+  // of precise per-category peaks); here we also emit the largest observed
+  // sampled total (a non-atomic per-category sum; approximate).
   emit("native_mem_max_observed_total_bytes", NativeMem::maxTotalObserved());
 }
 
@@ -2142,8 +2149,12 @@ void FlightRecorder::stop() {
   if (rec != nullptr) {
     // NULL first, deallocate later
     _rec = nullptr;
-    NativeMem::record(NM_JFR_BUFFERS, -(long long)sizeof(Recording));
+    // Decrement AFTER delete: ~Recording() runs finishChunk(), which emits the
+    // native-memory counters for the final chunk. The Recording buffers are
+    // still live during that serialization, so account the free only once it
+    // has actually happened.
     delete rec;
+    NativeMem::record(NM_JFR_BUFFERS, -(long long)sizeof(Recording));
   }
 }
 

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -12,6 +12,7 @@
 #include "context.h"
 #include "context_api.h"
 #include "counters.h"
+#include "nativeMem.h"
 #include "dictionary.h"
 #include "flightRecorder.inline.h"
 #include "incbin.h"
@@ -810,7 +811,9 @@ off_t Recording::finishChunk(bool end_recording, bool do_cleanup) {
   // dictionary) will reflect the previous serialization. That is, some level of
   // familiarity with the code base will be required to use this diagnostic
   // information for now.
+  updateNativeMemStats();
   writeCounters(_buf);
+  writeNativeMem(_buf);
 
   // Keep a simple stats for where we failed to unwind
   // For the sakes of simplicity we are not keeping the count of failed unwinds which would also be
@@ -1773,6 +1776,50 @@ void Recording::writeLogLevels(Buffer *buf) {
     buf->putVar32(i);
     buf->putUtf8(Log::LEVEL_NAME[i]);
     flushIfNeeded(buf);
+  }
+}
+
+void Recording::updateNativeMemStats() {
+  // Fold the per-category live gauges into their moving-window averages and
+  // running peaks. This is a sampled max: peaks that rise and fall entirely
+  // between two chunk finishes are not observed. A spike-accurate max would
+  // track the high-water mark at allocation time.
+  NativeMem::sample();
+
+  // Mirror the totals into the flat counter table so they flow out through the
+  // existing counter path (JFR T_DATADOG_COUNTER events and the JNI debug
+  // counters). Per-category values are emitted separately by writeNativeMem().
+  Counters::set(NATIVE_MEM_LIVE_BYTES, NativeMem::liveTotal());
+  Counters::set(NATIVE_MEM_AVG_BYTES, NativeMem::avgTotal());
+  Counters::set(NATIVE_MEM_MAX_BYTES, NativeMem::maxTotal());
+}
+
+void Recording::writeNativeMem(Buffer *buf) {
+  // Emit live/avg/max per category as counter events, reusing the counter event
+  // format with a "<metric>.<category>" name so they land alongside the totals
+  // without needing a dedicated event type or a slot in the counter table.
+  for (int c = 0; c < NM_NUM_CATEGORIES; c++) {
+    NativeMemCategory cat = (NativeMemCategory)c;
+    const char *name = NativeMem::categoryName(cat);
+    const struct {
+      const char *prefix;
+      long long value;
+    } metrics[] = {
+        {"native_mem_live_bytes.", NativeMem::live(cat)},
+        {"native_mem_avg_bytes.", NativeMem::avg(cat)},
+        {"native_mem_max_bytes.", NativeMem::max(cat)},
+    };
+    for (const auto &m : metrics) {
+      char label[64];
+      snprintf(label, sizeof(label), "%s%s", m.prefix, name);
+      int start = buf->skip(1);
+      buf->putVar64(T_DATADOG_COUNTER);
+      buf->putVar64(_start_ticks);
+      buf->putUtf8(label);
+      buf->putVar64(m.value);
+      writeEventSizePrefix(buf, start);
+      flushIfNeeded(buf);
+    }
   }
 }
 

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -74,6 +74,10 @@ SharedLineNumberTable::~SharedLineNumberTable() {
   if (_ptr != nullptr) {
     free(_ptr);
     Counters::decrement(LINE_NUMBER_TABLES);
+    // _size is the JVMTI entry count passed at construction (see
+    // fillJavaMethodInfo), so the byte size matches the allocation.
+    NativeMem::record(NM_LINE_TABLES, -(long long)((size_t)_size *
+                                                   sizeof(jvmtiLineNumberEntry)));
   }
 }
 
@@ -421,6 +425,8 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
             line_number_table_size, owned_table);
         // Increment counter for tracking live line number tables
         Counters::increment(LINE_NUMBER_TABLES);
+        NativeMem::record(NM_LINE_TABLES, (long long)((size_t)line_number_table_size *
+                                                      sizeof(jvmtiLineNumberEntry)));
       }
     }
 
@@ -2123,6 +2129,9 @@ Error FlightRecorder::newRecording(bool reset) {
   }
 
   _rec = new Recording(fd, _args);
+  // The Recording embeds the JFR RecordingBuffer array and the cpu-monitor
+  // buffer, so its allocation size is the profiler's JFR buffer footprint.
+  NativeMem::record(NM_JFR_BUFFERS, (long long)sizeof(Recording));
   return Error::OK;
 }
 
@@ -2133,6 +2142,7 @@ void FlightRecorder::stop() {
   if (rec != nullptr) {
     // NULL first, deallocate later
     _rec = nullptr;
+    NativeMem::record(NM_JFR_BUFFERS, -(long long)sizeof(Recording));
     delete rec;
   }
 }

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -304,6 +304,9 @@ public:
 
   void writeCounters(Buffer *buf);
 
+  void updateNativeMemStats();
+  void writeNativeMem(Buffer *buf);
+
   void writeUnwindFailures(Buffer *buf);
 
   void writeContextSnapshot(Buffer *buf, Context &context);

--- a/ddprof-lib/src/main/cpp/linearAllocator.cpp
+++ b/ddprof-lib/src/main/cpp/linearAllocator.cpp
@@ -17,6 +17,7 @@
 
 #include "linearAllocator.h"
 #include "counters.h"
+#include "nativeMem.h"
 #include "os.h"
 #include "common.h"
 #include <stdio.h>
@@ -167,6 +168,9 @@ void LinearAllocator::freeChunks(ChunkList& chunks) {
     OS::safeFree(current, chunks.chunk_size);
     Counters::decrement(LINEAR_ALLOCATOR_BYTES, chunks.chunk_size);
     Counters::decrement(LINEAR_ALLOCATOR_CHUNKS);
+    // The LinearAllocator's only user is call-trace storage, so all of its
+    // chunk memory is attributed to the CALLTRACE category.
+    NativeMem::record(NM_CALLTRACE, -(long long)chunks.chunk_size);
     current = prev;
   }
 
@@ -260,6 +264,7 @@ Chunk *LinearAllocator::allocateChunk(Chunk *current) {
 
     Counters::increment(LINEAR_ALLOCATOR_BYTES, _chunk_size);
     Counters::increment(LINEAR_ALLOCATOR_CHUNKS);
+    NativeMem::record(NM_CALLTRACE, (long long)_chunk_size);
   }
   return chunk;
 }
@@ -275,6 +280,7 @@ void LinearAllocator::freeChunk(Chunk *current) {
   OS::safeFree(current, _chunk_size);
   Counters::decrement(LINEAR_ALLOCATOR_BYTES, _chunk_size);
   Counters::decrement(LINEAR_ALLOCATOR_CHUNKS);
+  NativeMem::record(NM_CALLTRACE, -(long long)_chunk_size);
 }
 
 void LinearAllocator::reserveChunk(Chunk *current) {

--- a/ddprof-lib/src/main/cpp/nativeMem.cpp
+++ b/ddprof-lib/src/main/cpp/nativeMem.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "nativeMem.h"
+
+volatile long long NativeMem::_live[NM_NUM_CATEGORIES] = {};
+long long NativeMem::_window[NM_NUM_CATEGORIES][NativeMem::WINDOW] = {};
+long long NativeMem::_total_window[NativeMem::WINDOW] = {};
+int NativeMem::_window_pos = 0;
+int NativeMem::_window_count = 0;
+long long NativeMem::_avg[NM_NUM_CATEGORIES] = {};
+long long NativeMem::_max[NM_NUM_CATEGORIES] = {};
+long long NativeMem::_total_avg = 0;
+long long NativeMem::_total_max = 0;
+
+long long NativeMem::liveTotal() {
+  long long total = 0;
+  for (int c = 0; c < NM_NUM_CATEGORIES; c++) {
+    total += load(_live[c]);
+  }
+  return total;
+}
+
+void NativeMem::sample() {
+  long long total = 0;
+  for (int c = 0; c < NM_NUM_CATEGORIES; c++) {
+    long long v = load(_live[c]);
+    // Clamp transient negatives from not-yet-instrumented free sites so they do
+    // not skew the window; accounting is currently best-effort per category.
+    if (v < 0) {
+      v = 0;
+    }
+    _window[c][_window_pos] = v;
+    if (v > _max[c]) {
+      _max[c] = v;
+    }
+    total += v;
+  }
+
+  _total_window[_window_pos] = total;
+  if (total > _total_max) {
+    _total_max = total;
+  }
+
+  _window_pos = (_window_pos + 1) % WINDOW;
+  if (_window_count < WINDOW) {
+    _window_count++;
+  }
+
+  for (int c = 0; c < NM_NUM_CATEGORIES; c++) {
+    long long sum = 0;
+    for (int i = 0; i < _window_count; i++) {
+      sum += _window[c][i];
+    }
+    _avg[c] = sum / _window_count;
+  }
+
+  long long total_sum = 0;
+  for (int i = 0; i < _window_count; i++) {
+    total_sum += _total_window[i];
+  }
+  _total_avg = total_sum / _window_count;
+}
+
+void NativeMem::reset() {
+  for (int c = 0; c < NM_NUM_CATEGORIES; c++) {
+    store(_live[c], (long long)0);
+    _avg[c] = 0;
+    _max[c] = 0;
+    for (int i = 0; i < WINDOW; i++) {
+      _window[c][i] = 0;
+    }
+  }
+  for (int i = 0; i < WINDOW; i++) {
+    _total_window[i] = 0;
+  }
+  _window_pos = 0;
+  _window_count = 0;
+  _total_avg = 0;
+  _total_max = 0;
+}
+
+const char *NativeMem::categoryName(NativeMemCategory category) {
+#define X_NM_NAME(a, b) b,
+  static const char *const names[] = {DD_NATIVE_MEM_CATEGORY_TABLE(X_NM_NAME)};
+#undef X_NM_NAME
+  if (category < 0 || category >= NM_NUM_CATEGORIES) {
+    return "unknown";
+  }
+  return names[category];
+}

--- a/ddprof-lib/src/main/cpp/nativeMem.cpp
+++ b/ddprof-lib/src/main/cpp/nativeMem.cpp
@@ -45,8 +45,10 @@ void NativeMem::sample() {
   long long total = 0;
   for (int c = 0; c < NM_NUM_CATEGORIES; c++) {
     long long v = load(_live[c]);
-    // Clamp transient negatives from not-yet-instrumented free sites so they do
-    // not skew the window; accounting is currently best-effort per category.
+    // A category's live bytes are never negative under correct pairing (asserted
+    // in record()). This clamp is a release-mode safety net: should an accounting
+    // bug slip past the assert under NDEBUG, it keeps a negative from skewing the
+    // window average and total rather than propagating garbage.
     if (v < 0) {
       v = 0;
     }

--- a/ddprof-lib/src/main/cpp/nativeMem.cpp
+++ b/ddprof-lib/src/main/cpp/nativeMem.cpp
@@ -16,19 +16,27 @@
 #include "nativeMem.h"
 
 volatile long long NativeMem::_live[NM_NUM_CATEGORIES] = {};
+volatile long long NativeMem::_max[NM_NUM_CATEGORIES] = {};
 long long NativeMem::_window[NM_NUM_CATEGORIES][NativeMem::WINDOW] = {};
 long long NativeMem::_total_window[NativeMem::WINDOW] = {};
 int NativeMem::_window_pos = 0;
 int NativeMem::_window_count = 0;
 long long NativeMem::_avg[NM_NUM_CATEGORIES] = {};
-long long NativeMem::_max[NM_NUM_CATEGORIES] = {};
 long long NativeMem::_total_avg = 0;
-long long NativeMem::_total_max = 0;
+long long NativeMem::_total_max_observed = 0;
 
 long long NativeMem::liveTotal() {
   long long total = 0;
   for (int c = 0; c < NM_NUM_CATEGORIES; c++) {
     total += load(_live[c]);
+  }
+  return total;
+}
+
+long long NativeMem::maxTotal() {
+  long long total = 0;
+  for (int c = 0; c < NM_NUM_CATEGORIES; c++) {
+    total += load(_max[c]);
   }
   return total;
 }
@@ -43,15 +51,14 @@ void NativeMem::sample() {
       v = 0;
     }
     _window[c][_window_pos] = v;
-    if (v > _max[c]) {
-      _max[c] = v;
-    }
     total += v;
   }
 
+  // The per-category peaks are maintained precisely at allocation time by
+  // record(); here we only track the observed total (lower bound on the peak).
   _total_window[_window_pos] = total;
-  if (total > _total_max) {
-    _total_max = total;
+  if (total > _total_max_observed) {
+    _total_max_observed = total;
   }
 
   _window_pos = (_window_pos + 1) % WINDOW;
@@ -77,8 +84,8 @@ void NativeMem::sample() {
 void NativeMem::reset() {
   for (int c = 0; c < NM_NUM_CATEGORIES; c++) {
     store(_live[c], (long long)0);
+    store(_max[c], (long long)0);
     _avg[c] = 0;
-    _max[c] = 0;
     for (int i = 0; i < WINDOW; i++) {
       _window[c][i] = 0;
     }
@@ -89,7 +96,7 @@ void NativeMem::reset() {
   _window_pos = 0;
   _window_count = 0;
   _total_avg = 0;
-  _total_max = 0;
+  _total_max_observed = 0;
 }
 
 const char *NativeMem::categoryName(NativeMemCategory category) {

--- a/ddprof-lib/src/main/cpp/nativeMem.cpp
+++ b/ddprof-lib/src/main/cpp/nativeMem.cpp
@@ -28,7 +28,13 @@ long long NativeMem::_total_max_observed = 0;
 long long NativeMem::liveTotal() {
   long long total = 0;
   for (int c = 0; c < NM_NUM_CATEGORIES; c++) {
-    total += load(_live[c]);
+    // Clamp per-category negatives to 0 (see sample()): the total is exported
+    // as an unsigned varint, so a stray negative would otherwise serialize as a
+    // huge value and corrupt the counter stream.
+    long long v = load(_live[c]);
+    if (v > 0) {
+      total += v;
+    }
   }
   return total;
 }
@@ -57,7 +63,9 @@ void NativeMem::sample() {
   }
 
   // The per-category peaks are maintained precisely at allocation time by
-  // record(); here we only track the observed total (lower bound on the peak).
+  // record(); here we only track the largest observed total. Note `total` is a
+  // non-atomic sum of the per-category gauges read moments apart, so it is an
+  // approximate sampled figure, not a strict instantaneous total.
   _total_window[_window_pos] = total;
   if (total > _total_max_observed) {
     _total_max_observed = total;

--- a/ddprof-lib/src/main/cpp/nativeMem.cpp
+++ b/ddprof-lib/src/main/cpp/nativeMem.cpp
@@ -1,17 +1,6 @@
 /*
- * Copyright 2026 Datadog, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
  */
 #include "nativeMem.h"
 

--- a/ddprof-lib/src/main/cpp/nativeMem.h
+++ b/ddprof-lib/src/main/cpp/nativeMem.h
@@ -46,13 +46,14 @@ typedef enum NativeMemCategory : int {
 
 // Tracks the profiler's live native memory per category, plus a moving-window
 // average and running peak. Live accounting is always-on and independent of the
-// COUNTERS build flag: record() is a single relaxed atomic add.
+// COUNTERS build flag: record() is a relaxed atomic add, plus (for allocations)
+// a conditional lock-free high-water update of the per-category peak.
 //
 // Most call sites are off the signal path (they allocate via malloc/new, which
 // are not async-signal-safe anyway). The exception is the CALLTRACE arena: it
 // allocates from within the sampling signal handler (via OS::safeAlloc's raw
-// mmap syscall), so record() must stay async-signal-safe there -- which a
-// relaxed atomic add is.
+// mmap syscall), so record() must stay async-signal-safe there -- which
+// lock-free relaxed atomics are.
 //
 // The moving average and peak are refreshed by sample(), which is expected to
 // be called from a single thread (the JFR chunk-finish path).

--- a/ddprof-lib/src/main/cpp/nativeMem.h
+++ b/ddprof-lib/src/main/cpp/nativeMem.h
@@ -58,21 +58,35 @@ private:
   static const int WINDOW = 64;
 
   static volatile long long _live[NM_NUM_CATEGORIES];
+  // Precise per-category high-water mark, maintained at allocation time by
+  // record() so peaks that rise and fall between sample() ticks are still seen.
+  static volatile long long _max[NM_NUM_CATEGORIES];
 
-  // sample()-owned state; not touched from allocation sites.
+  // sample()-owned state; touched only from the single-threaded sampling path.
   static long long _window[NM_NUM_CATEGORIES][WINDOW];
   static long long _total_window[WINDOW];
   static int _window_pos;
   static int _window_count;
   static long long _avg[NM_NUM_CATEGORIES];
-  static long long _max[NM_NUM_CATEGORIES];
   static long long _total_avg;
-  static long long _total_max;
+  static long long _total_max_observed;
 
 public:
   // Account for a backing allocation (delta > 0) or free (delta < 0).
   static void record(NativeMemCategory category, long long delta) {
-    atomicIncRelaxed(_live[category], delta);
+    long long prev = atomicIncRelaxed(_live[category], delta);
+    if (delta > 0) {
+      // Only allocations can raise the peak. In the common case (no new peak)
+      // this is a single relaxed load plus a compare; the CAS fires only when a
+      // genuinely higher peak is set, which is rare since _max is monotonic.
+      long long now = prev + delta;
+      long long m = load(_max[category]);
+      while (now > m &&
+             !__atomic_compare_exchange_n(&_max[category], &m, now, false,
+                                          __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+        // On failure m is reloaded with the current value; loop and retry.
+      }
+    }
   }
 
   static long long live(NativeMemCategory category) {
@@ -80,14 +94,19 @@ public:
   }
   static long long liveTotal();
 
-  // Fold the current live gauges into the moving-average window and the running
-  // peak. Call once per sampling tick from a single thread.
+  // Fold the current live gauges into the moving-average window and the observed
+  // total peak. Call once per sampling tick from a single thread.
   static void sample();
 
   static long long avg(NativeMemCategory category) { return _avg[category]; }
-  static long long max(NativeMemCategory category) { return _max[category]; }
+  static long long max(NativeMemCategory category) { return load(_max[category]); }
   static long long avgTotal() { return _total_avg; }
-  static long long maxTotal() { return _total_max; }
+  // Upper bound on the total peak: the sum of the precise per-category peaks.
+  // Exact only if the category peaks coincided; otherwise an overestimate.
+  static long long maxTotal();
+  // Lower bound on the total peak: the largest instantaneous total seen at a
+  // sampling tick. Misses peaks that rise and fall entirely between ticks.
+  static long long maxTotalObserved() { return _total_max_observed; }
 
   // Clear all live gauges and window/peak state. Not thread-safe against
   // concurrent record()/sample(); intended for process init and tests.

--- a/ddprof-lib/src/main/cpp/nativeMem.h
+++ b/ddprof-lib/src/main/cpp/nativeMem.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _NATIVEMEM_H
+#define _NATIVEMEM_H
+
+#include "arch.h"
+
+// Physical native-memory categories used by the profiler's own allocations.
+// Every tracked backing allocation belongs to exactly one category, so the
+// per-category live byte gauges partition the total: sum(category) == total,
+// with no double counting.
+//
+// The "reserved vs used vs wasted" breakdowns exposed by the existing counters
+// (CALLTRACE_STORAGE_BYTES is the used slice of the CALLTRACE arena;
+// DICTIONARY_ARENA_WASTE_BYTES is the wasted slice of the DICTIONARY arena) are
+// a separate, nested dimension. They are intentionally NOT summed in here.
+#define DD_NATIVE_MEM_CATEGORY_TABLE(X)                                        \
+  X(CALLTRACE, "calltrace")                                                    \
+  X(DICTIONARY, "dictionary")                                                  \
+  X(CONTEXT, "context")                                                        \
+  X(THREAD_FILTER, "thread_filter")                                            \
+  X(CODECACHE, "codecache")                                                    \
+  X(LINE_TABLES, "line_tables")                                                \
+  X(PERF, "perf")                                                              \
+  X(THREAD_LOCAL, "thread_local")                                              \
+  X(JFR_BUFFERS, "jfr_buffers")                                                \
+  X(MISC, "misc")
+
+#define X_NM_ENUM(a, b) NM_##a,
+typedef enum NativeMemCategory : int {
+  DD_NATIVE_MEM_CATEGORY_TABLE(X_NM_ENUM) NM_NUM_CATEGORIES
+} NativeMemCategory;
+#undef X_NM_ENUM
+
+// Tracks the profiler's live native memory per category, plus a moving-window
+// average and running peak. Live accounting is always-on and independent of the
+// COUNTERS build flag: record() is a single relaxed atomic add, which is
+// async-signal-safe and therefore usable from signal handlers.
+//
+// The moving average and peak are refreshed by sample(), which is expected to
+// be called from a single thread (the JFR chunk-finish path).
+class NativeMem {
+private:
+  // Number of sample() ticks retained in the moving-average window.
+  static const int WINDOW = 64;
+
+  static volatile long long _live[NM_NUM_CATEGORIES];
+
+  // sample()-owned state; not touched from allocation sites.
+  static long long _window[NM_NUM_CATEGORIES][WINDOW];
+  static long long _total_window[WINDOW];
+  static int _window_pos;
+  static int _window_count;
+  static long long _avg[NM_NUM_CATEGORIES];
+  static long long _max[NM_NUM_CATEGORIES];
+  static long long _total_avg;
+  static long long _total_max;
+
+public:
+  // Account for a backing allocation (delta > 0) or free (delta < 0).
+  static void record(NativeMemCategory category, long long delta) {
+    atomicIncRelaxed(_live[category], delta);
+  }
+
+  static long long live(NativeMemCategory category) {
+    return load(_live[category]);
+  }
+  static long long liveTotal();
+
+  // Fold the current live gauges into the moving-average window and the running
+  // peak. Call once per sampling tick from a single thread.
+  static void sample();
+
+  static long long avg(NativeMemCategory category) { return _avg[category]; }
+  static long long max(NativeMemCategory category) { return _max[category]; }
+  static long long avgTotal() { return _total_avg; }
+  static long long maxTotal() { return _total_max; }
+
+  // Clear all live gauges and window/peak state. Not thread-safe against
+  // concurrent record()/sample(); intended for process init and tests.
+  static void reset();
+
+  static const char *categoryName(NativeMemCategory category);
+};
+
+#endif // _NATIVEMEM_H

--- a/ddprof-lib/src/main/cpp/nativeMem.h
+++ b/ddprof-lib/src/main/cpp/nativeMem.h
@@ -17,6 +17,7 @@
 #define _NATIVEMEM_H
 
 #include "arch.h"
+#include <cassert>
 
 // Physical native-memory categories used by the profiler's own allocations.
 // Every tracked backing allocation belongs to exactly one category, so the
@@ -80,14 +81,20 @@ public:
   // Account for a backing allocation (delta > 0) or free (delta < 0).
   static void record(NativeMemCategory category, long long delta) {
     long long prev = atomicIncRelaxed(_live[category], delta);
+    long long updated = prev + delta;
+    // Invariant: a category's live bytes never go negative — every decrement is
+    // matched by a prior same-sized increment. A negative result means an
+    // unbalanced or oversized free (an accounting bug). Stripped under NDEBUG,
+    // so this costs nothing in release and never runs in a real signal handler
+    // there; it catches pairing bugs in debug/gtest builds instead.
+    assert(updated >= 0);
     if (delta > 0) {
       // Only allocations can raise the peak. In the common case (no new peak)
       // this is a single relaxed load plus a compare; the CAS fires only when a
       // genuinely higher peak is set, which is rare since _max is monotonic.
-      long long now = prev + delta;
       long long m = load(_max[category]);
-      while (now > m &&
-             !__atomic_compare_exchange_n(&_max[category], &m, now, false,
+      while (updated > m &&
+             !__atomic_compare_exchange_n(&_max[category], &m, updated, false,
                                           __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
         // On failure m is reloaded with the current value; loop and retry.
       }

--- a/ddprof-lib/src/main/cpp/nativeMem.h
+++ b/ddprof-lib/src/main/cpp/nativeMem.h
@@ -30,7 +30,6 @@
 #define DD_NATIVE_MEM_CATEGORY_TABLE(X)                                        \
   X(CALLTRACE, "calltrace")                                                    \
   X(DICTIONARY, "dictionary")                                                  \
-  X(CONTEXT, "context")                                                        \
   X(THREAD_FILTER, "thread_filter")                                            \
   X(CODECACHE, "codecache")                                                    \
   X(LINE_TABLES, "line_tables")                                                \

--- a/ddprof-lib/src/main/cpp/nativeMem.h
+++ b/ddprof-lib/src/main/cpp/nativeMem.h
@@ -89,6 +89,18 @@ public:
     }
   }
 
+  // Set a category's live value directly, for gauge-style subsystems whose size
+  // is recomputed as an absolute (rather than tracked via alloc/free deltas).
+  // Also advances the peak. Not for use from a signal handler.
+  static void setLive(NativeMemCategory category, long long value) {
+    store(_live[category], value);
+    long long m = load(_max[category]);
+    while (value > m &&
+           !__atomic_compare_exchange_n(&_max[category], &m, value, false,
+                                        __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+    }
+  }
+
   static long long live(NativeMemCategory category) {
     return load(_live[category]);
   }

--- a/ddprof-lib/src/main/cpp/nativeMem.h
+++ b/ddprof-lib/src/main/cpp/nativeMem.h
@@ -31,7 +31,7 @@
   X(CALLTRACE, "calltrace")                                                    \
   X(DICTIONARY, "dictionary")                                                  \
   X(THREAD_FILTER, "thread_filter")                                            \
-  X(CODECACHE, "codecache")                                                    \
+  X(NATIVE_SYMBOLS, "native_symbols")                                          \
   X(LINE_TABLES, "line_tables")                                                \
   X(PERF, "perf")                                                              \
   X(THREAD_LOCAL, "thread_local")                                              \

--- a/ddprof-lib/src/main/cpp/nativeMem.h
+++ b/ddprof-lib/src/main/cpp/nativeMem.h
@@ -128,8 +128,12 @@ public:
   // Upper bound on the total peak: the sum of the precise per-category peaks.
   // Exact only if the category peaks coincided; otherwise an overestimate.
   static long long maxTotal();
-  // Lower bound on the total peak: the largest instantaneous total seen at a
-  // sampling tick. Misses peaks that rise and fall entirely between ticks.
+  // The largest total seen at a sampling tick, where each tick sums the
+  // per-category live gauges. The sum is not an atomic snapshot, so under
+  // concurrent churn across categories it can drift somewhat above or below any
+  // true instantaneous total — treat it as an approximate sampled figure, not a
+  // strict bound. maxTotal() is the authoritative ceiling; this complements it
+  // as an observed, typically-tighter estimate.
   static long long maxTotalObserved() { return _total_max_observed; }
 
   // Clear all live gauges and window/peak state. Not thread-safe against

--- a/ddprof-lib/src/main/cpp/nativeMem.h
+++ b/ddprof-lib/src/main/cpp/nativeMem.h
@@ -46,8 +46,13 @@ typedef enum NativeMemCategory : int {
 
 // Tracks the profiler's live native memory per category, plus a moving-window
 // average and running peak. Live accounting is always-on and independent of the
-// COUNTERS build flag: record() is a single relaxed atomic add, which is
-// async-signal-safe and therefore usable from signal handlers.
+// COUNTERS build flag: record() is a single relaxed atomic add.
+//
+// Most call sites are off the signal path (they allocate via malloc/new, which
+// are not async-signal-safe anyway). The exception is the CALLTRACE arena: it
+// allocates from within the sampling signal handler (via OS::safeAlloc's raw
+// mmap syscall), so record() must stay async-signal-safe there -- which a
+// relaxed atomic add is.
 //
 // The moving average and peak are refreshed by sample(), which is expected to
 // be called from a single thread (the JFR chunk-finish path).

--- a/ddprof-lib/src/main/cpp/nativeMem.h
+++ b/ddprof-lib/src/main/cpp/nativeMem.h
@@ -1,17 +1,6 @@
 /*
- * Copyright 2026 Datadog, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
  */
 #ifndef _NATIVEMEM_H
 #define _NATIVEMEM_H

--- a/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
+++ b/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
@@ -26,6 +26,7 @@
 #include "jvmThread.h"
 #include "libraries.h"
 #include "log.h"
+#include "nativeMem.h"
 #include "os.h"
 #include "perfEvents.h"
 #include "profiler.h"
@@ -673,6 +674,10 @@ int PerfEvents::registerThread(int tid) {
     }
   }
 
+  if (page != NULL) {
+    NativeMem::record(NM_PERF, (long long)(2 * OS::page_size));
+  }
+
   _events[tid].reset();
   _events[tid]._fd = fd;
   _events[tid]._page = (struct perf_event_mmap_page *)page;
@@ -707,6 +712,7 @@ void PerfEvents::unregisterThread(int tid) {
     munmap(event->_page, 2 * OS::page_size);
     event->_page = NULL;
     event->unlock();
+    NativeMem::record(NM_PERF, -(long long)(2 * OS::page_size));
   }
 }
 

--- a/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
+++ b/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
@@ -888,9 +888,19 @@ Error PerfEvents::start(Arguments &args) {
 
   int max_events = OS::getMaxThreadId();
   if (max_events != _max_events) {
+    // Account the per-thread PerfEvent array under NM_PERF, alongside the ring
+    // mappings. Guard on non-null so a prior calloc failure isn't mis-accounted.
+    if (_events != NULL) {
+      NativeMem::record(NM_PERF,
+                        -(long long)((size_t)_max_events * sizeof(PerfEvent)));
+    }
     free(_events);
     _events = (PerfEvent *)calloc(max_events, sizeof(PerfEvent));
     _max_events = max_events;
+    if (_events != NULL) {
+      NativeMem::record(NM_PERF,
+                        (long long)((size_t)max_events * sizeof(PerfEvent)));
+    }
   }
 
   OS::installSignalHandler(SIGPROF, signalHandler);

--- a/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
+++ b/ddprof-lib/src/main/cpp/perfEvents_linux.cpp
@@ -890,11 +890,14 @@ Error PerfEvents::start(Arguments &args) {
   if (max_events != _max_events) {
     // Account the per-thread PerfEvent array under NM_PERF, alongside the ring
     // mappings. Guard on non-null so a prior calloc failure isn't mis-accounted.
-    if (_events != NULL) {
-      NativeMem::record(NM_PERF,
-                        -(long long)((size_t)_max_events * sizeof(PerfEvent)));
-    }
+    // Record the decrement after the free (consistent with the other decrement
+    // sites); capture the old size first since _max_events is overwritten below.
+    long long old_bytes =
+        (_events != NULL) ? (long long)((size_t)_max_events * sizeof(PerfEvent)) : 0;
     free(_events);
+    if (old_bytes > 0) {
+      NativeMem::record(NM_PERF, -old_bytes);
+    }
     _events = (PerfEvent *)calloc(max_events, sizeof(PerfEvent));
     _max_events = max_events;
     if (_events != NULL) {

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1793,6 +1793,9 @@ Error Profiler::dump(const char *path, const int length) {
     // J9/Zing). Read under its shared lock.
     Counters::set(CODECACHE_RUNTIME_STUBS_SIZE_BYTES,
                   JVMSupport::runtimeStubsMemoryUsage());
+    // CodeCache size is a recomputed gauge (not alloc/free deltas), so mirror it
+    // as an absolute. It shares the accuracy caveats of the counter above.
+    NativeMem::setLive(NM_CODECACHE, native_libs.memoryUsage());
 
     Error err = Error::OK;
     // rotateDictsAndRun rotates the dictionaries, takes lockAll() around the

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1416,26 +1416,35 @@ Error Profiler::start(Arguments &args, bool reset) {
   // (Re-)allocate calltrace buffers
   if (_max_stack_depth != args._jstackdepth) {
     size_t prev_nelem = _max_stack_depth + RESERVED_FRAMES;
-    _max_stack_depth = args._jstackdepth;
-    size_t nelem = _max_stack_depth + RESERVED_FRAMES;
+    size_t nelem = (size_t)args._jstackdepth + RESERVED_FRAMES;
 
+    // Phase 1: allocate all replacements up front. If any allocation fails,
+    // roll back the ones already made and leave the profiler unchanged — old
+    // buffers, _max_stack_depth, and all accounting stay consistent. (The old
+    // code swapped shard-by-shard and reset _max_stack_depth to 0 on failure,
+    // leaving a partially-swapped, mis-accounted state.)
+    CallTraceBuffer *fresh[CONCURRENCY_LEVEL];
     for (int i = 0; i < CONCURRENCY_LEVEL; i++) {
-      // Allocate the replacement before touching the slot so a calloc failure
-      // does not leave the slot pointing at freed memory.
-      CallTraceBuffer *fresh =
-          (CallTraceBuffer*)calloc(nelem, sizeof(CallTraceBuffer));
-      if (fresh == NULL) {
-        _max_stack_depth = 0;
+      fresh[i] = (CallTraceBuffer*)calloc(nelem, sizeof(CallTraceBuffer));
+      if (fresh[i] == NULL) {
+        for (int j = 0; j < i; j++) {
+          free(fresh[j]);
+        }
         return Error("Not enough memory to allocate stack trace buffers (try "
                      "smaller jstackdepth)");
       }
+    }
+
+    // Phase 2: all allocations succeeded — commit. Swap each shard under its
+    // per-shard lock (readers acquire it via tryLock before reading
+    // _calltrace_buffer, so none observes a freed pointer mid-replacement),
+    // then free the old buffer and reconcile accounting.
+    _max_stack_depth = args._jstackdepth;
+    for (int i = 0; i < CONCURRENCY_LEVEL; i++) {
       NativeMem::record(NM_CALLTRACE, (long long)(nelem * sizeof(CallTraceBuffer)));
-      // Swap under the per-shard lock: all readers (recordJVMTISample,
-      // recordExternalSample) acquire this lock via tryLock before reading
-      // _calltrace_buffer, so no reader can observe a freed pointer mid-replacement.
       _locks[i].lock();
       CallTraceBuffer *prev = _calltrace_buffer[i];
-      _calltrace_buffer[i] = fresh;
+      _calltrace_buffer[i] = fresh[i];
       _locks[i].unlock();
       if (prev != NULL) {
         NativeMem::record(NM_CALLTRACE, -(long long)(prev_nelem * sizeof(CallTraceBuffer)));
@@ -1672,6 +1681,9 @@ Error Profiler::stop() {
   Libraries::instance()->refresh();
   updateJavaThreadNames();
   updateNativeThreadNames();
+  // Refresh native-symbol counters so the final chunk (emitted by _jfr.stop()
+  // below) reflects them even when stop() runs without a preceding dump().
+  updateNativeLibMemStats();
 
   // If jvmtistacks delegation was used this recording, surface likely
   // misconfigurations. The JVM returns WRONG_PHASE when JFR is not recording
@@ -1767,6 +1779,22 @@ Error Profiler::check(Arguments &args) {
   return error;
 }
 
+void Profiler::updateNativeLibMemStats() {
+  // CodeCache here is the profiler's native-symbol tables (not the JVM code
+  // cache). memoryUsage() is a recomputed gauge; read it once and publish the
+  // counters plus the NativeMem gauge (NATIVE_SYMBOLS) as absolutes.
+  const CodeCacheArray& native_libs = _libs->native_libs();
+  long long usage = (long long)native_libs.memoryUsage();
+  Counters::set(CODECACHE_NATIVE_COUNT, native_libs.count());
+  Counters::set(CODECACHE_NATIVE_SIZE_BYTES, usage);
+  // The runtime-stubs cache is a distinct HotSpot cache, not the native-symbol
+  // tables. Routed through JVMSupport so the HotSpot-only implementation stays
+  // behind the VM abstraction (0 on J9/Zing).
+  Counters::set(CODECACHE_RUNTIME_STUBS_SIZE_BYTES,
+                JVMSupport::runtimeStubsMemoryUsage());
+  NativeMem::setLive(NM_NATIVE_SYMBOLS, usage);
+}
+
 Error Profiler::dump(const char *path, const int length) {
   MutexLocker ml(_state_lock);
   State cur_state = state();
@@ -1784,18 +1812,7 @@ Error Profiler::dump(const char *path, const int length) {
     updateJavaThreadNames();
     updateNativeThreadNames();
 
-    const CodeCacheArray& native_libs = _libs->native_libs();
-    Counters::set(CODECACHE_NATIVE_COUNT, native_libs.count());
-    Counters::set(CODECACHE_NATIVE_SIZE_BYTES, native_libs.memoryUsage());
-    // The runtime-stubs counter reflects the JIT runtime-stubs code cache, a
-    // separate cache from the native libraries. Routed through JVMSupport so
-    // the HotSpot-only implementation stays behind the VM abstraction (0 on
-    // J9/Zing). Read under its shared lock.
-                  JVMSupport::runtimeStubsMemoryUsage());
-    // CodeCache here is the profiler's native-symbol tables (not the JVM code
-    // cache). Its size is a recomputed gauge (not alloc/free deltas), so mirror
-    // it as an absolute. It shares the accuracy caveats of the counter above.
-    NativeMem::setLive(NM_NATIVE_SYMBOLS, native_libs.memoryUsage());
+    updateNativeLibMemStats();
 
     Error err = Error::OK;
     // rotateDictsAndRun rotates the dictionaries, takes lockAll() around the

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1446,10 +1446,12 @@ Error Profiler::start(Arguments &args, bool reset) {
       CallTraceBuffer *prev = _calltrace_buffer[i];
       _calltrace_buffer[i] = fresh[i];
       _locks[i].unlock();
+      free(prev);
       if (prev != NULL) {
+        // Account the free after it has happened, consistent with the other
+        // decrement sites (FlightRecorder::stop, ~ThreadFilter).
         NativeMem::record(NM_CALLTRACE, -(long long)(prev_nelem * sizeof(CallTraceBuffer)));
       }
-      free(prev);
     }
   }
 

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1791,11 +1791,11 @@ Error Profiler::dump(const char *path, const int length) {
     // separate cache from the native libraries. Routed through JVMSupport so
     // the HotSpot-only implementation stays behind the VM abstraction (0 on
     // J9/Zing). Read under its shared lock.
-    Counters::set(CODECACHE_RUNTIME_STUBS_SIZE_BYTES,
                   JVMSupport::runtimeStubsMemoryUsage());
-    // CodeCache size is a recomputed gauge (not alloc/free deltas), so mirror it
-    // as an absolute. It shares the accuracy caveats of the counter above.
-    NativeMem::setLive(NM_CODECACHE, native_libs.memoryUsage());
+    // CodeCache here is the profiler's native-symbol tables (not the JVM code
+    // cache). Its size is a recomputed gauge (not alloc/free deltas), so mirror
+    // it as an absolute. It shares the accuracy caveats of the counter above.
+    NativeMem::setLive(NM_NATIVE_SYMBOLS, native_libs.memoryUsage());
 
     Error err = Error::OK;
     // rotateDictsAndRun rotates the dictionaries, takes lockAll() around the

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -13,6 +13,7 @@
 #include "guards.h"
 #include "common.h"
 #include "counters.h"
+#include "nativeMem.h"
 #include "ctimer.h"
 #include "signalInflight.h"
 #include "dwarf.h"
@@ -1414,6 +1415,7 @@ Error Profiler::start(Arguments &args, bool reset) {
 
   // (Re-)allocate calltrace buffers
   if (_max_stack_depth != args._jstackdepth) {
+    size_t prev_nelem = _max_stack_depth + RESERVED_FRAMES;
     _max_stack_depth = args._jstackdepth;
     size_t nelem = _max_stack_depth + RESERVED_FRAMES;
 
@@ -1427,6 +1429,7 @@ Error Profiler::start(Arguments &args, bool reset) {
         return Error("Not enough memory to allocate stack trace buffers (try "
                      "smaller jstackdepth)");
       }
+      NativeMem::record(NM_CALLTRACE, (long long)(nelem * sizeof(CallTraceBuffer)));
       // Swap under the per-shard lock: all readers (recordJVMTISample,
       // recordExternalSample) acquire this lock via tryLock before reading
       // _calltrace_buffer, so no reader can observe a freed pointer mid-replacement.
@@ -1434,6 +1437,9 @@ Error Profiler::start(Arguments &args, bool reset) {
       CallTraceBuffer *prev = _calltrace_buffer[i];
       _calltrace_buffer[i] = fresh;
       _locks[i].unlock();
+      if (prev != NULL) {
+        NativeMem::record(NM_CALLTRACE, -(long long)(prev_nelem * sizeof(CallTraceBuffer)));
+      }
       free(prev);
     }
   }

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -165,6 +165,10 @@ private:
   void updateThreadName(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread,
                         bool self = false);
   void updateJavaThreadNames();
+  // Publish the native-symbol (CodeCache) memory counters and NativeMem gauge
+  // from the current library set. Called before each JFR chunk is finalized
+  // (dump and stop) so the emitted counters reflect the latest libraries.
+  void updateNativeLibMemStats();
   void mangle(const char *name, char *buf, size_t size);
 
   Engine *selectCpuEngine(Arguments &args);

--- a/ddprof-lib/src/main/cpp/stringDictionary.h
+++ b/ddprof-lib/src/main/cpp/stringDictionary.h
@@ -8,6 +8,7 @@
 
 #include "counters.h"
 #include "log.h"
+#include "nativeMem.h"
 #include "refCountGuard.h"
 #include "tripleBuffer.h"
 #include "arch.h"
@@ -80,7 +81,14 @@ class StringArena {
     bool                _oom_logged{false};// latched per generation; cleared by reset()
 
     static Chunk* make_chunk() {
-        return static_cast<Chunk*>(calloc(1, sizeof(Chunk)));
+        Chunk* c = static_cast<Chunk*>(calloc(1, sizeof(Chunk)));
+        // Track every backing chunk regardless of _counter_offset (which only
+        // gates the diagnostic DICTIONARY_BYTES counter). Keys are bump-allocated
+        // inside these chunks, so they must not be counted separately.
+        if (c != nullptr) {
+            NativeMem::record(NM_DICTIONARY, (long long)sizeof(Chunk));
+        }
+        return c;
     }
 
     void countChunkAlloc() {
@@ -133,7 +141,12 @@ public:
 
     ~StringArena() {
         Chunk* c = _first;
-        while (c) { Chunk* n = c->next; free(c); c = n; }
+        while (c) {
+            Chunk* n = c->next;
+            NativeMem::record(NM_DICTIONARY, -(long long)sizeof(Chunk));
+            free(c);
+            c = n;
+        }
     }
 
     StringArena(const StringArena&) = delete;
@@ -167,7 +180,13 @@ public:
     void reset() {
         Chunk* c = _first ? _first->next : nullptr;
         int freed = 0;
-        while (c) { Chunk* n = c->next; free(c); c = n; ++freed; }
+        while (c) {
+            Chunk* n = c->next;
+            NativeMem::record(NM_DICTIONARY, -(long long)sizeof(Chunk));
+            free(c);
+            c = n;
+            ++freed;
+        }
         if (_first) {
             _first->next = nullptr;
             __atomic_store_n(&_first->pos, (size_t)0, __ATOMIC_RELAXED);
@@ -229,7 +248,11 @@ private:
         while (!stk.empty()) {
             Frame& f = stk.back();
             if (f.row >= ROWS) {
-                if (f.t != table) { free(f.t); freed++; }
+                if (f.t != table) {
+                    NativeMem::record(NM_DICTIONARY, -(long long)sizeof(SBTable));
+                    free(f.t);
+                    freed++;
+                }
                 stk.pop_back();
                 continue;
             }
@@ -264,11 +287,15 @@ private:
 public:
     StringDictionaryBuffer() {
         _table = static_cast<SBTable*>(calloc(1, sizeof(SBTable)));
+        if (_table != nullptr) {
+            NativeMem::record(NM_DICTIONARY, (long long)sizeof(SBTable));
+        }
     }
 
     ~StringDictionaryBuffer() {
         if (_table != nullptr) {
-            freeOverflowNodes(_table);
+            freeOverflowNodes(_table);  // records its own decrements
+            NativeMem::record(NM_DICTIONARY, -(long long)sizeof(SBTable));
             free(_table);
             _table = nullptr;
         }
@@ -356,9 +383,12 @@ public:
                 if (nt == nullptr) return 0;
                 if (!__sync_bool_compare_and_swap(&row->next, nullptr, nt)) {
                     free(nt);
-                } else if (_counter_offset != 0) {
-                    Counters::increment(DICTIONARY_PAGES, 1, _counter_offset);
-                    Counters::increment(DICTIONARY_BYTES, (long long)sizeof(SBTable), _counter_offset);
+                } else {
+                    NativeMem::record(NM_DICTIONARY, (long long)sizeof(SBTable));
+                    if (_counter_offset != 0) {
+                        Counters::increment(DICTIONARY_PAGES, 1, _counter_offset);
+                        Counters::increment(DICTIONARY_BYTES, (long long)sizeof(SBTable), _counter_offset);
+                    }
                 }
             }
             table = __atomic_load_n(&row->next, __ATOMIC_ACQUIRE);

--- a/ddprof-lib/src/main/cpp/stringDictionary.h
+++ b/ddprof-lib/src/main/cpp/stringDictionary.h
@@ -143,8 +143,8 @@ public:
         Chunk* c = _first;
         while (c) {
             Chunk* n = c->next;
-            NativeMem::record(NM_DICTIONARY, -(long long)sizeof(Chunk));
             free(c);
+            NativeMem::record(NM_DICTIONARY, -(long long)sizeof(Chunk));
             c = n;
         }
     }
@@ -182,8 +182,8 @@ public:
         int freed = 0;
         while (c) {
             Chunk* n = c->next;
-            NativeMem::record(NM_DICTIONARY, -(long long)sizeof(Chunk));
             free(c);
+            NativeMem::record(NM_DICTIONARY, -(long long)sizeof(Chunk));
             c = n;
             ++freed;
         }
@@ -249,8 +249,8 @@ private:
             Frame& f = stk.back();
             if (f.row >= ROWS) {
                 if (f.t != table) {
-                    NativeMem::record(NM_DICTIONARY, -(long long)sizeof(SBTable));
                     free(f.t);
+                    NativeMem::record(NM_DICTIONARY, -(long long)sizeof(SBTable));
                     freed++;
                 }
                 stk.pop_back();
@@ -295,8 +295,8 @@ public:
     ~StringDictionaryBuffer() {
         if (_table != nullptr) {
             freeOverflowNodes(_table);  // records its own decrements
-            NativeMem::record(NM_DICTIONARY, -(long long)sizeof(SBTable));
             free(_table);
+            NativeMem::record(NM_DICTIONARY, -(long long)sizeof(SBTable));
             _table = nullptr;
         }
     }

--- a/ddprof-lib/src/main/cpp/threadFilter.cpp
+++ b/ddprof-lib/src/main/cpp/threadFilter.cpp
@@ -64,16 +64,19 @@ ThreadFilter::~ThreadFilter() {
     }
     // Publish 0 chunks to stop range scans (collect)
     _num_chunks.store(0, std::memory_order_release);
-    // Detach and delete chunks
+    // Detach and delete chunks. Record the decrement after the delete so the
+    // gauge reflects the free only once it has happened.
     for (int i = 0; i < kMaxChunks; ++i) {
         ChunkStorage* chunk = _chunks[i].exchange(nullptr, std::memory_order_acquire);
+        delete chunk;
         if (chunk != nullptr) {
             NativeMem::record(NM_THREAD_FILTER, -(long long)sizeof(ChunkStorage));
         }
-        delete chunk;
     }
-    // The _free_list unique_ptr frees its FreeListNode[] as this destructor
-    // returns; account for it here.
+    // Free the FreeListNode[] explicitly before recording, rather than letting
+    // the unique_ptr free it after this destructor returns, so the decrement
+    // does not lead the actual free.
+    _free_list.reset();
     NativeMem::record(NM_THREAD_FILTER,
                       -(long long)(kFreeListSize * sizeof(FreeListNode)));
 }

--- a/ddprof-lib/src/main/cpp/threadFilter.cpp
+++ b/ddprof-lib/src/main/cpp/threadFilter.cpp
@@ -21,6 +21,7 @@
 
 #include "threadFilter.h"
 #include "arch.h"
+#include "nativeMem.h"
 #include "os.h"
 #include "threadLocalData.h"
 #include <cassert>
@@ -38,6 +39,8 @@ ThreadFilter::ThreadFilter() : _enabled(false) {
         _chunks[i].store(nullptr, std::memory_order_relaxed);
     }
     _free_list = std::make_unique<FreeListNode[]>(kFreeListSize);
+    NativeMem::record(NM_THREAD_FILTER,
+                      (long long)(kFreeListSize * sizeof(FreeListNode)));
 
     // Initialize the first chunk
     initializeChunk(0);
@@ -64,8 +67,15 @@ ThreadFilter::~ThreadFilter() {
     // Detach and delete chunks
     for (int i = 0; i < kMaxChunks; ++i) {
         ChunkStorage* chunk = _chunks[i].exchange(nullptr, std::memory_order_acquire);
+        if (chunk != nullptr) {
+            NativeMem::record(NM_THREAD_FILTER, -(long long)sizeof(ChunkStorage));
+        }
         delete chunk;
     }
+    // The _free_list unique_ptr frees its FreeListNode[] as this destructor
+    // returns; account for it here.
+    NativeMem::record(NM_THREAD_FILTER,
+                      -(long long)(kFreeListSize * sizeof(FreeListNode)));
 }
 
 void ThreadFilter::initializeChunk(int chunk_idx) {
@@ -86,6 +96,7 @@ void ThreadFilter::initializeChunk(int chunk_idx) {
     ChunkStorage* expected = nullptr;
     if (_chunks[chunk_idx].compare_exchange_strong(expected, new_chunk, std::memory_order_release)) {
         // Successfully installed
+        NativeMem::record(NM_THREAD_FILTER, (long long)sizeof(ChunkStorage));
     } else {
         // Another thread beat us to it - clean up our allocation
         delete new_chunk;

--- a/ddprof-lib/src/main/cpp/threadLocalData.cpp
+++ b/ddprof-lib/src/main/cpp/threadLocalData.cpp
@@ -50,9 +50,10 @@ void ProfiledThread::freeValue(void* value) {
   SignalBlocker blocker;
   ProfiledThread* pt = reinterpret_cast<ProfiledThread*>(value);
   // Sole deletion site for a ProfiledThread (invoked by the ThreadLocal
-  // destructor callback), so the THREAD_LOCAL decrement belongs here.
-  NativeMem::record(NM_THREAD_LOCAL, -(long long)sizeof(ProfiledThread));
+  // destructor callback), so the THREAD_LOCAL decrement belongs here. Record
+  // after the delete, consistent with the other decrement sites.
   delete pt;
+  NativeMem::record(NM_THREAD_LOCAL, -(long long)sizeof(ProfiledThread));
 }
 
 void ProfiledThread::release() {

--- a/ddprof-lib/src/main/cpp/threadLocalData.cpp
+++ b/ddprof-lib/src/main/cpp/threadLocalData.cpp
@@ -49,6 +49,9 @@ ProfiledThread* ProfiledThread::initCurrentThreadSignalSafe() {
 void ProfiledThread::freeValue(void* value) {
   SignalBlocker blocker;
   ProfiledThread* pt = reinterpret_cast<ProfiledThread*>(value);
+  // Sole deletion site for a ProfiledThread (invoked by the ThreadLocal
+  // destructor callback), so the THREAD_LOCAL decrement belongs here.
+  NativeMem::record(NM_THREAD_LOCAL, -(long long)sizeof(ProfiledThread));
   delete pt;
 }
 

--- a/ddprof-lib/src/main/cpp/threadLocalData.h
+++ b/ddprof-lib/src/main/cpp/threadLocalData.h
@@ -7,6 +7,7 @@
 #define THREAD_LOCAL_DATA_H
 
 #include "context.h"
+#include "nativeMem.h"
 #include "otel_context.h"
 #include "os.h"
 #include "threadLocal.h"
@@ -117,7 +118,11 @@ private:
 
   virtual ~ProfiledThread() { }
 public:
-  static ProfiledThread *forTid(int tid) { return new ProfiledThread(tid); }
+  static ProfiledThread *forTid(int tid) {
+    ProfiledThread *pt = new ProfiledThread(tid);
+    NativeMem::record(NM_THREAD_LOCAL, (long long)sizeof(ProfiledThread));
+    return pt;
+  }
   static bool isThreadKeyValid() {
     return _current_thread.isKeyValid();
   }

--- a/ddprof-lib/src/main/cpp/threadLocalData.h
+++ b/ddprof-lib/src/main/cpp/threadLocalData.h
@@ -138,8 +138,13 @@ public:
     return pt;
   }
   // Deletes a ProfiledThread returned by clearCurrentThreadTLS().
-  // Needed because the destructor is private.
-  static void deleteForTest(ProfiledThread *pt) { delete pt; }
+  // Needed because the destructor is private. This stands in for the delete
+  // that freeValue() performs in production, so it mirrors freeValue()'s
+  // NM_THREAD_LOCAL decrement to keep the accounting balanced in tests.
+  static void deleteForTest(ProfiledThread *pt) {
+    delete pt;
+    NativeMem::record(NM_THREAD_LOCAL, -(long long)sizeof(ProfiledThread));
+  }
 #endif
   // initCurrentThread() and release() are not async-signal-safe: 
   // must be called outside of a signal handler with signal blocked

--- a/ddprof-lib/src/test/cpp/dictionary_ut.cpp
+++ b/ddprof-lib/src/test/cpp/dictionary_ut.cpp
@@ -16,7 +16,10 @@
 
 #include <gtest/gtest.h>
 #include "dictionary.h"
+#include "nativeMem.h"
 #include <climits>
+#include <cstdio>
+#include <cstring>
 #include <map>
 
 // ── Dictionary ─────────────────────────────────────────────────────────────
@@ -26,6 +29,30 @@ TEST(DictionaryTest, LookupReturnsSameIdForSameKey) {
     unsigned int id1 = d.lookup("hello", 5);
     EXPECT_GT(id1, 0U);
     EXPECT_EQ(id1, d.lookup("hello", 5));
+}
+
+// Native-memory accounting must balance: growth is tracked, clear() returns to
+// the root-table baseline, and destruction releases everything. Exercises the
+// per-key strlen-at-free path and the overflow-table inc/dec pairing.
+TEST(DictionaryTest, NativeMemAccountingBalancesAcrossLifecycle) {
+    long long before = NativeMem::live(NM_DICTIONARY);
+    {
+        Dictionary d(0);
+        long long after_ctor = NativeMem::live(NM_DICTIONARY);
+        EXPECT_GT(after_ctor, before);  // root table counted
+
+        for (int i = 0; i < 5000; i++) {
+            char key[32];
+            snprintf(key, sizeof(key), "symbol_%d", i);
+            d.lookup(key, strlen(key));  // inserts key strings + overflow tables
+        }
+        EXPECT_GT(NativeMem::live(NM_DICTIONARY), after_ctor);  // grew
+
+        d.clear();
+        // Keys + overflow tables freed; root table retained.
+        EXPECT_EQ(after_ctor, NativeMem::live(NM_DICTIONARY));
+    }
+    EXPECT_EQ(before, NativeMem::live(NM_DICTIONARY));  // fully released
 }
 
 TEST(DictionaryTest, LookupReturnsDifferentIdsForDifferentKeys) {

--- a/ddprof-lib/src/test/cpp/dictionary_ut.cpp
+++ b/ddprof-lib/src/test/cpp/dictionary_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, 2026 Datadog, Inc
+ * Copyright 2025, 2026, Datadog, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ddprof-lib/src/test/cpp/dictionary_ut.cpp
+++ b/ddprof-lib/src/test/cpp/dictionary_ut.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Datadog, Inc
+ * Copyright 2025, 2026 Datadog, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ddprof-lib/src/test/cpp/nativeMem_ut.cpp
+++ b/ddprof-lib/src/test/cpp/nativeMem_ut.cpp
@@ -94,12 +94,12 @@ TEST_F(NativeMemTest, NegativeLiveClampedInSample) {
 // setLive() overwrites the live value (gauge semantics) but still advances the
 // peak, which is retained when the gauge shrinks.
 TEST_F(NativeMemTest, SetLiveOverwritesAndAdvancesMax) {
-    NativeMem::setLive(NM_CODECACHE, 4096);
-    EXPECT_EQ(4096, NativeMem::live(NM_CODECACHE));
-    EXPECT_EQ(4096, NativeMem::max(NM_CODECACHE));
-    NativeMem::setLive(NM_CODECACHE, 1024);  // gauge shrinks
-    EXPECT_EQ(1024, NativeMem::live(NM_CODECACHE));
-    EXPECT_EQ(4096, NativeMem::max(NM_CODECACHE));  // peak retained
+    NativeMem::setLive(NM_NATIVE_SYMBOLS, 4096);
+    EXPECT_EQ(4096, NativeMem::live(NM_NATIVE_SYMBOLS));
+    EXPECT_EQ(4096, NativeMem::max(NM_NATIVE_SYMBOLS));
+    NativeMem::setLive(NM_NATIVE_SYMBOLS, 1024);  // gauge shrinks
+    EXPECT_EQ(1024, NativeMem::live(NM_NATIVE_SYMBOLS));
+    EXPECT_EQ(4096, NativeMem::max(NM_NATIVE_SYMBOLS));  // peak retained
 }
 
 // Every category exposes a distinct, non-empty name.

--- a/ddprof-lib/src/test/cpp/nativeMem_ut.cpp
+++ b/ddprof-lib/src/test/cpp/nativeMem_ut.cpp
@@ -59,15 +59,27 @@ TEST_F(NativeMemTest, MovingAverageOverSamples) {
     EXPECT_EQ(200, NativeMem::avg(NM_CALLTRACE));
 }
 
-// The peak is a high-water mark: it retains the largest sampled value even
-// after live memory has been freed back down.
+// The peak is a high-water mark: it retains the largest value even after live
+// memory has been freed back down.
 TEST_F(NativeMemTest, MaxIsHighWaterMark) {
     NativeMem::record(NM_CALLTRACE, 5000);
-    NativeMem::sample();
     NativeMem::record(NM_CALLTRACE, -4900);  // live drops to 100
-    NativeMem::sample();
     EXPECT_EQ(100, NativeMem::live(NM_CALLTRACE));
     EXPECT_EQ(5000, NativeMem::max(NM_CALLTRACE));
+}
+
+// The per-category peak is precise: it is captured at allocation time, so a
+// spike that rises and falls entirely between two sample() ticks is still seen
+// by max(), while the observed total (sampled) misses it. maxTotal() (upper
+// bound = sum of per-category peaks) brackets the true peak from above.
+TEST_F(NativeMemTest, PerCategoryMaxIsPreciseBetweenSamples) {
+    NativeMem::record(NM_CALLTRACE, 9000);
+    NativeMem::record(NM_CALLTRACE, -8000);  // peak of 9000 undone before any sample
+    NativeMem::sample();                     // only ever observes live == 1000
+    EXPECT_EQ(1000, NativeMem::live(NM_CALLTRACE));
+    EXPECT_EQ(9000, NativeMem::max(NM_CALLTRACE));    // precise: caught the spike
+    EXPECT_EQ(1000, NativeMem::maxTotalObserved());   // sampled: missed the spike
+    EXPECT_EQ(9000, NativeMem::maxTotal());           // upper bound
 }
 
 // Transient negative live (an over-counted free at a not-yet-paired site) is

--- a/ddprof-lib/src/test/cpp/nativeMem_ut.cpp
+++ b/ddprof-lib/src/test/cpp/nativeMem_ut.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <cstring>
+#include "nativeMem.h"
+
+class NativeMemTest : public ::testing::Test {
+protected:
+    void SetUp() override { NativeMem::reset(); }
+    void TearDown() override { NativeMem::reset(); }
+};
+
+// record() adds to and subtracts from the per-category live gauge, and the
+// total is the sum across categories.
+TEST_F(NativeMemTest, RecordTracksLivePerCategoryAndTotal) {
+    NativeMem::record(NM_CALLTRACE, 1000);
+    NativeMem::record(NM_DICTIONARY, 250);
+    EXPECT_EQ(1000, NativeMem::live(NM_CALLTRACE));
+    EXPECT_EQ(250, NativeMem::live(NM_DICTIONARY));
+    EXPECT_EQ(0, NativeMem::live(NM_CONTEXT));
+    EXPECT_EQ(1250, NativeMem::liveTotal());
+
+    NativeMem::record(NM_CALLTRACE, -400);
+    EXPECT_EQ(600, NativeMem::live(NM_CALLTRACE));
+    EXPECT_EQ(850, NativeMem::liveTotal());
+}
+
+// sample() folds the current live gauge into the moving average; a single
+// sample yields avg == live and max == live.
+TEST_F(NativeMemTest, SingleSampleAverageEqualsLive) {
+    NativeMem::record(NM_CALLTRACE, 800);
+    NativeMem::sample();
+    EXPECT_EQ(800, NativeMem::avg(NM_CALLTRACE));
+    EXPECT_EQ(800, NativeMem::max(NM_CALLTRACE));
+    EXPECT_EQ(800, NativeMem::avgTotal());
+    EXPECT_EQ(800, NativeMem::maxTotal());
+}
+
+// The moving average is the mean over the sampled ticks.
+TEST_F(NativeMemTest, MovingAverageOverSamples) {
+    NativeMem::record(NM_CALLTRACE, 100);
+    NativeMem::sample();               // window: [100]
+    NativeMem::record(NM_CALLTRACE, 200);  // live now 300
+    NativeMem::sample();               // window: [100, 300] -> avg 200
+    EXPECT_EQ(200, NativeMem::avg(NM_CALLTRACE));
+}
+
+// The peak is a high-water mark: it retains the largest sampled value even
+// after live memory has been freed back down.
+TEST_F(NativeMemTest, MaxIsHighWaterMark) {
+    NativeMem::record(NM_CALLTRACE, 5000);
+    NativeMem::sample();
+    NativeMem::record(NM_CALLTRACE, -4900);  // live drops to 100
+    NativeMem::sample();
+    EXPECT_EQ(100, NativeMem::live(NM_CALLTRACE));
+    EXPECT_EQ(5000, NativeMem::max(NM_CALLTRACE));
+}
+
+// Transient negative live (an over-counted free at a not-yet-paired site) is
+// clamped to zero when sampled so it does not skew the average or total.
+TEST_F(NativeMemTest, NegativeLiveClampedInSample) {
+    NativeMem::record(NM_MISC, -1234);
+    NativeMem::sample();
+    EXPECT_EQ(0, NativeMem::avg(NM_MISC));
+    EXPECT_EQ(0, NativeMem::maxTotal());
+}
+
+// Every category exposes a distinct, non-empty name.
+TEST_F(NativeMemTest, CategoryNamesPresent) {
+    for (int c = 0; c < NM_NUM_CATEGORIES; c++) {
+        const char *name = NativeMem::categoryName((NativeMemCategory)c);
+        ASSERT_NE(nullptr, name);
+        EXPECT_GT((int)strlen(name), 0);
+    }
+}

--- a/ddprof-lib/src/test/cpp/nativeMem_ut.cpp
+++ b/ddprof-lib/src/test/cpp/nativeMem_ut.cpp
@@ -31,7 +31,7 @@ TEST_F(NativeMemTest, RecordTracksLivePerCategoryAndTotal) {
     NativeMem::record(NM_DICTIONARY, 250);
     EXPECT_EQ(1000, NativeMem::live(NM_CALLTRACE));
     EXPECT_EQ(250, NativeMem::live(NM_DICTIONARY));
-    EXPECT_EQ(0, NativeMem::live(NM_CONTEXT));
+    EXPECT_EQ(0, NativeMem::live(NM_THREAD_FILTER));
     EXPECT_EQ(1250, NativeMem::liveTotal());
 
     NativeMem::record(NM_CALLTRACE, -400);

--- a/ddprof-lib/src/test/cpp/nativeMem_ut.cpp
+++ b/ddprof-lib/src/test/cpp/nativeMem_ut.cpp
@@ -82,15 +82,6 @@ TEST_F(NativeMemTest, PerCategoryMaxIsPreciseBetweenSamples) {
     EXPECT_EQ(9000, NativeMem::maxTotal());           // upper bound
 }
 
-// Transient negative live (an over-counted free at a not-yet-paired site) is
-// clamped to zero when sampled so it does not skew the average or total.
-TEST_F(NativeMemTest, NegativeLiveClampedInSample) {
-    NativeMem::record(NM_MISC, -1234);
-    NativeMem::sample();
-    EXPECT_EQ(0, NativeMem::avg(NM_MISC));
-    EXPECT_EQ(0, NativeMem::maxTotal());
-}
-
 // setLive() overwrites the live value (gauge semantics) but still advances the
 // peak, which is retained when the gauge shrinks.
 TEST_F(NativeMemTest, SetLiveOverwritesAndAdvancesMax) {

--- a/ddprof-lib/src/test/cpp/nativeMem_ut.cpp
+++ b/ddprof-lib/src/test/cpp/nativeMem_ut.cpp
@@ -1,17 +1,6 @@
 /*
- * Copyright 2026 Datadog, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <gtest/gtest.h>

--- a/ddprof-lib/src/test/cpp/nativeMem_ut.cpp
+++ b/ddprof-lib/src/test/cpp/nativeMem_ut.cpp
@@ -91,6 +91,17 @@ TEST_F(NativeMemTest, NegativeLiveClampedInSample) {
     EXPECT_EQ(0, NativeMem::maxTotal());
 }
 
+// setLive() overwrites the live value (gauge semantics) but still advances the
+// peak, which is retained when the gauge shrinks.
+TEST_F(NativeMemTest, SetLiveOverwritesAndAdvancesMax) {
+    NativeMem::setLive(NM_CODECACHE, 4096);
+    EXPECT_EQ(4096, NativeMem::live(NM_CODECACHE));
+    EXPECT_EQ(4096, NativeMem::max(NM_CODECACHE));
+    NativeMem::setLive(NM_CODECACHE, 1024);  // gauge shrinks
+    EXPECT_EQ(1024, NativeMem::live(NM_CODECACHE));
+    EXPECT_EQ(4096, NativeMem::max(NM_CODECACHE));  // peak retained
+}
+
 // Every category exposes a distinct, non-empty name.
 TEST_F(NativeMemTest, CategoryNamesPresent) {
     for (int c = 0; c < NM_NUM_CATEGORIES; c++) {

--- a/ddprof-lib/src/test/cpp/stringDictionary_ut.cpp
+++ b/ddprof-lib/src/test/cpp/stringDictionary_ut.cpp
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <gtest/gtest.h>
 #include "stringDictionary.h"
 #include "nativeMem.h"

--- a/ddprof-lib/src/test/cpp/stringDictionary_ut.cpp
+++ b/ddprof-lib/src/test/cpp/stringDictionary_ut.cpp
@@ -1,12 +1,41 @@
 #include <gtest/gtest.h>
 #include "stringDictionary.h"
+#include "nativeMem.h"
 #include <atomic>
+#include <cstdio>
+#include <cstring>
 #include <map>
 #include <string>
 #include <thread>
 #include <vector>
 
 // ── StringDictionaryBuffer ─────────────────────────────────────────────────
+
+// Native-memory accounting must balance across the arena lifecycle: the root
+// SBTable and initial chunk are counted at construction, growth adds overflow
+// SBTables and arena chunks, clear() returns to the construction baseline, and
+// destruction releases everything. 50k keys force at least one extra 512 KiB
+// arena chunk so chunk alloc/free pairing is exercised too.
+TEST(StringDictionaryBufferTest, NativeMemAccountingBalancesAcrossLifecycle) {
+    long long before = NativeMem::live(NM_DICTIONARY);
+    {
+        StringDictionaryBuffer buf;
+        long long after_ctor = NativeMem::live(NM_DICTIONARY);
+        EXPECT_GT(after_ctor, before);  // root SBTable + initial arena chunk
+
+        for (int i = 0; i < 50000; i++) {
+            char key[32];
+            int len = snprintf(key, sizeof(key), "string_key_%d", i);
+            buf.insert_with_id(key, (size_t)len, (u32)(i + 1));
+        }
+        EXPECT_GT(NativeMem::live(NM_DICTIONARY), after_ctor);  // grew
+
+        buf.clear();
+        // Overflow SBTables + extra arena chunks freed; root + first chunk kept.
+        EXPECT_EQ(after_ctor, NativeMem::live(NM_DICTIONARY));
+    }
+    EXPECT_EQ(before, NativeMem::live(NM_DICTIONARY));  // fully released
+}
 
 TEST(StringDictionaryBufferTest, InsertWithIdReturnsSameIdForSameKey) {
     StringDictionaryBuffer buf;

--- a/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/thread_teardown_safety_ut.cpp
@@ -19,6 +19,7 @@
 #ifdef __linux__
 
 #include "guards.h"
+#include "nativeMem.h"
 #include "threadLocalData.h"
 
 #include <atomic>
@@ -464,6 +465,47 @@ TEST(ThreadTeardownSafetyTest, CriticalSectionReentrancyGuard) {
   pthread_t t;
   ASSERT_EQ(0, pthread_create(&t, nullptr, t10_body, nullptr));
   pthread_join(t, nullptr);
+}
+
+// ── NM_THREAD_LOCAL accounting balances across the ProfiledThread lifecycle ──
+// forTid() (in initCurrentThread) increments NM_THREAD_LOCAL; the matching
+// decrement lives in freeValue(), which is invoked both by release() (via
+// ThreadLocal::clear()) and by the pthread-key destructor on thread exit.
+// These verify both teardown paths return the gauge to its baseline.
+
+static std::atomic<long long> g_tl_live_during{0};
+
+static void *tl_release_body(void *) {
+  ProfiledThread::initCurrentThread();
+  g_tl_live_during.store(NativeMem::live(NM_THREAD_LOCAL),
+                         std::memory_order_relaxed);
+  ProfiledThread::release();
+  return nullptr;
+}
+
+TEST(ThreadTeardownSafetyTest, NativeMemThreadLocalBalancesOnRelease) {
+  long long base = NativeMem::live(NM_THREAD_LOCAL);
+  pthread_t t;
+  ASSERT_EQ(0, pthread_create(&t, nullptr, tl_release_body, nullptr));
+  pthread_join(t, nullptr);
+  EXPECT_GT(g_tl_live_during.load(std::memory_order_relaxed), base)
+      << "forTid() must account the ProfiledThread allocation";
+  EXPECT_EQ(base, NativeMem::live(NM_THREAD_LOCAL))
+      << "release() -> clear() -> freeValue() must balance the accounting";
+}
+
+static void *tl_exit_body(void *) {
+  ProfiledThread::initCurrentThread();
+  return nullptr;  // no explicit release: thread exit runs freeValue()
+}
+
+TEST(ThreadTeardownSafetyTest, NativeMemThreadLocalReleasedOnThreadExit) {
+  long long base = NativeMem::live(NM_THREAD_LOCAL);
+  pthread_t t;
+  ASSERT_EQ(0, pthread_create(&t, nullptr, tl_exit_body, nullptr));
+  pthread_join(t, nullptr);
+  EXPECT_EQ(base, NativeMem::live(NM_THREAD_LOCAL))
+      << "pthread-key destructor (freeValue) must balance the accounting";
 }
 
 #endif // __linux__

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/nativemem/NativeMemAccountingTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/nativemem/NativeMemAccountingTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.datadoghq.profiler.nativemem;
+
+import com.datadoghq.profiler.AbstractProfilerTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Smoke test for the always-on categorized native-memory accounting facility
+ * ({@code NativeMem}).
+ *
+ * <p>It does not exercise any particular allocation path; it verifies that the
+ * aggregate counters the facility publishes into every recording
+ * ({@code native_mem_live_bytes}, {@code native_mem_avg_bytes},
+ * {@code native_mem_max_bytes}) are present after a short profiling run and hold
+ * their sanity invariants. The peak total is an upper bound (sum of the precise
+ * per-category peaks), so it must be {@code >=} both the current live total and
+ * the moving-window average total.
+ */
+public class NativeMemAccountingTest extends AbstractProfilerTest {
+
+    @Override
+    protected String getProfilerCommand() {
+        return "wall=~1ms";
+    }
+
+    @Test
+    public void shouldPublishSaneNativeMemCounters() throws Exception {
+        // Keep the sampler busy briefly so the profiler's native buffers
+        // (calltrace storage, dictionaries, per-thread data, ...) are populated
+        // while the recording captures the counters.
+        long deadline = System.nanoTime() + 100_000_000L; // ~100ms
+        double sink = 0;
+        while (System.nanoTime() < deadline) {
+            for (int i = 0; i < 10_000; i++) {
+                sink += Math.sqrt(i);
+            }
+        }
+        // Guard against dead-code elimination of the busy loop.
+        assertTrue(!Double.isNaN(sink));
+
+        stopProfiler();
+
+        // getRecordedCounterValue returns -1 when the named counter was never
+        // emitted, so the presence checks below double as "is emitted" assertions.
+        long live = getRecordedCounterValue("native_mem_live_bytes");
+        long avg = getRecordedCounterValue("native_mem_avg_bytes");
+        long max = getRecordedCounterValue("native_mem_max_bytes");
+
+        // The agent always holds some native memory while running (at minimum the
+        // calltrace buffers), so the peak total is present and non-zero.
+        assertTrue(max > 0, "native_mem_max_bytes present and non-zero, was " + max);
+        assertTrue(live >= 0, "native_mem_live_bytes present, was " + live);
+        assertTrue(avg >= 0, "native_mem_avg_bytes present, was " + avg);
+
+        // The peak is a bracketing upper bound on the total.
+        assertTrue(max >= live, "max (" + max + ") >= live (" + live + ")");
+        assertTrue(max >= avg, "max (" + max + ") >= avg (" + avg + ")");
+    }
+}


### PR DESCRIPTION
## What

Adds a `NativeMem` facility to measure the **profiler's own native memory usage** — currently we only observe whole-process RSS. Per-category live gauge, moving-window **average**, and a **precise per-category peak**, wired through the existing counter/JFR path.

## Why

We measure the agent's native footprint only as an RSS delta (~150–200 MB) with no breakdown. This gives an in-process, attributable, categorized number we can trend, and a foundation for later pinpointing which code is responsible.

## How

- **`NativeMem`** (`nativeMem.h` / `nativeMem.cpp`): a `NativeMemCategory` enum whose per-category live gauges **partition the total** — each backing allocation belongs to exactly one category, so no double-counting.
- **Always-on**, independent of the `COUNTERS` build flag: `record()` is a single relaxed atomic add. Most sites are off the signal path (malloc/new is not async-signal-safe anyway); the exception is **CALLTRACE**, whose arena allocates inside the sampling signal handler (via `OS::safeAlloc`), so `record()` is kept async-signal-safe there.
- **Precise per-category peak**: `record()` maintains each category's high-water mark at allocation time via a relaxed CAS (common path is load+compare; CAS only on a new peak; frees skip it). Spikes between sample ticks are still captured.
- **`sample()`** refreshes the moving-window averages and the observed total, ticked once per JFR chunk finish.
- **Exposure**: totals mirror into `NATIVE_MEM_{LIVE,AVG,MAX}_BYTES` (JFR `T_DATADOG_COUNTER` + JNI debug counters); per-category `native_mem_{live,avg,max}_bytes.<category>` values reuse the same event format — no new event type.

## Total peak: bracketed, no shared hotspot

A *precise* total peak would need a single global atomic hit by every allocation (a contention hotspot). Instead the total peak is bracketed:
- `NATIVE_MEM_MAX_BYTES` = **upper bound** = sum of the precise per-category peaks.
- `native_mem_max_observed_total_bytes` = **lower bound** = the largest instantaneous total seen at a sampling tick.

## Instrumented categories

Tagged via `record()` at their backing alloc/free sites (precise, always-on):
- **CALLTRACE** — `LinearAllocator` chunks (call-trace arena) + per-shard calltrace buffers.
- **DICTIONARY** — both implementations: the older per-key-malloc `Dictionary` (symbols/packages — root/overflow `DictTable`s + key strings, whose size is recovered via `strlen` at bulk-free), and the arena `StringDictionary` (arena chunks + root/overflow `SBTable`s; keys live inside chunks so they're not counted separately). Counted unconditionally, independent of the diagnostic counters' offset gate. Single category — a per-role split, if ever wanted, belongs in a nested dimension.
- **THREAD_LOCAL** — `ProfiledThread` per thread.
- **JFR_BUFFERS** — the `Recording` object (embeds the JFR buffer array).
- **LINE_TABLES** — malloc'd JVMTI line-number table copies.
- **PERF** — perf ring `mmap` (2 × page_size).
- **THREAD_FILTER** — `ChunkStorage` chunks (bounded) + free-list array.

Gauge-mirrored (`NativeMem::setLive()` at a recompute site):
- **NATIVE_SYMBOLS** — the profiler's per-native-library symbol tables used to symbolicate native frames (async-profiler's `CodeCache`; not the JVM code cache). Sourced from `CodeCache::memoryUsage()`, which is now accurate on `main` (#677 merged); the gauge is refreshed at dump/stop, the same cadence as the existing `CODECACHE_NATIVE_SIZE_BYTES` counter.

**Not yet covered (reads 0):**
- **The long tail** — scattered `new`/`malloc` across the remaining files → best captured by malloc interception, not hand-tagging.

(`CONTEXT` was removed: the OTel context record is embedded in `ProfiledThread`, already counted under `THREAD_LOCAL`; a separate category would double-count or read a permanent 0.)

So the total is still a **subset** of the RSS delta until interception lands, but now covers the major consumers.

## Avoiding double-counting

Call-trace bytes appear at three layers (`safeAlloc` mmap, `LINEAR_ALLOCATOR_BYTES` reserved chunks, `CALLTRACE_STORAGE_BYTES` used-within-chunks); summing counters would double/triple-count. `NativeMem` counts **backing memory once per category**; the existing reserved/used/waste counters remain an independent **nested** diagnostic dimension. The dictionary tagging follows the same rule — e.g. arena keys are inside chunks and are not counted separately.

## Performance

Designed to be off the hot path. Measured in operations, not observed as a regression in this workload:

- **Per sample (signal handler): zero in the common case.** A sample's `CallTraceStorage::put` normally just bump-allocates within an existing arena chunk and touches no `record()`. `record()` runs only when the call-trace arena grows a new chunk (8 MiB apart), and there it's a lock-free relaxed atomic add + high-water update — async-signal-safe.
- **Per backing allocation: ~1–2 relaxed atomic ops.** `record()` is one relaxed `fetch_add`; on allocation it also does a relaxed load + compare, with a CAS only when a new per-category peak is set (rare, since the peak is monotonic). This sits next to a `malloc`/`calloc`/`mmap`/`new` that dominates the cost, so it's negligible. These sites (dictionary inserts, chunk/table growth, thread/lib/recording creation) are not per-sample.
- **Per JFR chunk finish: a fixed, tiny cost.** `sample()` is O(categories × window) ≈ 9 × 64 folds; `writeNativeMem()` emits ~28 counter events. This runs once per chunk rotation (seconds–minutes), off the sampling path.
- **One extra pass at dictionary `clear()`:** the per-key free now also does a `strlen` to recover the freed size, so `clear()` cost is O(sum of key lengths) rather than O(key count). `clear()` already walks every key; this is a marginal constant-factor increase, at dictionary rotation only.

No new locks, no shared global counter on the hot path (the total peak is bracketed precisely to avoid one), and the always-on atomics are relaxed. `sample()`/`writeNativeMem()` run within the existing recording flush.

## Roadmap

1. **This PR** — facility + precise per-category max (bracketed total) + the major consumers, including DICTIONARY.
2. **Malloc interception** — capture the untagged long tail so categories sum toward the RSS delta, plus a reconciliation check to quantify what's still unattributed.

## Testing

- `nativeMem_ut` (7 tests): live tracking + total partition, single-sample avg==live, moving average, max high-water, precise per-category max catching an inter-sample spike (with the bracket), `setLive` gauge + peak retention, category names. (The non-negative invariant is enforced by an assert in `record()` rather than a dedicated clamp test.)
- **Lifecycle invariants** for both dictionary implementations (`dictionary_ut`, `stringDictionary_ut`): accounting grows on insert, returns exactly to the construction baseline after `clear()`, and to zero after destruction — directly proving inc/dec pairing (incl. the strlen-at-free path and arena chunk growth).
- **THREAD_LOCAL lifecycle** (`thread_teardown_safety_ut`, Linux): `NM_THREAD_LOCAL` returns to baseline after both `release()` and thread-exit teardown, proving the `forTid`/`freeValue` pairing.
- Full `:ddprof-lib:gtestDebug` suite green (**358 cross-platform tests, 0 failures** locally; Linux-only perf/thread-teardown coverage runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)





