### PR TITLE
[fault-injection] Unprotected access to JVM class loader data mutex and method list

### DIFF
--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
@@ -1264,11 +1264,10 @@ static void patchClassLoaderData(JNIEnv* jni, jclass klass) {
       int method_count = vmklass->methodCount();
       if (method_count > 0) {
         VMClassLoaderData *cld = vmklass->classLoaderData();
-        cld->lock();
+        VMClassLoaderDataMutexLocker locker(cld->mutex());
         for (int i = 0; i < method_count; i += MethodList::SIZE) {
-          *cld->methodList() = new MethodList(*cld->methodList());
+          *cld->methodList() = new MethodList(cld->methodList());
         }
-        cld->unlock();
       }
     }
   }

--- a/ddprof-lib/src/main/cpp/hotspot/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/vmStructs.cpp
@@ -1165,3 +1165,15 @@ HeapUsage HeapUsage::get(bool allow_jmx) {
     }
     return usage;
 }
+
+VMClassLoaderDataMutexLocker::VMClassLoaderDataMutexLocker(void* mutex) : _mutex(mutex) {
+    if (_mutex != nullptr) {
+        _lock_func(_mutex);
+    }
+}
+
+VMClassLoaderDataMutexLocker::~VMClassLoaderDataMutexLocker() {
+    if (_mutex != nullptr) {
+        _unlock_func(_mutex);
+    }
+}

--- a/ddprof-lib/src/main/cpp/hotspot/vmStructs.h
+++ b/ddprof-lib/src/main/cpp/hotspot/vmStructs.h
@@ -449,18 +449,11 @@ class VMStructs {
     static void checkNativeBinding(jvmtiEnv *jvmti, JNIEnv *jni, jmethodID method, void *address);
     static const void *findHeapUsageFunc();
 
-    const char* at(int offset) {
-        const char* ptr = (const char*)this + offset;
-        assert(crashProtectionActive() || SafeAccess::isReadable(ptr));
-        // Poison only the returned pointer; the assert above sees the real ptr.
-        return INJECT_FAULT_ADDRESS_RARE(ptr);
-    }
+    const char* at(int offset);
+    const char* at(int offset) const;
 
-    const char* at(int offset) const {
-        const char* ptr = (const char*)this + offset;
-        assert(crashProtectionActive() || SafeAccess::isReadable(ptr));
-        return INJECT_FAULT_ADDRESS_RARE(ptr);
-    }
+    template <typename T, bool safe = false>
+    T load_at_offset(int offset) const;
 
     static bool goodPtr(const void* ptr) {
         return (uintptr_t)ptr >= 0x1000 && ((uintptr_t)ptr & (sizeof(uintptr_t) - 1)) == 0;
@@ -635,24 +628,20 @@ DECLARE(VMSymbol)
     static int bodyOffset()   { return _symbol_body_offset; }
 DECLARE_END
 
-DECLARE(VMClassLoaderData)
+class VMClassLoaderDataMutexLocker : protected VMStructs {
   private:
-    void* mutex() {
-        return *(void**) at(sizeof(uintptr_t) * 3);
-    }
-
+    void* _mutex;
   public:
-    void lock() {
-        _lock_func(mutex());
-    }
+    VMClassLoaderDataMutexLocker(void* mutex);
+    ~VMClassLoaderDataMutexLocker();
+};
 
-    void unlock() {
-        _unlock_func(mutex());
-    }
-
-    MethodList** methodList() {
-        return (MethodList**) at(sizeof(uintptr_t) * 6 + 8);
-    }
+// VMClassLoaderData is used outside of protected (longjmp) context,
+// so both methods are protected by SafeAccess
+DECLARE(VMClassLoaderData)
+  public:
+    inline void* mutex();
+    inline MethodList* methodList();
 DECLARE_END
 
 DECLARE(VMKlass)    

--- a/ddprof-lib/src/main/cpp/hotspot/vmStructs.inline.h
+++ b/ddprof-lib/src/main/cpp/hotspot/vmStructs.inline.h
@@ -28,6 +28,29 @@ inline T* cast_to(const void* ptr) {
     return reinterpret_cast<T*>(const_cast<void*>(ptr));
 }
 
+inline const char* VMStructs::at(int offset) {
+    const char* ptr = (const char*)this + offset;
+    assert(crashProtectionActive() || SafeAccess::isReadable(ptr));
+    // Poison only the returned pointer; the assert above sees the real ptr.
+    return INJECT_FAULT_ADDRESS_RARE(ptr);
+}
+
+inline const char* VMStructs::at(int offset) const {
+    const char* ptr = (const char*)this + offset;
+    assert(crashProtectionActive() || SafeAccess::isReadable(ptr));
+    return INJECT_FAULT_ADDRESS_RARE(ptr);
+}
+
+template <typename T, bool safe>
+T VMStructs::load_at_offset(int offset) const {
+    const char* ptr = at(offset);
+    if (safe) {
+        return (T)SafeAccess::loadPtr((void**)ptr, nullptr);
+    } else {
+        return  *((T*)ptr);
+    }
+}
+
 VMThread* VMThread::current() {
     assert(VM::isHotspot());
     return VMThread::cast(JVMThread::current());
@@ -186,6 +209,15 @@ u16 VMConstMethod::nameIndex() const {
 u16 VMConstMethod::signatureIndex() const {
     assert(_constmethod_sig_index_offset >= 0 && "Invalid signature index");
     return *(u16*)at(_constmethod_sig_index_offset);
+}
+
+// ClassLoaderData accesses are unprotected
+void* VMClassLoaderData::mutex() {
+    return load_at_offset<void*, true /*safe*/>(sizeof(uintptr_t) * 3);
+}
+
+MethodList* VMClassLoaderData::methodList() {
+    return load_at_offset<MethodList*, true /*safe*/>(sizeof(uintptr_t) * 6 + 8);
 }
 
 


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->

**Motivation**:
<!-- What inspired you to submit this pull request? -->

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [ ] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
