### PR TITLE
chore: address release script

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -20,8 +20,13 @@ check_not_stuck() {
   local base=$1
   local branch=$2
 
-  [ -n "$DRYRUN" ] && return
-  git rev-parse "v_${base}" >/dev/null 2>&1 || return
+  if [ -n "$DRYRUN" ]; then
+    return 0
+  fi
+
+  if ! git show-ref --verify --quiet "refs/tags/v_${base}"; then
+    return 0
+  fi
 
   echo "::error::${branch} is stuck at version ${base}, which is already tagged (v_${base})."
   echo "::error::The automated post-release version-bump PR for this branch was never merged."


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->

fixes `check_not_stuck` so that a missing release tag is treated as the expected state for a new release.

The check now uses `git show-ref --verify --quiet` with the complete tag reference and returns success explicitly when the tag does not exist or the release is a dry run.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

With `set -e`, the previous `git rev-parse ... || return` propagated exit code 128 when the target tag did not exist. This aborted valid releases before tag creation.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

Existing tags still trigger the intended “branch is stuck” failure. Using the complete `refs/tags/...` reference also ensures that only the exact tag is checked.

An end-to-end release dry run can only be executed after merging because minor-release workflows require remote `main`.

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

- `bash -n .github/scripts/release.sh`
- `git diff --check origin/main...HEAD`
- Verified `check_not_stuck` behavior:
  - Missing tag returns 0.
  - Existing tag returns 1 with the expected diagnostic.
  - Dry-run returns 0.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [ ] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
