### PR TITLE
fix: restore trivial approval action pins

### DIFF
--- a/.github/scripts/tests/test_release_automation.sh
+++ b/.github/scripts/tests/test_release_automation.sh
@@ -422,6 +422,10 @@ AUTHORIZATION_LINE=$(grep -n "Authorize trivial labeler" \
   fail "approval workflow does not conditionally validate release bumps"
 [[ "$APPROVAL_WORKFLOW" == *"commit_id: process.env.EXPECTED_HEAD_SHA"* ]] ||
   fail "approval is not pinned to the validated SHA"
+while IFS= read -r action_ref; do
+  [[ "$action_ref" =~ ^[0-9a-f]{40}$ ]] ||
+    fail "approval workflow action ref is not a full commit SHA: $action_ref"
+done < <(sed -nE 's/^[[:space:]]*uses: [^@]+@([^[:space:]]+).*/\1/p' <<<"$APPROVAL_WORKFLOW")
 pass
 
 RELEASE_WORKFLOW=$(<"$ROOT/.github/workflows/release-validated.yml")

--- a/.github/workflows/approve-trivial.yml
+++ b/.github/workflows/approve-trivial.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Check for an existing exact approval
         id: existing
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b # 9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # 9.0.0
         env:
           EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
@@ -98,7 +98,7 @@ jobs:
 
       - name: Approve exact current commit
         if: steps.existing.outputs.approved != 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b # 9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # 9.0.0
         env:
           EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:


### PR DESCRIPTION
## Summary
- restore the full 40-character actions/github-script pins in the trivial-approval workflow
- add a hermetic regression assertion requiring every action in that workflow to use a full commit SHA

## Why
PR #698 accidentally truncated both actions/github-script pins from 40 to 39 characters. GitHub cannot resolve shortened action SHAs, so the pull_request_target workflow fails during job setup before it can auto-approve any PR, including the release/1.48 backport.

## Validation
- bash -n .github/scripts/tests/test_release_automation.sh
- .github/scripts/tests/test_release_automation.sh (74 groups pass)
- ./.claude/commands/build-and-summarize spotlessApply