### PR TITLE
chore: update token for version bump auto-merge

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -162,19 +162,17 @@ if [ -z "$DRYRUN" ]; then
   BUMP_BRANCH="automated/bump-${CANDIDATE//./-}"
   git checkout -b "$BUMP_BRANCH"
   git push --force-with-lease --set-upstream origin "$BUMP_BRANCH"
-  # Create, label and merge with the federated BUMP_PR_TOKEN (not the ambient
-  # GITHUB_TOKEN): GitHub does not fire new workflow runs for events caused by
-  # the default GITHUB_TOKEN, so a GITHUB_TOKEN-applied label would never
-  # trigger approve-trivial.yml's `labeled` trigger and the PR would never
-  # auto-merge. Labeling is a separate call from creation so it produces its
-  # own `labeled` event rather than being folded into the `opened` payload.
+  # Create and label with the federated BUMP_PR_TOKEN: GitHub does not fire new
+  # workflow runs for labeled events caused by the default GITHUB_TOKEN, so the
+  # no-review label would never trigger approve-trivial.yml. Enable auto-merge
+  # with the write-enabled GITHUB_TOKEN after emitting the labeled event.
   BUMP_PR_URL=$(GH_TOKEN="$BUMP_PR_TOKEN" gh pr create \
     --title "[Automated] Bump dev version to ${CANDIDATE}" \
     --body "Automated version bump after releasing v_${BASE}." \
     --base "$BRANCH" \
     --head "$BUMP_BRANCH")
   GH_TOKEN="$BUMP_PR_TOKEN" gh pr edit "$BUMP_PR_URL" --add-label "no-review"
-  GH_TOKEN="$BUMP_PR_TOKEN" gh pr merge "$BUMP_PR_URL" --auto --squash
+  GH_TOKEN="$GITHUB_TOKEN" gh pr merge "$BUMP_PR_URL" --auto --squash
   echo "BUMP_PR_URL=$BUMP_PR_URL" >> "${GITHUB_OUTPUT:-/dev/null}"
   echo "✓ Version bump PR created and queued for auto-merge: $BUMP_PR_URL"
 else


### PR DESCRIPTION
**What does this PR do?**:
<!-- A brief description of the change being made with this pull request. -->

Uses the workflow-scoped `GITHUB_TOKEN` when enabling auto-merge on the automated version-bump PR.

The federated `BUMP_PR_TOKEN` remains responsible for creating the PR and applying the `no-review` label, ensuring that the label event triggers the auto-approval workflow.

**Motivation**:
<!-- What inspired you to submit this pull request? -->

The release workflow failed while enabling auto-merge with:

```
  GraphQL: Resource not accessible by integration (enablePullRequestAutoMerge)
```
The federated token can create and label the bump PR but cannot invoke the `enablePullRequestAutoMerge` mutation. The workflow's `GITHUB_TOKEN` has the required repository permissions.

Using `GITHUB_TOKEN` only for the merge command preserves the existing label-trigger behavior while allowing auto-merge to be enabled.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->

- `bash -n .github/scripts/release.sh`
- `git diff --check`
- Verify during the next release that:
  - the version-bump PR is created;
  - the no-review label triggers the auto-approval workflow;
  - auto-merge is enabled without an enablePullRequestAutoMerge authorization error.

The complete path cannot be exercised by the release dry-run because dry-run skips bump-PR creation and auto-merge.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [ ] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
