### PR TITLE
fix: skip jobs needing build/deploy-artifact on release/* branches

### DIFF
--- a/.github/workflows/cache_java.yml
+++ b/.github/workflows/cache_java.yml
@@ -34,7 +34,7 @@ env:
   # jdk1.8.0_361
   JAVA_8_ORACLE_URL: "https://javadl.oracle.com/webapps/download/AutoDL?BundleId=247926_0ae14417abb444ebb02b9815e2103550"
 
-  JAVA_8_IBM_URL: "https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/8.0.8.60/linux/x86_64/ibm-java-jre-8.0-8.60-linux-x86_64.tgz"
+  JAVA_8_IBM_URL: "https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/8.0.8.70/linux/x86_64/ibm-java-jre-8.0-8.70-linux-x86_64.tgz"
 
   # FIXME: Azul pulled public CDN access to Zing/Prime downloads - all URLs return 404
   # JAVA_8_ZING_URL         : "https://cdn.azul.com/zing-zvm/ZVM23.05.0.0/zing23.05.0.0-2-jdk8.0.372-linux_x64.tar.gz"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -133,6 +133,15 @@ create_key:
     paths:
       - pubkeys
 
+# Unit tests for shared helpers in .gitlab/scripts/includes.sh (e.g. the
+# snapshot-staleness check deploy.sh relies on to poll Sonatype).
+shell-unit-tests:
+  stage: prepare
+  needs: []
+  image: ${PREPARE_IMAGE}
+  script:
+    - bash .gitlab/scripts/tests/includes_test.sh
+
 # Shared version detection used by benchmarks and reliability pipelines
 get-versions:
   extends: .get-versions

--- a/.gitlab/benchmarks/.gitlab-ci.yml
+++ b/.gitlab/benchmarks/.gitlab-ci.yml
@@ -17,6 +17,8 @@ benchmarks-trigger:
   rules:
     - if: '$CANCELLED == "true"'
       when: never
+    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
+      when: never
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
       when: never
     - if: '$CI_PIPELINE_SOURCE == "schedule"'

--- a/.gitlab/benchmarks/.gitlab-ci.yml
+++ b/.gitlab/benchmarks/.gitlab-ci.yml
@@ -17,8 +17,7 @@ benchmarks-trigger:
   rules:
     - if: '$CANCELLED == "true"'
       when: never
-    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
-      when: never
+    - !reference [.skip-on-release, rules]
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
       when: never
     - if: '$CI_PIPELINE_SOURCE == "schedule"'

--- a/.gitlab/build-deploy/.gitlab-ci.yml
+++ b/.gitlab/build-deploy/.gitlab-ci.yml
@@ -345,7 +345,10 @@ notify-slack-on-success:
       artifacts: true
     - job: deploy-artifact
       artifacts: false
-  when: on_success
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
+      when: never
+    - when: on_success
   image: registry.ddbuild.io/slack-notifier:v91289620-4ec922a-latest@sha256:06b24f392ccc383d371c72001520a254edef523bc0bfdc445f487106107b4202
   tags: ["arch:amd64"]
   script:
@@ -359,7 +362,10 @@ notify-slack-on-failure:
       artifacts: true
     - job: deploy-artifact
       artifacts: true
-  when: on_failure
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
+      when: never
+    - when: on_failure
   image: registry.ddbuild.io/slack-notifier:v91289620-4ec922a-latest@sha256:06b24f392ccc383d371c72001520a254edef523bc0bfdc445f487106107b4202
   tags: ["arch:amd64"]
   script:

--- a/.gitlab/build-deploy/.gitlab-ci.yml
+++ b/.gitlab/build-deploy/.gitlab-ci.yml
@@ -218,8 +218,7 @@ build-artifact:
       artifacts: false
       optional: true
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
-      when: never
+    - !reference [.skip-on-release, rules]
     - when: on_success
   tags: [ "arch:amd64" ]
   image: ${BUILD_IMAGE_X64}
@@ -254,8 +253,7 @@ deploy-artifact:
     - job: build:arm64-musl
       artifacts: true
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
-      when: never
+    - !reference [.skip-on-release, rules]
     - when: on_success
   tags: [ "arch:amd64" ]
   image: ${BUILD_IMAGE_X64}
@@ -346,8 +344,7 @@ notify-slack-on-success:
     - job: deploy-artifact
       artifacts: false
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
-      when: never
+    - !reference [.skip-on-release, rules]
     - when: on_success
   image: registry.ddbuild.io/slack-notifier:v91289620-4ec922a-latest@sha256:06b24f392ccc383d371c72001520a254edef523bc0bfdc445f487106107b4202
   tags: ["arch:amd64"]
@@ -363,8 +360,7 @@ notify-slack-on-failure:
     - job: deploy-artifact
       artifacts: true
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
-      when: never
+    - !reference [.skip-on-release, rules]
     - when: on_failure
   image: registry.ddbuild.io/slack-notifier:v91289620-4ec922a-latest@sha256:06b24f392ccc383d371c72001520a254edef523bc0bfdc445f487106107b4202
   tags: ["arch:amd64"]

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -41,6 +41,17 @@
   variables:
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: java-profiler
 
+# Skip a job on release/* branches. build-artifact/deploy-artifact don't run
+# there, so anything that needs: them must also skip there or pipeline
+# creation fails. Splice into a job's own rules with:
+#   rules:
+#     - !reference [.skip-on-release, rules]
+#     - ...
+.skip-on-release:
+  rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
+      when: never
+
 # Install gh and crane when not already present in the image.
 # Extend this in before_script for jobs that need GitHub CLI or crane.
 .bootstrap-gh-tools:

--- a/.gitlab/dd-trace-integration/.gitlab-ci.yml
+++ b/.gitlab/dd-trace-integration/.gitlab-ci.yml
@@ -17,6 +17,8 @@ prepare-patched-agent:
     - job: build-artifact
       artifacts: true
   rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
+      when: never
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
       when: never
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
@@ -87,6 +89,8 @@ prepare-patched-agent:
     - job: prepare-patched-agent
       artifacts: true
   rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
+      when: never
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
       when: never
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
@@ -268,6 +272,8 @@ report-dd-trace-results:
     - job: integration-test-arm64-musl
       artifacts: true
   rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
+      when: never
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
       when: never
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
@@ -296,6 +302,8 @@ post-pr-comment:
     - job: integration-test-arm64-musl
       artifacts: true
   rules:
+    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
+      when: never
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
       when: never
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'

--- a/.gitlab/dd-trace-integration/.gitlab-ci.yml
+++ b/.gitlab/dd-trace-integration/.gitlab-ci.yml
@@ -17,8 +17,7 @@ prepare-patched-agent:
     - job: build-artifact
       artifacts: true
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
-      when: never
+    - !reference [.skip-on-release, rules]
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
       when: never
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
@@ -89,8 +88,7 @@ prepare-patched-agent:
     - job: prepare-patched-agent
       artifacts: true
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
-      when: never
+    - !reference [.skip-on-release, rules]
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
       when: never
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
@@ -272,8 +270,7 @@ report-dd-trace-results:
     - job: integration-test-arm64-musl
       artifacts: true
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
-      when: never
+    - !reference [.skip-on-release, rules]
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
       when: never
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
@@ -302,8 +299,7 @@ post-pr-comment:
     - job: integration-test-arm64-musl
       artifacts: true
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /^release\//'
-      when: never
+    - !reference [.skip-on-release, rules]
     - if: '$JDK_VERSION != null || $DEBUG_LEVEL != null || $HASH != null || $DOWNSTREAM != null'
       when: never
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'

--- a/.gitlab/scripts/deploy.sh
+++ b/.gitlab/scripts/deploy.sh
@@ -48,24 +48,4 @@ if [ "$MODE" = "publish" ] || [ "$MODE" = "all" ]; then
     exit 1
   fi
   ./gradlew -Pskip-native -Pskip-tests -Pddprof_version="${LIB_VERSION}" -PbuildInfo.build.number=$CI_JOB_ID -Pwith-libs="$(pwd)/libs" publishToSonatype closeAndReleaseSonatypeStagingRepository --exclude-task compileFuzzer --max-workers=1 --no-build-cache --stacktrace --info --no-watch-fs --no-daemon
-
-  # Snapshot artifacts publish straight to the Central Portal snapshot repo (no
-  # staging/close/release step), but the repo can take a while to make a freshly
-  # published artifact fetchable. benchmarks-trigger downloads it immediately
-  # after this job succeeds, so poll until it's actually there before returning.
-  if [[ "${LIB_VERSION}" == *-SNAPSHOT ]]; then
-    JAR_URL="https://central.sonatype.com/repository/maven-snapshots/com/datadoghq/ddprof/${LIB_VERSION}/ddprof-${LIB_VERSION}-debug.jar"
-    echo "=== Waiting for snapshot artifact to propagate: ${JAR_URL} ==="
-    for attempt in $(seq 1 20); do
-      if curl -sf -o /dev/null "${JAR_URL}"; then
-        echo "Snapshot artifact available after ${attempt} attempt(s)"
-        break
-      fi
-      if [ "${attempt}" -eq 20 ]; then
-        echo "ERROR: snapshot artifact still not available after ${attempt} attempts"
-        exit 1
-      fi
-      sleep 15
-    done
-  fi
 fi

--- a/.gitlab/scripts/deploy.sh
+++ b/.gitlab/scripts/deploy.sh
@@ -48,20 +48,4 @@ if [ "$MODE" = "publish" ] || [ "$MODE" = "all" ]; then
     exit 1
   fi
   ./gradlew -Pskip-native -Pskip-tests -Pddprof_version="${LIB_VERSION}" -PbuildInfo.build.number=$CI_JOB_ID -Pwith-libs="$(pwd)/libs" publishToSonatype closeAndReleaseSonatypeStagingRepository --exclude-task compileFuzzer --max-workers=1 --no-build-cache --stacktrace --info --no-watch-fs --no-daemon
-
-  # Gradle's maven-publish always uploads snapshots under a unique timestamped
-  # filename (e.g. ddprof-1.2.3-branch-20260804.115820-1-debug.jar); there's no
-  # supported way to opt out of that. Some downstream consumers (e.g. the
-  # benchmarking-platform's downloader) fetch snapshots by the literal
-  # "-SNAPSHOT" filename instead of resolving maven-metadata.xml, so also
-  # publish plain copies of the locally-built jars under that literal name.
-  if [[ "${LIB_VERSION}" == *-SNAPSHOT ]]; then
-    echo "=== Publishing literal-named snapshot copies for non-metadata-aware consumers ==="
-    BASE_URL="https://central.sonatype.com/repository/maven-snapshots/com/datadoghq/ddprof/${LIB_VERSION}"
-    for jar in ddprof-lib/build/libs/ddprof-"${LIB_VERSION}"*.jar; do
-      [ -f "$jar" ] || continue
-      echo "Uploading $(basename "$jar")"
-      curl -sf -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" --upload-file "$jar" "${BASE_URL}/$(basename "$jar")"
-    done
-  fi
 fi

--- a/.gitlab/scripts/deploy.sh
+++ b/.gitlab/scripts/deploy.sh
@@ -48,4 +48,24 @@ if [ "$MODE" = "publish" ] || [ "$MODE" = "all" ]; then
     exit 1
   fi
   ./gradlew -Pskip-native -Pskip-tests -Pddprof_version="${LIB_VERSION}" -PbuildInfo.build.number=$CI_JOB_ID -Pwith-libs="$(pwd)/libs" publishToSonatype closeAndReleaseSonatypeStagingRepository --exclude-task compileFuzzer --max-workers=1 --no-build-cache --stacktrace --info --no-watch-fs --no-daemon
+
+  # Snapshot artifacts publish straight to the Central Portal snapshot repo (no
+  # staging/close/release step), but the repo can take a while to make a freshly
+  # published artifact fetchable. benchmarks-trigger downloads it immediately
+  # after this job succeeds, so poll until it's actually there before returning.
+  if [[ "${LIB_VERSION}" == *-SNAPSHOT ]]; then
+    JAR_URL="https://central.sonatype.com/repository/maven-snapshots/com/datadoghq/ddprof/${LIB_VERSION}/ddprof-${LIB_VERSION}-debug.jar"
+    echo "=== Waiting for snapshot artifact to propagate: ${JAR_URL} ==="
+    for attempt in $(seq 1 20); do
+      if curl -sf -o /dev/null "${JAR_URL}"; then
+        echo "Snapshot artifact available after ${attempt} attempt(s)"
+        break
+      fi
+      if [ "${attempt}" -eq 20 ]; then
+        echo "ERROR: snapshot artifact still not available after ${attempt} attempts"
+        exit 1
+      fi
+      sleep 15
+    done
+  fi
 fi

--- a/.gitlab/scripts/deploy.sh
+++ b/.gitlab/scripts/deploy.sh
@@ -48,4 +48,32 @@ if [ "$MODE" = "publish" ] || [ "$MODE" = "all" ]; then
     exit 1
   fi
   ./gradlew -Pskip-native -Pskip-tests -Pddprof_version="${LIB_VERSION}" -PbuildInfo.build.number=$CI_JOB_ID -Pwith-libs="$(pwd)/libs" publishToSonatype closeAndReleaseSonatypeStagingRepository --exclude-task compileFuzzer --max-workers=1 --no-build-cache --stacktrace --info --no-watch-fs --no-daemon
+
+  # Downstream consumers (e.g. benchmarking-platform's run-benchmarks.sh)
+  # resolve the real timestamped filename via maven-metadata.xml right after
+  # this job finishes. Sonatype needs a little time to index a freshly
+  # published snapshot, so wait until the metadata (and the jar it points to)
+  # are actually resolvable before this job reports success.
+  if [[ "${LIB_VERSION}" == *-SNAPSHOT ]]; then
+    echo "=== Waiting for snapshot artifact to become resolvable on Sonatype ==="
+    META_URL="https://central.sonatype.com/repository/maven-snapshots/com/datadoghq/ddprof/${LIB_VERSION}/maven-metadata.xml"
+    RESOLVED=0
+    for attempt in $(seq 1 20); do
+      SNAPSHOT_VER=$(curl -fsSL "${META_URL}" 2>/dev/null | grep -o '<value>[^<]*</value>' | tail -1 | sed 's/<[^>]*>//g' || true)
+      if [ -n "${SNAPSHOT_VER}" ]; then
+        JAR_URL="https://central.sonatype.com/repository/maven-snapshots/com/datadoghq/ddprof/${LIB_VERSION}/ddprof-${SNAPSHOT_VER}-debug.jar"
+        if curl -fsSL -o /dev/null "${JAR_URL}"; then
+          echo "Snapshot artifact resolvable: ${JAR_URL}"
+          RESOLVED=1
+          break
+        fi
+      fi
+      echo "Attempt ${attempt}/20: snapshot not yet resolvable, retrying in 15s..."
+      sleep 15
+    done
+    if [ "${RESOLVED}" -ne 1 ]; then
+      echo "ERROR: snapshot artifact still not resolvable after 20 attempts" >&2
+      exit 1
+    fi
+  fi
 fi

--- a/.gitlab/scripts/deploy.sh
+++ b/.gitlab/scripts/deploy.sh
@@ -40,6 +40,22 @@ if [ "$MODE" = "assemble" ] || [ "$MODE" = "all" ]; then
   ./gradlew -Pskip-native -Pskip-tests -Pddprof_version="${LIB_VERSION}" -PbuildInfo.build.number=$CI_JOB_ID -Pwith-libs="$(pwd)/libs" :ddprof-lib:jar assembleAll --exclude-task compileFuzzer --exclude-task sign --max-workers=1 --no-build-cache --stacktrace --info --no-watch-fs --no-daemon
 fi
 
+# Resolve the debug/jar classifier's timestamped version from a snapshot's
+# maven-metadata.xml. Only the last matching <snapshotVersion> block is
+# honored so a metadata file listing the same classifier/extension pair more
+# than once can't produce multiple version lines from a single lookup.
+CURL_TIMEOUT_OPTS=(--connect-timeout 10 --max-time 30)
+get_debug_jar_snapshot_version() {
+  curl -fsSL "${CURL_TIMEOUT_OPTS[@]}" "$1" 2>/dev/null | awk '
+    /<snapshotVersion>/ { classifier=""; extension=""; value="" }
+    /<classifier>/ { gsub(/<\/?classifier>/,""); gsub(/^[ \t]+|[ \t]+$/,""); classifier=$0 }
+    /<extension>/ { gsub(/<\/?extension>/,""); gsub(/^[ \t]+|[ \t]+$/,""); extension=$0 }
+    /<value>/ { gsub(/<\/?value>/,""); gsub(/^[ \t]+|[ \t]+$/,""); value=$0 }
+    /<\/snapshotVersion>/ { if (classifier=="debug" && extension=="jar") last=value }
+    END { print last }
+  ' || true
+}
+
 # Publish task (only when publishing to Maven Central)
 if [ "$MODE" = "publish" ] || [ "$MODE" = "all" ]; then
   echo "=== Publishing to Sonatype ==="
@@ -47,38 +63,42 @@ if [ "$MODE" = "publish" ] || [ "$MODE" = "all" ]; then
     echo "ERROR: GPG_PRIVATE_KEY is not set — run the create_key CI job first to provision the signing key in SSM (ci.java-profiler.signing.gpg_private_key)"
     exit 1
   fi
+  META_URL="https://central.sonatype.com/repository/maven-snapshots/com/datadoghq/ddprof/${LIB_VERSION}/maven-metadata.xml"
+  # Record whatever debug/jar version is resolvable *before* publishing so the
+  # post-publish wait below can tell the freshly uploaded build apart from a
+  # preceding one that Sonatype hasn't finished replacing in the metadata yet.
+  PRE_PUBLISH_SNAPSHOT_VER=""
+  if [[ "${LIB_VERSION}" == *-SNAPSHOT ]]; then
+    PRE_PUBLISH_SNAPSHOT_VER=$(get_debug_jar_snapshot_version "${META_URL}")
+  fi
+
   ./gradlew -Pskip-native -Pskip-tests -Pddprof_version="${LIB_VERSION}" -PbuildInfo.build.number=$CI_JOB_ID -Pwith-libs="$(pwd)/libs" publishToSonatype closeAndReleaseSonatypeStagingRepository --exclude-task compileFuzzer --max-workers=1 --no-build-cache --stacktrace --info --no-watch-fs --no-daemon
 
   # Downstream consumers (e.g. benchmarking-platform's run-benchmarks.sh)
   # resolve the real timestamped filename via maven-metadata.xml right after
   # this job finishes. Sonatype needs a little time to index a freshly
   # published snapshot, so wait until the metadata (and the jar it points to)
-  # are actually resolvable before this job reports success.
+  # are actually resolvable before this job reports success. A version that
+  # matches PRE_PUBLISH_SNAPSHOT_VER is rejected: that's the preceding build's
+  # entry still lingering in the metadata, not the one just uploaded.
   if [[ "${LIB_VERSION}" == *-SNAPSHOT ]]; then
     echo "=== Waiting for snapshot artifact to become resolvable on Sonatype ==="
-    META_URL="https://central.sonatype.com/repository/maven-snapshots/com/datadoghq/ddprof/${LIB_VERSION}/maven-metadata.xml"
     RESOLVED=0
     for attempt in $(seq 1 20); do
-      SNAPSHOT_VER=$(curl -fsSL "${META_URL}" 2>/dev/null | awk '
-        /<snapshotVersion>/ { classifier=""; extension=""; value="" }
-        /<classifier>/ { gsub(/<\/?classifier>/,""); gsub(/^[ \t]+|[ \t]+$/,""); classifier=$0 }
-        /<extension>/ { gsub(/<\/?extension>/,""); gsub(/^[ \t]+|[ \t]+$/,""); extension=$0 }
-        /<value>/ { gsub(/<\/?value>/,""); gsub(/^[ \t]+|[ \t]+$/,""); value=$0 }
-        /<\/snapshotVersion>/ { if (classifier=="debug" && extension=="jar") print value }
-      ' || true)
-      if [ -n "${SNAPSHOT_VER}" ]; then
+      SNAPSHOT_VER=$(get_debug_jar_snapshot_version "${META_URL}")
+      if is_new_snapshot_version "${SNAPSHOT_VER}" "${PRE_PUBLISH_SNAPSHOT_VER}"; then
         JAR_URL="https://central.sonatype.com/repository/maven-snapshots/com/datadoghq/ddprof/${LIB_VERSION}/ddprof-${SNAPSHOT_VER}-debug.jar"
-        if curl -fsSL -o /dev/null "${JAR_URL}"; then
+        if curl -fsSL "${CURL_TIMEOUT_OPTS[@]}" -o /dev/null "${JAR_URL}"; then
           echo "Snapshot artifact resolvable: ${JAR_URL}"
           RESOLVED=1
           break
         fi
       fi
-      echo "Attempt ${attempt}/20: snapshot not yet resolvable, retrying in 15s..."
+      echo "Attempt ${attempt}/20: newly published snapshot not yet resolvable, retrying in 15s..."
       sleep 15
     done
     if [ "${RESOLVED}" -ne 1 ]; then
-      echo "ERROR: snapshot artifact still not resolvable after 20 attempts" >&2
+      echo "ERROR: newly published snapshot artifact still not resolvable after 20 attempts" >&2
       exit 1
     fi
   fi

--- a/.gitlab/scripts/deploy.sh
+++ b/.gitlab/scripts/deploy.sh
@@ -48,4 +48,20 @@ if [ "$MODE" = "publish" ] || [ "$MODE" = "all" ]; then
     exit 1
   fi
   ./gradlew -Pskip-native -Pskip-tests -Pddprof_version="${LIB_VERSION}" -PbuildInfo.build.number=$CI_JOB_ID -Pwith-libs="$(pwd)/libs" publishToSonatype closeAndReleaseSonatypeStagingRepository --exclude-task compileFuzzer --max-workers=1 --no-build-cache --stacktrace --info --no-watch-fs --no-daemon
+
+  # Gradle's maven-publish always uploads snapshots under a unique timestamped
+  # filename (e.g. ddprof-1.2.3-branch-20260804.115820-1-debug.jar); there's no
+  # supported way to opt out of that. Some downstream consumers (e.g. the
+  # benchmarking-platform's downloader) fetch snapshots by the literal
+  # "-SNAPSHOT" filename instead of resolving maven-metadata.xml, so also
+  # publish plain copies of the locally-built jars under that literal name.
+  if [[ "${LIB_VERSION}" == *-SNAPSHOT ]]; then
+    echo "=== Publishing literal-named snapshot copies for non-metadata-aware consumers ==="
+    BASE_URL="https://central.sonatype.com/repository/maven-snapshots/com/datadoghq/ddprof/${LIB_VERSION}"
+    for jar in ddprof-lib/build/libs/ddprof-"${LIB_VERSION}"*.jar; do
+      [ -f "$jar" ] || continue
+      echo "Uploading $(basename "$jar")"
+      curl -sf -u "${SONATYPE_USERNAME}:${SONATYPE_PASSWORD}" --upload-file "$jar" "${BASE_URL}/$(basename "$jar")"
+    done
+  fi
 fi

--- a/.gitlab/scripts/deploy.sh
+++ b/.gitlab/scripts/deploy.sh
@@ -59,7 +59,13 @@ if [ "$MODE" = "publish" ] || [ "$MODE" = "all" ]; then
     META_URL="https://central.sonatype.com/repository/maven-snapshots/com/datadoghq/ddprof/${LIB_VERSION}/maven-metadata.xml"
     RESOLVED=0
     for attempt in $(seq 1 20); do
-      SNAPSHOT_VER=$(curl -fsSL "${META_URL}" 2>/dev/null | grep -o '<value>[^<]*</value>' | tail -1 | sed 's/<[^>]*>//g' || true)
+      SNAPSHOT_VER=$(curl -fsSL "${META_URL}" 2>/dev/null | awk '
+        /<snapshotVersion>/ { classifier=""; extension=""; value="" }
+        /<classifier>/ { gsub(/<\/?classifier>/,""); gsub(/^[ \t]+|[ \t]+$/,""); classifier=$0 }
+        /<extension>/ { gsub(/<\/?extension>/,""); gsub(/^[ \t]+|[ \t]+$/,""); extension=$0 }
+        /<value>/ { gsub(/<\/?value>/,""); gsub(/^[ \t]+|[ \t]+$/,""); value=$0 }
+        /<\/snapshotVersion>/ { if (classifier=="debug" && extension=="jar") print value }
+      ' || true)
       if [ -n "${SNAPSHOT_VER}" ]; then
         JAR_URL="https://central.sonatype.com/repository/maven-snapshots/com/datadoghq/ddprof/${LIB_VERSION}/ddprof-${SNAPSHOT_VER}-debug.jar"
         if curl -fsSL -o /dev/null "${JAR_URL}"; then

--- a/.gitlab/scripts/includes.sh
+++ b/.gitlab/scripts/includes.sh
@@ -53,6 +53,12 @@ function setup_java_home() {
   echo "Using Java @ ${JAVA_HOME}"
 }
 
+function is_new_snapshot_version() {
+  local candidate="$1"
+  local baseline="$2"
+  [ -n "${candidate}" ] && [ "${candidate}" != "${baseline}" ]
+}
+
 function collect_artifacts() {
   local target=$1
   local artifact_type=$2  # "test" or "stresstest"

--- a/.gitlab/scripts/tests/includes_test.sh
+++ b/.gitlab/scripts/tests/includes_test.sh
@@ -1,0 +1,54 @@
+#! /bin/bash
+# Minimal, dependency-free unit tests for .gitlab/scripts/includes.sh helpers.
+# Run with: bash .gitlab/scripts/tests/includes_test.sh
+
+set -eo pipefail
+
+HERE=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${HERE}/../includes.sh"
+
+FAILED=0
+
+assert_true() {
+  local desc="$1"
+  shift
+  if "$@"; then
+    echo "PASS: ${desc}"
+  else
+    echo "FAIL: ${desc} — expected success"
+    FAILED=1
+  fi
+}
+
+assert_false() {
+  local desc="$1"
+  shift
+  if "$@"; then
+    echo "FAIL: ${desc} — expected failure"
+    FAILED=1
+  else
+    echo "PASS: ${desc}"
+  fi
+}
+
+# A freshly published snapshot version differs from the pre-publish baseline
+# and must be accepted.
+assert_true "differing candidate is accepted as new" \
+  is_new_snapshot_version "20260101.120000-5" "20260101.100000-3"
+
+# The metadata still pointing at the pre-publish baseline is stale and must
+# be rejected — this is the guard the retry loop in deploy.sh relies on.
+assert_false "candidate matching baseline is rejected as stale" \
+  is_new_snapshot_version "20260101.100000-3" "20260101.100000-3"
+
+# An empty candidate (metadata not resolvable yet) must be rejected
+# regardless of the baseline.
+assert_false "empty candidate is rejected" \
+  is_new_snapshot_version "" "20260101.100000-3"
+
+# An empty baseline (no prior publish) plus any non-empty candidate must be
+# accepted.
+assert_true "non-empty candidate with empty baseline is accepted" \
+  is_new_snapshot_version "20260101.120000-5" ""
+
+exit "${FAILED}"


### PR DESCRIPTION
**What does this PR do?**:
`build-artifact` and `deploy-artifact` already skip on `release/*` branches (added in #548), but the jobs that `needs:` them — `prepare-patched-agent`, the four `integration-test-*` matrix jobs, `report-dd-trace-results`, `post-pr-comment`, `benchmarks-trigger`, and `notify-slack-on-success`/`notify-slack-on-failure` — still needed them unconditionally. GitLab requires every `needs:` target to exist in the pipeline or be marked `optional: true`, so pipeline creation failed outright on `release/*` branches. This adds the same `release/*` skip rule to all of those dependent jobs.

**Motivation**:
GitLab CI rejected pipeline creation on `release/*` branches with errors like:
`'prepare-patched-agent' job needs 'build-artifact' job, but 'build-artifact' does not exist in the pipeline.`

**Additional Notes**:
`notify-slack-on-success`/`notify-slack-on-failure` used a bare `when:` rather than `rules:`, so those were converted to `rules:` (GitLab doesn't allow both) with the same `release/*` exclusion added.

**How to test the change?**:
- [x] Validated all three edited YAML files parse (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] Push/trigger a pipeline on a `release/*` branch and confirm it creates successfully

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [x] This PR doesn't touch any of that.
- [ ] JIRA: N/A

Unsure? Have a question? Request a review!