### PR TITLE
Missing libgcc_s.so.1 on the host should not result in crash

### DIFF
--- a/ddprof-lib/src/main/cpp/faultInjection.h
+++ b/ddprof-lib/src/main/cpp/faultInjection.h
@@ -28,6 +28,12 @@
 //   pc = SafeAccess::load(INJECT_FAULT_ADDRESS_LIKELY((void**)fp));
 //   VMMethod* m = ((VMMethod**)INJECT_FAULT_ADDRESS_UNLIKELY(fp))[off];
 //
+// INJECT_FAULT_BOOL_* wraps the *result* of a call that already ran for
+// real, forcing it to report `false` so a caller's failure-handling path
+// (not its memory-safety recovery path) gets exercised, e.g.:
+//
+//   return INJECT_FAULT_BOOL_LIKELY(dlopen(name, flags) != nullptr);
+//
 // The three tiers name their firing frequency: RARE 0.01%, UNLIKELY 0.1%,
 // LIKELY 1%.  See faultInjection.cpp for the poison-address and PRNG details.
 
@@ -76,6 +82,19 @@ inline T injectAddress(T ptr, u64 threshold, const char* fn) {
   }
   return ptr;
 }
+
+// Returns orig unchanged, or `faulty` when the tier fires. Unlike
+// injectAddress() (which fakes an input about to be dereferenced), this fakes
+// the *outcome* of a call that already ran for real — e.g. making a
+// successful dlopen() appear to have failed, to exercise a caller's error
+// path without needing the library to actually be absent.
+template <typename T>
+inline T injectValue(T orig, T faulty, u64 threshold, const char* fn) {
+  if (__builtin_expect(shouldFire(threshold, fn), 0)) {
+    return faulty;
+  }
+  return orig;
+}
 }  // namespace faultinj
 
 #define INJECT_FAULT_ADDRESS_RARE(ptr) \
@@ -84,6 +103,13 @@ inline T injectAddress(T ptr, u64 threshold, const char* fn) {
     ::faultinj::injectAddress((ptr), ::faultinj::PROB_UNLIKELY, __func__)
 #define INJECT_FAULT_ADDRESS_LIKELY(ptr) \
     ::faultinj::injectAddress((ptr), ::faultinj::PROB_LIKELY, __func__)
+
+#define INJECT_FAULT_BOOL_RARE(v) \
+    ::faultinj::injectValue((v), false, ::faultinj::PROB_RARE, __func__)
+#define INJECT_FAULT_BOOL_UNLIKELY(v) \
+    ::faultinj::injectValue((v), false, ::faultinj::PROB_UNLIKELY, __func__)
+#define INJECT_FAULT_BOOL_LIKELY(v) \
+    ::faultinj::injectValue((v), false, ::faultinj::PROB_LIKELY, __func__)
 
 #else  // __FAULT_INJECTION__ not defined — strict identity, zero cost.
 
@@ -98,6 +124,10 @@ inline T injectAddress(T ptr, u64 threshold, const char* fn) {
 #define INJECT_FAULT_LONG_RARE(v)     (v)
 #define INJECT_FAULT_LONG_UNLIKELY(v) (v)
 #define INJECT_FAULT_LONG_LIKELY(v)   (v)
+
+#define INJECT_FAULT_BOOL_RARE(v)     (v)
+#define INJECT_FAULT_BOOL_UNLIKELY(v) (v)
+#define INJECT_FAULT_BOOL_LIKELY(v)   (v)
 
 #endif  // __FAULT_INJECTION__
 

--- a/ddprof-lib/src/main/cpp/jvmThread.h
+++ b/ddprof-lib/src/main/cpp/jvmThread.h
@@ -15,6 +15,8 @@
  * JVMThread represents a native JVM thread that is JVM implementation agnostic
  */
 class JVMThread {
+  friend class JVMThreadTestAccessor;
+
 private:
     static jfieldID _tid;
     static ThreadLocal<JVMThread*> _jvm_thread;

--- a/ddprof-lib/src/main/cpp/jvmThread.h
+++ b/ddprof-lib/src/main/cpp/jvmThread.h
@@ -15,8 +15,6 @@
  * JVMThread represents a native JVM thread that is JVM implementation agnostic
  */
 class JVMThread {
-  friend class JVMThreadTestAccessor;
-
 private:
     static jfieldID _tid;
     static ThreadLocal<JVMThread*> _jvm_thread;

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1293,12 +1293,6 @@ void Profiler::check_JDK_8313796_workaround() {
 }
 
 Error Profiler::checkState() {
-  // Force libgcc_s to load now (idempotent dlopen) so the JVM's DWARF
-  // unwinder cannot lazy-load it later from signal context.
-  if (!prewarmUnwinder()) {
-    return Error("Missing libgcc_s.so");
-  }
-
   State s = state();
   if (s == ERROR) {
     return Error("Profiler encountered fatal error");
@@ -1309,6 +1303,13 @@ Error Profiler::checkState() {
     if (!JVMSupport::initialize()) {
       _state.store(ERROR, std::memory_order_release);
       return Error("Profiler encountered fatal error");
+    }
+
+    // Force libgcc_s to load now (idempotent dlopen) so the JVM's DWARF
+    // unwinder cannot lazy-load it later from signal context.
+    if (!prewarmUnwinder()) {
+      _state.store(ERROR, std::memory_order_release);
+      return Error("Missing libgcc_s.so");
     }
   } else if (s > IDLE) {
     return Error("Profiler already started");

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -843,7 +843,7 @@ void Profiler::writeHeapUsage(long value, bool live) {
   _locks[lock_index].unlock();
 }
 
-void Profiler::prewarmUnwinder() {
+bool Profiler::prewarmUnwinder() {
 #ifdef __linux__
   // J9 on aarch64 (and other JVMs) lazily loads libgcc_s.so.1 from its DWARF
   // unwinder during stack walks. When that happens inside a signal handler
@@ -864,7 +864,9 @@ void Profiler::prewarmUnwinder() {
   // dlopen by SONAME is the only mechanism that works under static-libgcc.
   // libgcc_s.so.1 has been the stable SONAME since 2002; a bump would
   // constitute a glibc/GCC C++ ABI break and is treated as a fixed contract.
-  (void)dlopen("libgcc_s.so.1", RTLD_LAZY | RTLD_GLOBAL);
+  return dlopen("libgcc_s.so.1", RTLD_LAZY | RTLD_GLOBAL) != nullptr;
+#else
+  return true;
 #endif
 }
 
@@ -1306,6 +1308,12 @@ Error Profiler::checkState() {
 
 Error Profiler::init() {
   MutexLocker ml(_state_lock);
+  // Force libgcc_s to load now (idempotent dlopen) so the JVM's DWARF
+  // unwinder cannot lazy-load it later from signal context.
+  if (!prewarmUnwinder()) {
+    return Error("Missing libgcc_s.so");
+  }
+
   State s = state();
   if (s == ERROR) {
     return Error("Profiler encountered fatal error");
@@ -1335,10 +1343,6 @@ Error Profiler::start(Arguments &args, bool reset) {
   if (error) {
     return error;
   }
-
-  // Force libgcc_s to load now (idempotent dlopen) so the JVM's DWARF
-  // unwinder cannot lazy-load it later from signal context.
-  prewarmUnwinder();
 
   error = checkJvmCapabilities();
   if (error) {

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -864,7 +864,11 @@ bool Profiler::prewarmUnwinder() {
   // dlopen by SONAME is the only mechanism that works under static-libgcc.
   // libgcc_s.so.1 has been the stable SONAME since 2002; a bump would
   // constitute a glibc/GCC C++ ABI break and is treated as a fixed contract.
-  return dlopen("libgcc_s.so.1", RTLD_LAZY | RTLD_GLOBAL) != nullptr;
+  //
+  // INJECT_FAULT_BOOL_LIKELY lets fault-injection builds force this to
+  // report failure without the library actually being absent, so
+  // checkState()'s "Missing libgcc_s.so" path can be exercised in CI.
+  return INJECT_FAULT_BOOL_LIKELY(dlopen("libgcc_s.so.1", RTLD_LAZY | RTLD_GLOBAL) != nullptr);
 #else
   return true;
 #endif
@@ -1289,6 +1293,12 @@ void Profiler::check_JDK_8313796_workaround() {
 }
 
 Error Profiler::checkState() {
+  // Force libgcc_s to load now (idempotent dlopen) so the JVM's DWARF
+  // unwinder cannot lazy-load it later from signal context.
+  if (!prewarmUnwinder()) {
+    return Error("Missing libgcc_s.so");
+  }
+
   State s = state();
   if (s == ERROR) {
     return Error("Profiler encountered fatal error");
@@ -1308,11 +1318,6 @@ Error Profiler::checkState() {
 
 Error Profiler::init() {
   MutexLocker ml(_state_lock);
-  // Force libgcc_s to load now (idempotent dlopen) so the JVM's DWARF
-  // unwinder cannot lazy-load it later from signal context.
-  if (!prewarmUnwinder()) {
-    return Error("Missing libgcc_s.so");
-  }
 
   State s = state();
   if (s == ERROR) {

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1297,19 +1297,19 @@ Error Profiler::checkState() {
   if (s == ERROR) {
     return Error("Profiler encountered fatal error");
   } else if (s == NEW) {
+    // Force libgcc_s to load now (idempotent dlopen) so the JVM's DWARF
+    // unwinder cannot lazy-load it later from signal context.
+    if (!prewarmUnwinder()) {
+      _state.store(ERROR, std::memory_order_release);
+      return Error("Missing libgcc_s.so");
+    }
+
     // Make sure JVMSupport is initialized
     // In theory, it should be initialized in JVMTI::VMInit() callback,
     // but the callback arrives too late, after this method is called.
     if (!JVMSupport::initialize()) {
       _state.store(ERROR, std::memory_order_release);
       return Error("Profiler encountered fatal error");
-    }
-
-    // Force libgcc_s to load now (idempotent dlopen) so the JVM's DWARF
-    // unwinder cannot lazy-load it later from signal context.
-    if (!prewarmUnwinder()) {
-      _state.store(ERROR, std::memory_order_release);
-      return Error("Missing libgcc_s.so");
     }
   } else if (s > IDLE) {
     return Error("Profiler already started");

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1301,7 +1301,7 @@ Error Profiler::checkState() {
     // unwinder cannot lazy-load it later from signal context.
     if (!prewarmUnwinder()) {
       _state.store(ERROR, std::memory_order_release);
-      return Error("Missing libgcc_s.so");
+      return Error("Missing libgcc_s.so.1");
     }
 
     // Make sure JVMSupport is initialized

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -152,7 +152,7 @@ private:
   void **_dlopen_entry;
   static void *dlopen_hook(const char *filename, int flags);
   void switchLibraryTrap(bool enable);
-  static void prewarmUnwinder();
+  static bool prewarmUnwinder();
 
   void disableEngines();
 

--- a/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
@@ -189,6 +189,9 @@ public:
   static void setState(Profiler* p, State s) {
     p->_state.store(s, std::memory_order_release);
   }
+  static State getState(Profiler* p) {
+    return p->_state.load(std::memory_order_acquire);
+  }
 };
 
 // (d) Value-injection path: PROF-15395 fixed Profiler::checkState() (shared by

--- a/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
@@ -15,6 +15,7 @@
 #include "os.h"
 #include "profiler.h"
 #include "threadLocalData.h"
+#include "jvmThread.h"
 #include "hotspot/hotspotSupport.h"
 #include "../../main/cpp/gtest_crash_handler.h"
 
@@ -194,8 +195,8 @@ TEST_F(FaultInjectionTest, WalkVmSigsetjmpRecoversFromInjectedFault) {
 }
 
 // Friend of Profiler (see profiler.h) — lets this test force the internal
-// state to IDLE so checkState() can be exercised deterministically without a
-// live JVM (matches the pattern in jvmSupport_ut.cpp).
+// state to a known value so checkState() can be exercised deterministically
+// (matches the pattern in jvmSupport_ut.cpp).
 class ProfilerTestAccessor {
 public:
   static void setState(Profiler* p, State s) {
@@ -203,6 +204,30 @@ public:
   }
   static State getState(Profiler* p) {
     return p->_state.load(std::memory_order_acquire);
+  }
+};
+
+// Friend of JVMThread — lets this test satisfy JVMSupport::initialize()'s
+// JVMThread::isInitialized() check without a live JVM attached, so
+// checkState()'s NEW branch falls through to prewarmUnwinder() instead of
+// latching ERROR on the JVMSupport::initialize() gate first. This binary has
+// no JVMTI/JNI environment to drive JVMThread::initialize() for real, so we
+// fake what a live JVM would have already set up: a discoverable pthread key
+// holding a per-thread marker, exactly what ThreadLocal<JVMThread*>::initialize
+// scans for.
+class JVMThreadTestAccessor {
+public:
+  static void forceInitialized() {
+    static jfieldID dummy_tid = reinterpret_cast<jfieldID>(0x1);  // never dereferenced here
+    JVMThread::_tid = dummy_tid;
+    if (JVMThread::_jvm_thread.isKeyValid()) {
+      return;
+    }
+    static void* marker = &marker;
+    pthread_key_t key;
+    ASSERT_EQ(pthread_key_create(&key, nullptr), 0);
+    ASSERT_EQ(pthread_setspecific(key, marker), 0);
+    ASSERT_TRUE(JVMThread::_jvm_thread.initialize(marker));
   }
 };
 
@@ -216,7 +241,11 @@ public:
 TEST_F(FaultInjectionTest, CheckStateSurfacesInjectedPrewarmUnwinderFailure) {
 #ifdef __linux__
   Profiler* p = Profiler::instance();
-  ProfilerTestAccessor::setState(p, IDLE);
+  // checkState() only calls prewarmUnwinder() from the NEW state, after
+  // JVMSupport::initialize() succeeds -- IDLE falls through checkState()
+  // untouched and never reaches prewarmUnwinder() at all.
+  JVMThreadTestAccessor::forceInitialized();
+  ProfilerTestAccessor::setState(p, NEW);
   ProfiledThread::current()->setFiRng(0x5EED5EED5EED5EEDULL);
 
   bool sawInjectedFailure = false;

--- a/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
@@ -48,6 +48,18 @@ TEST(FaultInjectionTest, DisabledValueMacrosAreIdentity) {
   EXPECT_EQ(INJECT_FAULT_LONG_RARE(l), l);
   EXPECT_EQ(INJECT_FAULT_LONG_UNLIKELY(l), l);
   EXPECT_EQ(INJECT_FAULT_LONG_LIKELY(l), l);
+
+  // BOOL must be identity both ways -- an accidental non-identity expansion
+  // (e.g. always forcing false) would otherwise only show up as a silent
+  // behavioural change in a production build, never a compile error.
+  bool t = true;
+  bool f = false;
+  EXPECT_EQ(INJECT_FAULT_BOOL_RARE(t), t);
+  EXPECT_EQ(INJECT_FAULT_BOOL_UNLIKELY(t), t);
+  EXPECT_EQ(INJECT_FAULT_BOOL_LIKELY(t), t);
+  EXPECT_EQ(INJECT_FAULT_BOOL_RARE(f), f);
+  EXPECT_EQ(INJECT_FAULT_BOOL_UNLIKELY(f), f);
+  EXPECT_EQ(INJECT_FAULT_BOOL_LIKELY(f), f);
 }
 
 #else  // __FAULT_INJECTION__ enabled (built under -PenableFaultInjection)

--- a/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
@@ -218,8 +218,8 @@ public:
 class JVMThreadTestAccessor {
 public:
   static void forceInitialized() {
-    static jfieldID dummy_tid = reinterpret_cast<jfieldID>(0x1);  // never dereferenced here
-    JVMThread::_tid = dummy_tid;
+  static char dummy_tid_storage;
+  JVMThread::_tid = reinterpret_cast<jfieldID>(&dummy_tid_storage);
     if (JVMThread::_jvm_thread.isKeyValid()) {
       return;
     }

--- a/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
@@ -250,11 +250,17 @@ TEST_F(FaultInjectionTest, CheckStateSurfacesInjectedPrewarmUnwinderFailure) {
 
   bool sawInjectedFailure = false;
   bool sawClean = false;
-  for (int i = 0; i < 5000 && !sawInjectedFailure; i++) {
+  // shouldFire() mixes the fixed RNG seed above with an ASLR-dependent
+  // per-call-site address, so which outcome the *first* call produces is not
+  // deterministic run to run -- the injected failure can land before a clean
+  // call is observed. Keep iterating (and un-latching the ERROR state that a
+  // failure leaves behind) until both outcomes have been seen at least once.
+  for (int i = 0; i < 5000 && !(sawInjectedFailure && sawClean); i++) {
     Error error = p->checkState();
     if (error) {
       EXPECT_STREQ("Missing libgcc_s.so", error.message());
       sawInjectedFailure = true;
+      ProfilerTestAccessor::setState(p, NEW);
     } else {
       sawClean = true;
     }

--- a/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
@@ -218,8 +218,10 @@ public:
 class JVMThreadTestAccessor {
 public:
   static void forceInitialized() {
-  static char dummy_tid_storage;
-  JVMThread::_tid = reinterpret_cast<jfieldID>(&dummy_tid_storage);
+    static char dummy_tid_storage;
+    if (JVMThread::_tid == nullptr) {
+      JVMThread::_tid = reinterpret_cast<jfieldID>(&dummy_tid_storage);
+    }
     if (JVMThread::_jvm_thread.isKeyValid()) {
       return;
     }

--- a/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
@@ -10,12 +10,14 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include <cstring>
+
 #include "faultInjection.h"
 #include "safeAccess.h"
 #include "os.h"
 #include "profiler.h"
 #include "threadLocalData.h"
-#include "jvmThread.h"
+#include "vmEntry.h"
 #include "hotspot/hotspotSupport.h"
 #include "../../main/cpp/gtest_crash_handler.h"
 
@@ -207,42 +209,39 @@ public:
   }
 };
 
-// Friend of JVMThread — lets this test satisfy JVMSupport::initialize()'s
-// JVMThread::isInitialized() check without a live JVM attached, so
-// checkState()'s NEW branch falls through to prewarmUnwinder() instead of
-// latching ERROR on the JVMSupport::initialize() gate first. This binary has
-// no JVMTI/JNI environment to drive JVMThread::initialize() for real, so we
-// fake what a live JVM would have already set up: a discoverable pthread key
-// holding a per-thread marker, exactly what ThreadLocal<JVMThread*>::initialize
-// scans for.
-class JVMThreadTestAccessor {
+// Friend of VM (see vmEntry.h) — lets this test install a mock jvmtiEnv, the
+// same seam jvmSupport_ut.cpp uses. checkState() (below) checks
+// prewarmUnwinder() before JVMSupport::initialize(), so the injected-failure
+// path never touches this at all; it exists only so the ~99% non-injected
+// iterations, which do fall through into JVMSupport::initialize(), fail
+// gracefully instead of crashing on a null VM::_jvmti in this no-live-JVM
+// binary. Unlike a JVMThread-level fake (which would permanently flip
+// JVMThread::isInitialized() for the rest of the process, since ThreadLocal
+// pthread keys are never invalidated), this is a plain pointer swap that
+// ScopedJvmtiMock restores on scope exit -- no state leaks into later tests.
+class VMTestAccessor {
 public:
-  static void forceInitialized() {
-  static char dummy_tid_storage;
-  JVMThread::_tid = reinterpret_cast<jfieldID>(&dummy_tid_storage);
-    if (JVMThread::_jvm_thread.isKeyValid()) {
-      return;
-    }
+  static jvmtiEnv* getJvmti() { return VM::_jvmti; }
+  static void setJvmti(jvmtiEnv* env) { VM::_jvmti = env; }
+};
 
-    static int marker_storage;
-    void* marker = &marker_storage;
+static jvmtiError JNICALL mock_GetCurrentThread_fails(jvmtiEnv*, jthread*) {
+  return JVMTI_ERROR_INTERNAL;
+}
 
-    pthread_key_t key;
-    int rc = pthread_key_create(&key, nullptr);
-    if (rc != 0) {
-      ADD_FAILURE() << "pthread_key_create failed: " << rc;
-      return;
-    }
-    rc = pthread_setspecific(key, marker);
-    if (rc != 0) {
-      ADD_FAILURE() << "pthread_setspecific failed: " << rc;
-      return;
-    }
-    if (!JVMThread::_jvm_thread.initialize(marker)) {
-      ADD_FAILURE() << "ThreadLocal<JVMThread*>::initialize failed";
-      return;
-    }
+class ScopedJvmtiMock {
+public:
+  ScopedJvmtiMock() : _orig(VMTestAccessor::getJvmti()) {
+    _tbl.GetCurrentThread = &mock_GetCurrentThread_fails;
+    _env.functions = &_tbl;
+    VMTestAccessor::setJvmti(&_env);
   }
+  ~ScopedJvmtiMock() { VMTestAccessor::setJvmti(_orig); }
+
+private:
+  jvmtiInterface_1_ _tbl{};
+  _jvmtiEnv _env{};
+  jvmtiEnv* _orig;
 };
 
 // (d) Value-injection path: PROF-15395 fixed Profiler::checkState() (shared by
@@ -255,36 +254,40 @@ public:
 TEST_F(FaultInjectionTest, CheckStateSurfacesInjectedPrewarmUnwinderFailure) {
 #ifdef __linux__
   Profiler* p = Profiler::instance();
-  // checkState() only calls prewarmUnwinder() from the NEW state, after
-  // JVMSupport::initialize() succeeds -- IDLE falls through checkState()
-  // untouched and never reaches prewarmUnwinder() at all.
-  JVMThreadTestAccessor::forceInitialized();
+  // checkState() checks prewarmUnwinder() before JVMSupport::initialize(), so
+  // reaching the injected-failure path below needs nothing but the NEW state.
+  ScopedJvmtiMock jvmti_mock;
   ProfilerTestAccessor::setState(p, NEW);
   ProfiledThread::current()->setFiRng(0x5EED5EED5EED5EEDULL);
 
   bool sawInjectedFailure = false;
-  bool sawClean = false;
+  bool sawNonInjectedPrewarm = false;
   // shouldFire() mixes the fixed RNG seed above with an ASLR-dependent
   // per-call-site address, so which outcome the *first* call produces is not
-  // deterministic run to run -- the injected failure can land before a clean
-  // call is observed. Keep iterating (and un-latching the ERROR state that a
-  // failure leaves behind) until both outcomes have been seen at least once.
-  for (int i = 0; i < 5000 && !(sawInjectedFailure && sawClean); i++) {
+  // deterministic run to run -- the injected failure can land before a
+  // non-injected call is observed. Keep iterating (and un-latching the ERROR
+  // state that every outcome here leaves behind) until both have been seen.
+  for (int i = 0; i < 5000 && !(sawInjectedFailure && sawNonInjectedPrewarm); i++) {
     Error error = p->checkState();
-    if (error) {
-      EXPECT_STREQ("Missing libgcc_s.so", error.message());
+    ASSERT_TRUE((bool)error) << "checkState() must fail here: either the "
+                                 "injected prewarmUnwinder() failure or the "
+                                 "mocked JVMSupport::initialize() failure";
+    if (std::strcmp(error.message(), "Missing libgcc_s.so") == 0) {
       sawInjectedFailure = true;
-      ProfilerTestAccessor::setState(p, NEW);
     } else {
-      sawClean = true;
+      // prewarmUnwinder() succeeded (non-injected, ~99% of calls) and fell
+      // through to the mocked JVMSupport::initialize() failure instead.
+      EXPECT_STREQ("Profiler encountered fatal error", error.message());
+      sawNonInjectedPrewarm = true;
     }
+    ProfilerTestAccessor::setState(p, NEW);
   }
 
   EXPECT_TRUE(sawInjectedFailure)
       << "expected at least one injected prewarmUnwinder() failure within 5000 tries";
-  EXPECT_TRUE(sawClean)
-      << "expected at least one non-injected call to succeed (LIKELY tier is ~1%)";
-  ProfilerTestAccessor::setState(p, NEW);
+  EXPECT_TRUE(sawNonInjectedPrewarm)
+      << "expected at least one non-injected prewarmUnwinder() success within 5000 tries";
+#endif // __linux__
 }
 
 #endif  // __FAULT_INJECTION__

--- a/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
@@ -278,7 +278,7 @@ TEST_F(FaultInjectionTest, CheckStateSurfacesInjectedPrewarmUnwinderFailure) {
       << "expected at least one injected prewarmUnwinder() failure within 5000 tries";
   EXPECT_TRUE(sawClean)
       << "expected at least one non-injected call to succeed (LIKELY tier is ~1%)";
-#endif // __linux__
+  ProfilerTestAccessor::setState(p, NEW);
 }
 
 #endif  // __FAULT_INJECTION__

--- a/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
@@ -223,11 +223,25 @@ public:
     if (JVMThread::_jvm_thread.isKeyValid()) {
       return;
     }
-    static void* marker = &marker;
+
+    static int marker_storage;
+    void* marker = &marker_storage;
+
     pthread_key_t key;
-    ASSERT_EQ(pthread_key_create(&key, nullptr), 0);
-    ASSERT_EQ(pthread_setspecific(key, marker), 0);
-    ASSERT_TRUE(JVMThread::_jvm_thread.initialize(marker));
+    int rc = pthread_key_create(&key, nullptr);
+    if (rc != 0) {
+      ADD_FAILURE() << "pthread_key_create failed: " << rc;
+      return;
+    }
+    rc = pthread_setspecific(key, marker);
+    if (rc != 0) {
+      ADD_FAILURE() << "pthread_setspecific failed: " << rc;
+      return;
+    }
+    if (!JVMThread::_jvm_thread.initialize(marker)) {
+      ADD_FAILURE() << "ThreadLocal<JVMThread*>::initialize failed";
+      return;
+    }
   }
 };
 

--- a/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
@@ -272,7 +272,7 @@ TEST_F(FaultInjectionTest, CheckStateSurfacesInjectedPrewarmUnwinderFailure) {
     ASSERT_TRUE((bool)error) << "checkState() must fail here: either the "
                                  "injected prewarmUnwinder() failure or the "
                                  "mocked JVMSupport::initialize() failure";
-    if (std::strcmp(error.message(), "Missing libgcc_s.so") == 0) {
+    if (std::strcmp(error.message(), "Missing libgcc_s.so.1") == 0) {
       sawInjectedFailure = true;
     } else {
       // prewarmUnwinder() succeeded (non-injected, ~99% of calls) and fell

--- a/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
@@ -214,6 +214,7 @@ public:
 // that failure path reachable here: the real dlopen() still runs and
 // succeeds, but the caller is deterministically told it failed.
 TEST_F(FaultInjectionTest, CheckStateSurfacesInjectedPrewarmUnwinderFailure) {
+#ifdef __linux__
   Profiler* p = Profiler::instance();
   ProfilerTestAccessor::setState(p, IDLE);
   ProfiledThread::current()->setFiRng(0x5EED5EED5EED5EEDULL);
@@ -234,6 +235,7 @@ TEST_F(FaultInjectionTest, CheckStateSurfacesInjectedPrewarmUnwinderFailure) {
       << "expected at least one injected prewarmUnwinder() failure within 5000 tries";
   EXPECT_TRUE(sawClean)
       << "expected at least one non-injected call to succeed (LIKELY tier is ~1%)";
+#endif // __linux__
 }
 
 #endif  // __FAULT_INJECTION__

--- a/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
@@ -13,6 +13,7 @@
 #include "faultInjection.h"
 #include "safeAccess.h"
 #include "os.h"
+#include "profiler.h"
 #include "threadLocalData.h"
 #include "hotspot/hotspotSupport.h"
 #include "../../main/cpp/gtest_crash_handler.h"
@@ -178,6 +179,46 @@ TEST_F(FaultInjectionTest, WalkVmSigsetjmpRecoversFromInjectedFault) {
   EXPECT_GT(faults, 0u) << "expected at least one injected fault to siglongjmp-recover";
   EXPECT_TRUE(recovered);
   SUCCEED();
+}
+
+// Friend of Profiler (see profiler.h) — lets this test force the internal
+// state to IDLE so checkState() can be exercised deterministically without a
+// live JVM (matches the pattern in jvmSupport_ut.cpp).
+class ProfilerTestAccessor {
+public:
+  static void setState(Profiler* p, State s) {
+    p->_state.store(s, std::memory_order_release);
+  }
+};
+
+// (d) Value-injection path: PROF-15395 fixed Profiler::checkState() (shared by
+// start()/check(), and therefore also reached by the -agentpath auto-start
+// path) to fail cleanly instead of crashing later when libgcc_s.so.1 can't be
+// loaded. libgcc_s.so.1 is always present in this test environment, so
+// INJECT_FAULT_BOOL_LIKELY on prewarmUnwinder()'s return value is what makes
+// that failure path reachable here: the real dlopen() still runs and
+// succeeds, but the caller is deterministically told it failed.
+TEST_F(FaultInjectionTest, CheckStateSurfacesInjectedPrewarmUnwinderFailure) {
+  Profiler* p = Profiler::instance();
+  ProfilerTestAccessor::setState(p, IDLE);
+  ProfiledThread::current()->setFiRng(0x5EED5EED5EED5EEDULL);
+
+  bool sawInjectedFailure = false;
+  bool sawClean = false;
+  for (int i = 0; i < 5000 && !sawInjectedFailure; i++) {
+    Error error = p->checkState();
+    if (error) {
+      EXPECT_STREQ("Missing libgcc_s.so", error.message());
+      sawInjectedFailure = true;
+    } else {
+      sawClean = true;
+    }
+  }
+
+  EXPECT_TRUE(sawInjectedFailure)
+      << "expected at least one injected prewarmUnwinder() failure within 5000 tries";
+  EXPECT_TRUE(sawClean)
+      << "expected at least one non-injected call to succeed (LIKELY tier is ~1%)";
 }
 
 #endif  // __FAULT_INJECTION__

--- a/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/faultInjection_ut.cpp
@@ -287,6 +287,7 @@ TEST_F(FaultInjectionTest, CheckStateSurfacesInjectedPrewarmUnwinderFailure) {
   EXPECT_TRUE(sawClean)
       << "expected at least one non-injected call to succeed (LIKELY tier is ~1%)";
   ProfilerTestAccessor::setState(p, NEW);
+#endif  // __linux__
 }
 
 #endif  // __FAULT_INJECTION__

--- a/ddprof-lib/src/test/cpp/jvmSupport_ut.cpp
+++ b/ddprof-lib/src/test/cpp/jvmSupport_ut.cpp
@@ -114,17 +114,20 @@ TEST_F(JvmSupportInitFailureTest, CheckStateBlocksOnInitFailureAndLatchesError) 
 
     // Under -PenableFaultInjection, checkState() checks prewarmUnwinder()
     // before JVMSupport::initialize() (see profiler.cpp), so an injected
-    // fault could occasionally surface "Missing libgcc_s.so.1" here instead of
+    // fault could occasionally surface "Missing libgcc_s.so" here instead of
     // the JVMSupport::initialize() failure this test targets. Retry past any
-    // such spurious injected failure -- a single-iteration no-op in the
-    // default build, where prewarmUnwinder() always succeeds.
+    // such injected failure. If it persists across retries, libgcc_s is likely
+    // genuinely absent on this host and this test cannot exercise the intended path.
     Error error = Error::OK;
     for (int i = 0; i < 100; i++) {
         error = p->checkState();
-        if (strcmp(error.message(), "Missing libgcc_s.so") != 0) {
+        if (!error || std::strcmp(error.message(), "Missing libgcc_s.so") != 0) {
             break;
         }
         ProfilerTestAccessor::setState(p, NEW);
+    }
+    if (error && std::strcmp(error.message(), "Missing libgcc_s.so") == 0) {
+        GTEST_SKIP() << "libgcc_s.so.1 is missing on this host; cannot exercise JVMSupport::initialize() failure path";
     }
     bool has_error = (bool)error;
 

--- a/ddprof-lib/src/test/cpp/jvmSupport_ut.cpp
+++ b/ddprof-lib/src/test/cpp/jvmSupport_ut.cpp
@@ -121,12 +121,12 @@ TEST_F(JvmSupportInitFailureTest, CheckStateBlocksOnInitFailureAndLatchesError) 
     Error error = Error::OK;
     for (int i = 0; i < 100; i++) {
         error = p->checkState();
-        if (!error || std::strcmp(error.message(), "Missing libgcc_s.so") != 0) {
+        if (!error || std::strcmp(error.message(), "Missing libgcc_s.so.1") != 0) {
             break;
         }
         ProfilerTestAccessor::setState(p, NEW);
     }
-    if (error && std::strcmp(error.message(), "Missing libgcc_s.so") == 0) {
+    if (error && std::strcmp(error.message(), "Missing libgcc_s.so.1") == 0) {
         GTEST_SKIP() << "libgcc_s.so.1 is missing on this host; cannot exercise JVMSupport::initialize() failure path";
     }
     bool has_error = (bool)error;

--- a/ddprof-lib/src/test/cpp/jvmSupport_ut.cpp
+++ b/ddprof-lib/src/test/cpp/jvmSupport_ut.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <cstring>
 #include "jvmSupport.h"
 #include "jvmThread.h"
 #include "vmEntry.h"
@@ -111,7 +112,20 @@ TEST_F(JvmSupportInitFailureTest, JVMSupportInitializeFailsWhenJVMThreadFails) {
 TEST_F(JvmSupportInitFailureTest, CheckStateBlocksOnInitFailureAndLatchesError) {
     Profiler* p = Profiler::instance();
 
-    Error error = p->checkState();
+    // Under -PenableFaultInjection, checkState() checks prewarmUnwinder()
+    // before JVMSupport::initialize() (see profiler.cpp), so an injected
+    // fault could occasionally surface "Missing libgcc_s.so" here instead of
+    // the JVMSupport::initialize() failure this test targets. Retry past any
+    // such spurious injected failure -- a single-iteration no-op in the
+    // default build, where prewarmUnwinder() always succeeds.
+    Error error = Error::OK;
+    for (int i = 0; i < 100; i++) {
+        error = p->checkState();
+        if (strcmp(error.message(), "Missing libgcc_s.so") != 0) {
+            break;
+        }
+        ProfilerTestAccessor::setState(p, NEW);
+    }
     bool has_error = (bool)error;
 
     EXPECT_TRUE(has_error);

--- a/ddprof-lib/src/test/cpp/jvmSupport_ut.cpp
+++ b/ddprof-lib/src/test/cpp/jvmSupport_ut.cpp
@@ -114,7 +114,7 @@ TEST_F(JvmSupportInitFailureTest, CheckStateBlocksOnInitFailureAndLatchesError) 
 
     // Under -PenableFaultInjection, checkState() checks prewarmUnwinder()
     // before JVMSupport::initialize() (see profiler.cpp), so an injected
-    // fault could occasionally surface "Missing libgcc_s.so" here instead of
+    // fault could occasionally surface "Missing libgcc_s.so.1" here instead of
     // the JVMSupport::initialize() failure this test targets. Retry past any
     // such spurious injected failure -- a single-iteration no-op in the
     // default build, where prewarmUnwinder() always succeeds.


### PR DESCRIPTION
**What does this PR do?**:
Gracefully disable profiler if `libgcc_s.so` is not installed on the host.

**Motivation**:
Profiler should not crash applications.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
Added fault injection to simulate the absence of `libgcc_s.so`, profiler should not crash.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-15395](https://datadoghq.atlassian.net/browse/PROF-15395)

Unsure? Have a question? Request a review!


[PROF-15395]: https://datadoghq.atlassian.net/browse/PROF-15395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ