### PR TITLE
Remove dead Lookup::_class_cache

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -672,22 +672,6 @@ MethodInfo *Lookup::resolveMethod(ASGCT_CallFrame &frame) {
   return mi;
 }
 
-void Lookup::initClassCache() {
-  // Snapshot _classes into _class_cache for use by resolveMethod(BCI_ALLOC).
-  // Must be called before writeStackTraces() so the snapshot covers all
-  // vtable-receiver classes (pre-registered before profiling starts).
-  // This snapshot is intentionally NOT used by writeClasses(): regular Java
-  // classes are inserted into _classes by fillJavaMethodInfo() during
-  // writeStackTraces/writeMethods, so writeClasses() must re-collect after
-  // those passes to obtain the complete class pool.
-  // standby() is the post-rotate snapshot of _classes; collect() copies its
-  // entries with no concurrent writers (rotate drained them).  The shared
-  // classMapSharedGuard is held for any concurrent #527 vtable readers that
-  // also touch _classes directly via lookup() on active.
-  auto guard = Profiler::instance()->classMapSharedGuard();
-  _classes->standby()->collect(_class_cache);
-}
-
 u32 Lookup::getPackage(const char *class_name) {
   const char *package = strrchr(class_name, '/');
   if (package == NULL) {
@@ -1503,13 +1487,11 @@ int Recording::writeCpool(Buffer *buf, int *count_offset_in_cpool) {
   // Profiler::rotateDictsAndRun() rotates the three dictionaries before this
   // path runs, so classMap()->standby() returns an old-active snapshot stable
   // for the lifetime of writeCpool().
-  // initClassCache() seeds vtable-receiver class names for resolveMethod(BCI_ALLOC).
-  // writeClasses() then collects the COMPLETE class set from standby(): regular Java
+  // writeClasses() collects the COMPLETE class set from standby(): regular Java
   // classes are inserted into the new-active by fillJavaMethodInfo during
   // writeStackTraces/writeMethods, and those would not appear in the snapshot —
   // standby() captures the pre-rotation state which writeClasses extends.
   Lookup lookup(this, &_method_map, Profiler::instance()->classMap());
-  lookup.initClassCache();
   // CONSTANT pools: always non-empty, always emitted -> 5 sections.
   // writeThreads always emits: it inserts _tid unconditionally before checking.
   writeFrameTypes(buf);

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -358,7 +358,6 @@ public:
   Recording *_rec;
   MethodMap *_method_map;
   StringDictionary *_classes;
-  std::map<u32, const char*> _class_cache;  // snapshot of _classes->standby() at dump time
   // Per-dump VMSymbol* -> resolved class_id cache for BCI_VTABLE_RECEIVER
   // frames. Two purposes: (1) amortise the SafeAccess work to once per
   // distinct Symbol pointer per dump; (2) the resolved class_id is used
@@ -406,14 +405,6 @@ public:
   Lookup(Recording *rec, MethodMap *method_map, StringDictionary *classes)
       : _rec(rec), _method_map(method_map), _classes(classes), _packages(),
         _symbols() {}
-
-  // Call once before writeStackTraces.  Populates _class_cache from
-  // _classes->standby() under the shared lock.  NOTE: _class_cache is
-  // currently write-only — writeClasses() re-collects from standby() and
-  // resolveMethod() inserts via lookupDuringDump() rather than reading
-  // this cache.  Kept for compatibility with #527's API and as a hook
-  // for future readers; safe to remove if no consumer materialises.
-  void initClassCache();
 
   MethodInfo *resolveMethod(ASGCT_CallFrame &frame);
   u32 getPackage(const char *class_name);

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1452,10 +1452,8 @@ Error Profiler::start(Arguments &args, bool reset) {
     memset(_failures, 0, sizeof(_failures));
 
     // Reset dictionaries. StringDictionary::clearAll() manages its own
-    // synchronisation (RefCountGuard drain). The exclusive _class_map_lock
-    // additionally fences out shared-lock readers introduced by #527
-    // (deferred vtable receiver resolution) so they cannot observe a
-    // half-cleared class map.
+    // synchronisation (RefCountGuard drain) internally; _class_map_lock is
+    // held exclusively here for the duration of the reset.
     {
       ExclusiveLockGuard guard(&_class_map_lock);
       _class_map.clearAll();
@@ -1887,9 +1885,7 @@ Error Profiler::dump(const char *path, const int length) {
     // rotateDictsAndRun rotates the dictionaries, takes lockAll() around the
     // dump (fences ASGCT/JNI writers to CallTraceStorage), then clearStandby()s
     // the rotated buffers.  StringDictionary's RefCountGuard protocol handles
-    // its own writer/reader coordination; #527's classMapSharedGuard readers
-    // (deferred vtable receiver resolution) are coordinated through
-    // _class_map_lock.
+    // its own writer/reader coordination.
     rotateDictsAndRun([&]{
       err = _jfr.dump(path, length);
       __atomic_add_fetch(&_epoch, 1, __ATOMIC_SEQ_CST);

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -292,7 +292,6 @@ public:
   // insertions (Lookup::_classes->lookupDuringDump in flightRecorder.cpp)
   // must use this too so _class_map cannot grow past it via that path.
   static int maxClassMapSize() { return MAX_CLASS_MAP_SIZE; }
-  SharedLockGuard classMapSharedGuard() { return SharedLockGuard(&_class_map_lock); }
   StringDictionary *stringLabelMap() { return &_string_label_map; }
   StringDictionary *contextValueMap() { return &_context_value_map; }
   // Atomically reads and clears the "context value dictionary was reset" flag (see the member).


### PR DESCRIPTION
## Summary
- `Lookup::_class_cache` (a `std::map<u32, const char*>`) and its populator `initClassCache()` are write-only: a full-repo search finds no reader anywhere.
- The call site's own comment claims it "seeds vtable-receiver class names for resolveMethod(BCI_ALLOC)", but that path actually resolves through the separate `_vtable_receiver_cache` / `resolveVTableReceiverCached()` — this map plays no role in it. Looks like leftover from an earlier version of the vtable-receiver feature that was superseded.
- Every JFR chunk dump was paying to snapshot the entire class table into this map just to discard it.

## Test plan
- [x] `./gradlew :ddprof-lib:compileRelease` — all 66 C++ sources compile clean
- [x] `./gradlew :ddprof-lib:gtestRelease_flightRecorder_result_ut :ddprof-lib:gtestRelease_lineNumberTableCopy_ut :ddprof-lib:gtestRelease_methodInfo_hash_ut :ddprof-lib:gtestRelease_methodMapId_ut` — all pass
- [x] repo-wide grep for `_class_cache`/`initClassCache` confirms no remaining references

🤖 Generated with [Claude Code](https://claude.com/claude-code)