### PR TITLE
Fix native OOM from unbounded CallTraceHashTable expansion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,5 +60,12 @@ updates:
       - "dependencies"
       - "no-release-notes"
       - "no-review"
+    groups:
+      # init and analyze must stay on the same codeql-action release, or
+      # analyze fails with "Loaded a configuration file for version X, but
+      # running version Y". Group them so dependabot bumps both together.
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
     cooldown:
       default-days: 2

--- a/.github/workflows/codecheck.yml
+++ b/.github/workflows/codecheck.yml
@@ -76,7 +76,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.

--- a/ddprof-lib/src/main/cpp/callTraceHashTable.cpp
+++ b/ddprof-lib/src/main/cpp/callTraceHashTable.cpp
@@ -46,13 +46,13 @@ private:
   volatile u32 _size;
   u32 _padding2[15];
 
+public:
   static size_t getSize(u32 capacity) {
     size_t size = sizeof(LongHashTable) +
                   (sizeof(u64) + sizeof(CallTraceSample)) * capacity;
     return (size + OS::page_mask) & ~OS::page_mask;
   }
 
-public:
   LongHashTable(LongHashTable *prev = nullptr, u32 capacity = 0,
                 u32 slot_base = 0, bool should_clean = true)
     : _prev(prev), _padding0(nullptr), _capacity(capacity),
@@ -319,6 +319,19 @@ void CallTraceHashTable::expandTableIfNeeded(LongHashTable* table, u32 size) {
     u64 prospective_base = (u64)table->slotBase() + capacity;
     u64 prospective_capacity = nextGenerationCapacity(capacity);
 
+    if (LongHashTable::getSize((u32)prospective_capacity) > _allocator.maxAllocatableSize()) {
+      // The doubled table would not fit in a single LinearAllocator chunk.
+      // alloc() bump-allocates within one chunk and cannot satisfy a request
+      // larger than a chunk - it would loop allocating fresh chunks until mmap
+      // fails (native OOM / vm.max_map_count exhaustion). Stop expanding here;
+      // put() keeps working on the current table at a higher load factor. This
+      // degraded state is bounded, not permanent: the next processTraces()
+      // rotation resets the table to its initial capacity, so normal JFR-flush
+      // cadence recovers it. Deriving the bound from the chunk size keeps it
+      // correct if the chunk size ever changes.
+      Counters::increment(CALLTRACE_STORAGE_EXPANSION_SKIPPED);
+      return;
+    }
     // Allocate new table with double capacity using LinearAllocator
     LongHashTable* new_table = LongHashTable::allocate(
         table, (u32)prospective_capacity, (u32)prospective_base, &_allocator);

--- a/ddprof-lib/src/main/cpp/callTraceHashTable.cpp
+++ b/ddprof-lib/src/main/cpp/callTraceHashTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, Datadog, Inc.
+ * Copyright 2026, Datadog, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/ddprof-lib/src/main/cpp/linearAllocator.h
+++ b/ddprof-lib/src/main/cpp/linearAllocator.h
@@ -73,6 +73,12 @@ public:
   static void freeChunks(ChunkList& chunks);
 
   void *alloc(size_t size);
+
+  // Largest single allocation this allocator can ever satisfy: one chunk minus
+  // its header. alloc() bump-allocates within a single chunk, so a request
+  // larger than this can never be placed - callers must not request more (see
+  // CallTraceHashTable::expandTableIfNeeded()).
+  size_t maxAllocatableSize() const { return _chunk_size - sizeof(Chunk); }
 };
 
 #endif // _LINEARALLOCATOR_H

--- a/ddprof-lib/src/main/cpp/livenessTracker.cpp
+++ b/ddprof-lib/src/main/cpp/livenessTracker.cpp
@@ -307,6 +307,27 @@ static void free_uniform_real_distribution(void* p) {
   delete urd;
 }
 
+// File-scope (not track()-local) so releaseThreadLocalState() below can reach
+// them from Profiler::onThreadEnd(). Relying solely on these ThreadLocal's own
+// pthread-key destructors is not sufficient: pthread key destructors only fire
+// when the underlying OS thread actually exits, not when a JNI-attached thread
+// detaches via DetachCurrentThread. A reused pooled OS thread that repeatedly
+// attaches/detaches would otherwise leak one mt19937 and one
+// uniform_real_distribution allocation per attach cycle, since get() lazily
+// re-creates the value on the next track() call but nothing ever frees the
+// previous one until OS thread exit (which may never happen). Hooking explicit
+// cleanup into onThreadEnd matches how every other per-thread profiler state
+// (CPU/wall engine registration, ProfiledThread) is already torn down.
+static ThreadLocal<std::mt19937*, create_mt19937, free_mt19937> gen;
+static ThreadLocal<std::uniform_real_distribution<>*, create_uniform_real_distribution, free_uniform_real_distribution> dis;
+static ThreadLocal<double> skipped;
+
+void LivenessTracker::releaseThreadLocalState() {
+  gen.clear();
+  dis.clear();
+  skipped.clear();
+}
+
 void LivenessTracker::track(JNIEnv *env, AllocEvent &event, jint tid,
                             jobject object, u64 call_trace_id) {
   if (!_enabled) {
@@ -317,10 +338,6 @@ void LivenessTracker::track(JNIEnv *env, AllocEvent &event, jint tid,
     // we are not to store any objects
     return;
   }
-
-  static ThreadLocal<std::mt19937*, create_mt19937, free_mt19937> gen;
-  static ThreadLocal<std::uniform_real_distribution<>*, create_uniform_real_distribution, free_uniform_real_distribution> dis;
-  static ThreadLocal<double> skipped;
 
   if (_subsample_ratio < 1.0) {
     std::mt19937* genp = gen.get();

--- a/ddprof-lib/src/main/cpp/livenessTracker.h
+++ b/ddprof-lib/src/main/cpp/livenessTracker.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, 2025, Datadog, Inc.
+ * Copyright 2021, 2026, Datadog, Inc.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/ddprof-lib/src/main/cpp/livenessTracker.h
+++ b/ddprof-lib/src/main/cpp/livenessTracker.h
@@ -94,6 +94,13 @@ public:
   void track(JNIEnv *env, AllocEvent &event, jint tid, jobject object, u64 call_trace_id);
   void flush(std::set<int> &tracked_thread_ids);
 
+  // Frees this thread's subsampling RNG state (track()'s gen/dis/skipped
+  // ThreadLocals, livenessTracker.cpp). Must be called from a thread that is
+  // about to detach/terminate - see those ThreadLocal's own comment for why
+  // their pthread-key destructors alone cannot be relied on for JNI-attached
+  // threads. Safe to call even if this thread never called track().
+  static void releaseThreadLocalState();
+
   static void JNICALL GarbageCollectionFinish(jvmtiEnv *jvmti_env);
 
 private:

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -119,6 +119,7 @@ void Profiler::onThreadEnd(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread) {
       SignalBlocker blocker;
       _cpu_engine->unregisterThread(tid);
       _wall_engine->unregisterThread(tid);
+      LivenessTracker::instance()->releaseThreadLocalState();
       ProfiledThread::release();
     }
     return;
@@ -134,6 +135,7 @@ void Profiler::onThreadEnd(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread) {
   updateThreadName(jvmti, jni, thread, false);
   _cpu_engine->unregisterThread(tid);
   _wall_engine->unregisterThread(tid);
+  LivenessTracker::instance()->releaseThreadLocalState();
 }
 
 int Profiler::registerThread(int tid) {


### PR DESCRIPTION
## Problem

Under live-heap profiling (`memory=...:l`) with a long-running, unrotated recording, the profiler can exhaust native address space and crash with `os::commit_memory ... failed; error='Not enough space' (errno=12)` / `pthread_create failed (EAGAIN)`. The failure is **`vm.max_map_count` (VMA) exhaustion**, not RAM: a captured memory map showed tens of thousands of 8 MB (and 8 MB-multiple) anonymous regions.

## Root cause

`CallTraceHashTable` grows its backing `LongHashTable` by doubling capacity, allocating each generation from a `LinearAllocator` whose chunks are a fixed 8 MB (`CALL_TRACE_CHUNK`). Once a table's byte size exceeds one chunk (capacity ≥ ~512K entries), `LinearAllocator::alloc()` can never place it: the bump-allocator's inner loop only fits `offs + size <= _chunk_size`, so an oversized request falls through to `getNextChunk()`, which allocates a fresh 8 MB chunk that *also* can't fit it — looping and allocating chunks until `mmap` fails.

The active table only grows this large between `processTraces()` rotations (which reset it to the initial capacity). In a single start-to-end JFR recording no rotation happens, so under the high distinct-trace volume that live-heap sampling sustains, the table crosses the one-chunk threshold and the allocator runs away.

## Fix

`expandTableIfNeeded()` now refuses to expand when the next generation's `getSize()` would exceed `LinearAllocator::maxAllocatableSize()` (one chunk minus its header). Instead of an unbounded allocation loop, `put()` keeps working on the current table at a higher load factor; the next rotation resets it. The bound is derived from the chunk size, so it stays correct if `CALL_TRACE_CHUNK` changes. A new `calltrace_storage_expansion_skipped` counter records when the cap engages.

This also includes a related per-thread native leak fix in `LivenessTracker`: its subsampling RNG `ThreadLocal`s (`gen`/`dis`/`skipped`) were reclaimed only via pthread-key destructors, which never fire when a JNI-attached thread detaches on a reused OS thread. They are now released explicitly from `Profiler::onThreadEnd()`, matching how the CPU/wall engines and `ProfiledThread` are already torn down.

## Validation

Reproducer (`renaissance akka-uct -r 20` under `memory=64:l`) OOM'd at ~90 s / 13 iterations before the fix. With the fix it completes all 20 iterations with peak VMA count in the hundreds (was pinned at the 65530 limit). Compiles clean; verified the change is compatible with the existing `expandTableIfNeeded`/overflow-guard unit tests by inspection (the new check sits alongside the existing guards and only engages for tables that exceed one chunk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)