### PR TITLE
fix(reliability): stop the reliability CI jobs from failing on every run

### DIFF
--- a/.gitlab/reliability/.gitlab-ci.yml
+++ b/.gitlab/reliability/.gitlab-ci.yml
@@ -7,7 +7,8 @@ variables:
   stage: reliability
   timeout: 6h
   variables:
-    RUNTIME: "${RUNTIME}"
+    # Default; a pipeline-schedule variable named RUNTIME overrides this.
+    RUNTIME: "3600"
   needs:
     - get-versions
   rules:
@@ -63,7 +64,8 @@ reliability-aarch64:
   stage: reliability
   timeout: 6h
   variables:
-    RUNTIME: "${RUNTIME}"
+    # Default; a pipeline-schedule variable named RUNTIME overrides this.
+    RUNTIME: "3600"
   needs:
     - get-versions
     - job: chaos:build

--- a/.gitlab/reliability/.gitlab-ci.yml
+++ b/.gitlab/reliability/.gitlab-ci.yml
@@ -13,6 +13,7 @@ variables:
     - get-versions
     - job: deploy-artifact
       artifacts: false
+      optional: true
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: always

--- a/.gitlab/reliability/.gitlab-ci.yml
+++ b/.gitlab/reliability/.gitlab-ci.yml
@@ -11,6 +11,8 @@ variables:
     RUNTIME: "3600"
   needs:
     - get-versions
+    - job: deploy-artifact
+      artifacts: false
   rules:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: always

--- a/.gitlab/reliability/.gitlab-ci.yml
+++ b/.gitlab/reliability/.gitlab-ci.yml
@@ -42,6 +42,7 @@ variables:
       - hs_err.log
       - err.log
       - out.log
+      - maven-get.log
     reports:
       dotenv: build.env
     expire_in: 7 days

--- a/.gitlab/reliability/jit_stability_check.sh
+++ b/.gitlab/reliability/jit_stability_check.sh
@@ -15,12 +15,27 @@ source "/root/.sdkman/bin/sdkman-init.sh" 1>/dev/null 2>/dev/null
 
 sdk install java 21.0.3-tem 1>/dev/null 2>/dev/null
 
-mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
-    -DrepoUrl=https://central.sonatype.com/repository/maven-snapshots/ \
-    -Dartifact=com.datadoghq:ddprof:${CURRENT_VERSION} 1>/dev/null 2>/dev/null
 DDPROF_JAR="/root/.m2/repository/com/datadoghq/ddprof/${CURRENT_VERSION}/ddprof-${CURRENT_VERSION}.jar"
+# Sonatype's snapshot repo can lag a bit between a successful publish and the
+# artifact being resolvable, even once deploy-artifact has already completed.
+# Capture mvn's actual output (not just presence/absence of the jar) so a
+# genuine failure (auth, 404, blocked network) is visible instead of looking
+# identical to indexing lag.
+MVN_GET_LOG="${HERE}/../../maven-get.log"
+: > "$MVN_GET_LOG"
+for attempt in 1 2 3 4 5 6; do
+  echo "=== mvn get attempt ${attempt}/6 ===" >> "$MVN_GET_LOG"
+  mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
+      -DrepoUrl=https://central.sonatype.com/repository/maven-snapshots/ \
+      -Dartifact=com.datadoghq:ddprof:${CURRENT_VERSION} >> "$MVN_GET_LOG" 2>&1
+  [ -f "$DDPROF_JAR" ] && break
+  echo "ddprof ${CURRENT_VERSION} not yet resolvable (attempt ${attempt}/6), retrying in 20s"
+  sleep 20
+done
 if [ ! -f "$DDPROF_JAR" ]; then
   echo "FAIL:Could not fetch ddprof ${CURRENT_VERSION} jar" >&2
+  echo "--- last mvn get output (see maven-get.log artifact for full history) ---" >&2
+  tail -n 40 "$MVN_GET_LOG" >&2
   exit 1
 fi
 

--- a/.gitlab/reliability/jit_stability_check.sh
+++ b/.gitlab/reliability/jit_stability_check.sh
@@ -16,18 +16,20 @@ source "/root/.sdkman/bin/sdkman-init.sh" 1>/dev/null 2>/dev/null
 sdk install java 21.0.3-tem 1>/dev/null 2>/dev/null
 
 DDPROF_JAR="/root/.m2/repository/com/datadoghq/ddprof/${CURRENT_VERSION}/ddprof-${CURRENT_VERSION}.jar"
-# Sonatype's snapshot repo can lag a bit between a successful publish and the
-# artifact being resolvable, even once deploy-artifact has already completed.
-# Capture mvn's actual output (not just presence/absence of the jar) so a
-# genuine failure (auth, 404, blocked network) is visible instead of looking
-# identical to indexing lag.
+# Run mvn from a temp dir, not the repo root: this repo has a stale, empty
+# pom.xml (a leftover from the old async-profiler publishing setup) that
+# makes mvn abort with "Non-readable POM ... input contained no data" before
+# it even attempts to resolve anything. Same workaround as
+# .gitlab/dd-trace-integration/download-snapshot-artifacts.sh.
+MVN_WORK_DIR=$(mktemp -d)
+trap 'rm -rf "${MVN_WORK_DIR}"' EXIT
 MVN_GET_LOG="${HERE}/../../maven-get.log"
 : > "$MVN_GET_LOG"
 for attempt in 1 2 3 4 5 6; do
   echo "=== mvn get attempt ${attempt}/6 ===" >> "$MVN_GET_LOG"
-  mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
+  (cd "${MVN_WORK_DIR}" && mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
       -DrepoUrl=https://central.sonatype.com/repository/maven-snapshots/ \
-      -Dartifact=com.datadoghq:ddprof:${CURRENT_VERSION} >> "$MVN_GET_LOG" 2>&1
+      -Dartifact=com.datadoghq:ddprof:${CURRENT_VERSION}) >> "$MVN_GET_LOG" 2>&1
   [ -f "$DDPROF_JAR" ] && break
   echo "ddprof ${CURRENT_VERSION} not yet resolvable (attempt ${attempt}/6), retrying in 20s"
   sleep 20

--- a/.gitlab/reliability/jit_stability_check.sh
+++ b/.gitlab/reliability/jit_stability_check.sh
@@ -18,12 +18,21 @@ sdk install java 21.0.3-tem 1>/dev/null 2>/dev/null
 mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
     -DrepoUrl=https://central.sonatype.com/repository/maven-snapshots/ \
     -Dartifact=com.datadoghq:ddprof:${CURRENT_VERSION} 1>/dev/null 2>/dev/null
+DDPROF_JAR="/root/.m2/repository/com/datadoghq/ddprof/${CURRENT_VERSION}/ddprof-${CURRENT_VERSION}.jar"
+if [ ! -f "$DDPROF_JAR" ]; then
+  echo "FAIL:Could not fetch ddprof ${CURRENT_VERSION} jar" >&2
+  exit 1
+fi
 
 mkdir -p /var/lib/datadog/${CURRENT_VERSION}
 rm -rf /var/lib/datadog/${CURRENT_VERSION}/*
 
-unzip -q -d /var/lib/datadog/${CURRENT_VERSION} /root/.m2/repository/com/datadoghq/ddprof/${CURRENT_VERSION}/ddprof-${CURRENT_VERSION}.jar
+unzip -q -d /var/lib/datadog/${CURRENT_VERSION} "$DDPROF_JAR"
 AGENT_LIB=$(find /var/lib/datadog/${CURRENT_VERSION} -name 'libjavaProfiler.so' | fgrep '/linux-x64/')
+if [ -z "$AGENT_LIB" ]; then
+  echo "FAIL:Could not locate libjavaProfiler.so for linux-x64" >&2
+  exit 1
+fi
 
 echo "Agent lib: ${AGENT_LIB}"
 uname -a

--- a/.gitlab/reliability/jit_stability_check.sh
+++ b/.gitlab/reliability/jit_stability_check.sh
@@ -16,20 +16,16 @@ source "/root/.sdkman/bin/sdkman-init.sh" 1>/dev/null 2>/dev/null
 sdk install java 21.0.3-tem 1>/dev/null 2>/dev/null
 
 DDPROF_JAR="/root/.m2/repository/com/datadoghq/ddprof/${CURRENT_VERSION}/ddprof-${CURRENT_VERSION}.jar"
-# Run mvn from a temp dir, not the repo root: this repo has a stale, empty
-# pom.xml (a leftover from the old async-profiler publishing setup) that
-# makes mvn abort with "Non-readable POM ... input contained no data" before
-# it even attempts to resolve anything. Same workaround as
-# .gitlab/dd-trace-integration/download-snapshot-artifacts.sh.
-MVN_WORK_DIR=$(mktemp -d)
-trap 'rm -rf "${MVN_WORK_DIR}"' EXIT
+# Capture mvn's actual output (not just presence/absence of the jar) so a
+# genuine failure (auth, 404, blocked network) is visible instead of looking
+# like a transient miss.
 MVN_GET_LOG="${HERE}/../../maven-get.log"
 : > "$MVN_GET_LOG"
 for attempt in 1 2 3 4 5 6; do
   echo "=== mvn get attempt ${attempt}/6 ===" >> "$MVN_GET_LOG"
-  (cd "${MVN_WORK_DIR}" && mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
+  mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
       -DrepoUrl=https://central.sonatype.com/repository/maven-snapshots/ \
-      -Dartifact=com.datadoghq:ddprof:${CURRENT_VERSION}) >> "$MVN_GET_LOG" 2>&1
+      -Dartifact=com.datadoghq:ddprof:${CURRENT_VERSION} >> "$MVN_GET_LOG" 2>&1
   [ -f "$DDPROF_JAR" ] && break
   echo "ddprof ${CURRENT_VERSION} not yet resolvable (attempt ${attempt}/6), retrying in 20s"
   sleep 20

--- a/.gitlab/reliability/memory_trend_check.sh
+++ b/.gitlab/reliability/memory_trend_check.sh
@@ -45,18 +45,20 @@ source "/root/.sdkman/bin/sdkman-init.sh" 1>/dev/null 2>/dev/null
 sdk install java 21.0.3-tem 1>/dev/null 2>/dev/null
 
 DDPROF_JAR="/root/.m2/repository/com/datadoghq/ddprof/${CURRENT_VERSION}/ddprof-${CURRENT_VERSION}.jar"
-# Sonatype's snapshot repo can lag a bit between a successful publish and the
-# artifact being resolvable, even once deploy-artifact has already completed.
-# Capture mvn's actual output (not just presence/absence of the jar) so a
-# genuine failure (auth, 404, blocked network) is visible instead of looking
-# identical to indexing lag.
+# Run mvn from a temp dir, not the repo root: this repo has a stale, empty
+# pom.xml (a leftover from the old async-profiler publishing setup) that
+# makes mvn abort with "Non-readable POM ... input contained no data" before
+# it even attempts to resolve anything. Same workaround as
+# .gitlab/dd-trace-integration/download-snapshot-artifacts.sh.
+MVN_WORK_DIR=$(mktemp -d)
+trap 'rm -rf "${MVN_WORK_DIR}"' EXIT
 MVN_GET_LOG="${HERE}/../../maven-get.log"
 : > "$MVN_GET_LOG"
 for attempt in 1 2 3 4 5 6; do
   echo "=== mvn get attempt ${attempt}/6 ===" >> "$MVN_GET_LOG"
-  mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
+  (cd "${MVN_WORK_DIR}" && mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
       -DrepoUrl=https://central.sonatype.com/repository/maven-snapshots/ \
-      -Dartifact=com.datadoghq:ddprof:${CURRENT_VERSION} >> "$MVN_GET_LOG" 2>&1
+      -Dartifact=com.datadoghq:ddprof:${CURRENT_VERSION}) >> "$MVN_GET_LOG" 2>&1
   [ -f "$DDPROF_JAR" ] && break
   echo "ddprof ${CURRENT_VERSION} not yet resolvable (attempt ${attempt}/6), retrying in 20s"
   sleep 20

--- a/.gitlab/reliability/memory_trend_check.sh
+++ b/.gitlab/reliability/memory_trend_check.sh
@@ -45,20 +45,16 @@ source "/root/.sdkman/bin/sdkman-init.sh" 1>/dev/null 2>/dev/null
 sdk install java 21.0.3-tem 1>/dev/null 2>/dev/null
 
 DDPROF_JAR="/root/.m2/repository/com/datadoghq/ddprof/${CURRENT_VERSION}/ddprof-${CURRENT_VERSION}.jar"
-# Run mvn from a temp dir, not the repo root: this repo has a stale, empty
-# pom.xml (a leftover from the old async-profiler publishing setup) that
-# makes mvn abort with "Non-readable POM ... input contained no data" before
-# it even attempts to resolve anything. Same workaround as
-# .gitlab/dd-trace-integration/download-snapshot-artifacts.sh.
-MVN_WORK_DIR=$(mktemp -d)
-trap 'rm -rf "${MVN_WORK_DIR}"' EXIT
+# Capture mvn's actual output (not just presence/absence of the jar) so a
+# genuine failure (auth, 404, blocked network) is visible instead of looking
+# like a transient miss.
 MVN_GET_LOG="${HERE}/../../maven-get.log"
 : > "$MVN_GET_LOG"
 for attempt in 1 2 3 4 5 6; do
   echo "=== mvn get attempt ${attempt}/6 ===" >> "$MVN_GET_LOG"
-  (cd "${MVN_WORK_DIR}" && mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
+  mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
       -DrepoUrl=https://central.sonatype.com/repository/maven-snapshots/ \
-      -Dartifact=com.datadoghq:ddprof:${CURRENT_VERSION}) >> "$MVN_GET_LOG" 2>&1
+      -Dartifact=com.datadoghq:ddprof:${CURRENT_VERSION} >> "$MVN_GET_LOG" 2>&1
   [ -f "$DDPROF_JAR" ] && break
   echo "ddprof ${CURRENT_VERSION} not yet resolvable (attempt ${attempt}/6), retrying in 20s"
   sleep 20

--- a/.gitlab/reliability/memory_trend_check.sh
+++ b/.gitlab/reliability/memory_trend_check.sh
@@ -44,12 +44,27 @@ source "/root/.sdkman/bin/sdkman-init.sh" 1>/dev/null 2>/dev/null
 
 sdk install java 21.0.3-tem 1>/dev/null 2>/dev/null
 
-mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
-    -DrepoUrl=https://central.sonatype.com/repository/maven-snapshots/ \
-    -Dartifact=com.datadoghq:ddprof:${CURRENT_VERSION} 1>/dev/null 2>/dev/null
 DDPROF_JAR="/root/.m2/repository/com/datadoghq/ddprof/${CURRENT_VERSION}/ddprof-${CURRENT_VERSION}.jar"
+# Sonatype's snapshot repo can lag a bit between a successful publish and the
+# artifact being resolvable, even once deploy-artifact has already completed.
+# Capture mvn's actual output (not just presence/absence of the jar) so a
+# genuine failure (auth, 404, blocked network) is visible instead of looking
+# identical to indexing lag.
+MVN_GET_LOG="${HERE}/../../maven-get.log"
+: > "$MVN_GET_LOG"
+for attempt in 1 2 3 4 5 6; do
+  echo "=== mvn get attempt ${attempt}/6 ===" >> "$MVN_GET_LOG"
+  mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
+      -DrepoUrl=https://central.sonatype.com/repository/maven-snapshots/ \
+      -Dartifact=com.datadoghq:ddprof:${CURRENT_VERSION} >> "$MVN_GET_LOG" 2>&1
+  [ -f "$DDPROF_JAR" ] && break
+  echo "ddprof ${CURRENT_VERSION} not yet resolvable (attempt ${attempt}/6), retrying in 20s"
+  sleep 20
+done
 if [ ! -f "$DDPROF_JAR" ]; then
   echo "FAIL:Could not fetch ddprof ${CURRENT_VERSION} jar" >&2
+  echo "--- last mvn get output (see maven-get.log artifact for full history) ---" >&2
+  tail -n 40 "$MVN_GET_LOG" >&2
   exit 1
 fi
 

--- a/.gitlab/reliability/memory_trend_check.sh
+++ b/.gitlab/reliability/memory_trend_check.sh
@@ -10,7 +10,15 @@ ALLOCATOR=${3:-gmalloc}
 
 # Function to count CPUs from ranges and individual numbers
 count_cpus() {
-    local cpus=$(cat /sys/fs/cgroup/cpuset/cpuset.cpus)
+    local cpuset_file="/sys/fs/cgroup/cpuset/cpuset.cpus"
+    if [ ! -f "$cpuset_file" ] && [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+        cpuset_file="/sys/fs/cgroup/cpuset.cpus.effective"
+    fi
+    if [ ! -f "$cpuset_file" ]; then
+        nproc
+        return
+    fi
+    local cpus=$(cat "$cpuset_file")
     local cpu_count=0
     local IFS=','  # Use comma as delimiter to split ranges and numbers
 
@@ -39,12 +47,21 @@ sdk install java 21.0.3-tem 1>/dev/null 2>/dev/null
 mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
     -DrepoUrl=https://central.sonatype.com/repository/maven-snapshots/ \
     -Dartifact=com.datadoghq:ddprof:${CURRENT_VERSION} 1>/dev/null 2>/dev/null
+DDPROF_JAR="/root/.m2/repository/com/datadoghq/ddprof/${CURRENT_VERSION}/ddprof-${CURRENT_VERSION}.jar"
+if [ ! -f "$DDPROF_JAR" ]; then
+  echo "FAIL:Could not fetch ddprof ${CURRENT_VERSION} jar" >&2
+  exit 1
+fi
 
 mkdir -p /var/lib/datadog/${CURRENT_VERSION}
 rm -rf /var/lib/datadog/${CURRENT_VERSION}/*
 
-unzip -q -d /var/lib/datadog/${CURRENT_VERSION} /root/.m2/repository/com/datadoghq/ddprof/${CURRENT_VERSION}/ddprof-${CURRENT_VERSION}.jar
+unzip -q -d /var/lib/datadog/${CURRENT_VERSION} "$DDPROF_JAR"
 AGENT_LIB=$(find /var/lib/datadog/${CURRENT_VERSION} -name 'libjavaProfiler.so' | fgrep '/linux-x64/')
+if [ -z "$AGENT_LIB" ]; then
+  echo "FAIL:Could not locate libjavaProfiler.so for linux-x64" >&2
+  exit 1
+fi
 
 echo "Agent lib: ${AGENT_LIB}"
 uname -a
@@ -55,7 +72,7 @@ wget -q -O /var/lib/datadog/dd-java-agent.jar 'https://dtdg.co/latest-java-trace
 
 CONTROL_FILE=".running"
 touch $CONTROL_FILE
-sh ./benchmarks/steps/mem_watch.sh $CONTROL_FILE ${HERE}/../../memwatch.log &
+sh ${HERE}/../benchmarks/steps/mem_watch.sh $CONTROL_FILE ${HERE}/../../memwatch.log &
 
 case $CONFIG in
   profiler)


### PR DESCRIPTION
**What does this PR do?**:
Fixes several independent bugs that were making the reliability pipeline (`memory_trend_check.sh`, `jit_stability_check.sh`) fail on every run:

- Removes a stale, empty `pom.xml` at the repo root (leftover from an old async-profiler publishing setup) that made every `mvn` invocation abort with "Non-readable POM ... input contained no data" before it could resolve anything.
- Adds a `deploy-artifact` dependency to `.reliability_job`'s `needs:` so the job can't start before the ddprof snapshot it depends on has actually been published.
- Adds a fail-fast check (with retry + captured `mvn` output) after fetching the ddprof snapshot jar, so a fetch failure is reported clearly instead of unzip/find silently producing empty results downstream.
- Fixes `count_cpus()` to fall back to cgroup v2's `cpuset.cpus.effective` (and to `nproc` if neither cgroup path exists) instead of only reading the cgroup v1 path.
- Fixes the `mem_watch.sh` path, which pointed at a nonexistent relative location.
- Replaces the self-referential `RUNTIME: "${RUNTIME}"` default (which only resolved via a pipeline-schedule variable) with an actual default value.

**Motivation**:
The reliability pipeline moved into this repo from `java-profiler-build` on 2026-04-03 and has been failing on every scheduled/manual run since, cascading through unzip/cgroup/library-load/env errors that all trace back to the issues above. See PROF-15567.

**Additional Notes**:
None.

**How to test the change?**:
Validated by re-running the reliability pipeline on this branch and confirming the ddprof snapshot resolves and the jobs progress past artifact setup. CI on this PR (and the scheduled reliability pipeline) is the real validation, since these scripts only run in that environment.

**For Datadog employees**:
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-15567]

Unsure? Have a question? Request a review!

[PROF-15567]: https://datadoghq.atlassian.net/browse/PROF-15567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ