### PR TITLE
Remove duplicated SpinLock Exclusive/Shared Locker

### DIFF
--- a/ddprof-lib/src/main/cpp/spinLock.h
+++ b/ddprof-lib/src/main/cpp/spinLock.h
@@ -34,7 +34,7 @@ public:
   explicit constexpr SpinLock(int initial_state = 0) : _lock(initial_state), _padding() {
     static_assert(sizeof(SpinLock) == DEFAULT_CACHE_LINE_SIZE);
   }
-  // No-copyable
+  // Non-copyable
   SpinLock(const SpinLock&) = delete;
   SpinLock& operator=(const SpinLock&) = delete;
 

--- a/ddprof-lib/src/main/cpp/spinLock.h
+++ b/ddprof-lib/src/main/cpp/spinLock.h
@@ -34,6 +34,9 @@ public:
   explicit constexpr SpinLock(int initial_state = 0) : _lock(initial_state), _padding() {
     static_assert(sizeof(SpinLock) == DEFAULT_CACHE_LINE_SIZE);
   }
+  // No-copyable
+  SpinLock(const SpinLock&) = delete;
+  SpinLock& operator=(const SpinLock&) = delete;
 
   void reset() { __atomic_store_n(&_lock, 0, __ATOMIC_RELAXED); }
 

--- a/ddprof-lib/src/main/cpp/unwindStats.h
+++ b/ddprof-lib/src/main/cpp/unwindStats.h
@@ -156,36 +156,6 @@ class UnwindFailures {
    }
 };
 
-class ExclusiveLock {
- private:
-  SpinLock &_lock;
- public:
-  ExclusiveLock(SpinLock &lock) : _lock(lock) {
-    _lock.lock();
-  }
-  ~ExclusiveLock() {
-    _lock.unlock();
-  }
-
-  ExclusiveLock(const ExclusiveLock &) = delete;
-  ExclusiveLock &operator=(const ExclusiveLock &) = delete;
-};
-
-class SharedLock {
- private:
-  SpinLock &_lock;
- public:
-  SharedLock(SpinLock &lock) : _lock(lock) {
-    _lock.lockShared();
-  }
-  ~SharedLock() {
-    _lock.unlockShared();
-  }
-
-  SharedLock(const SharedLock &) = delete;
-  SharedLock &operator=(const SharedLock &) = delete;
-};
-
 class UnwindStats
 {
  private:
@@ -206,17 +176,17 @@ class UnwindStats
   }
 
   static u64 countFailures(const char* name, UnwindFailureKind kind = UNWIND_FAILURE_ANY) {
-    SharedLock l(_lock);
+    SharedLockGuard l(&_lock);
     return _unwind_failures.count(name, kind);
   }
 
   static void collectAndReset(UnwindFailures& result) {
-    ExclusiveLock l(_lock);
+    ExclusiveLockGuard l(&_lock);
     result.swap(_unwind_failures);
   }
 
   static void reset() {
-    ExclusiveLock l(_lock);
+    ExclusiveLockGuard l(&_lock);
     _unwind_failures.clear();
   }
 };


### PR DESCRIPTION
**What does this PR do?**:
Removed duplicated implementation of `SpinLock`'s `ExclusiveLock/SharedLock` and make `SpinLock` no-copyable.

**Motivation**:
- Remove code duplication
- Avoid misuse of `SpinLock`

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
Passed existing CI tests

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-15691](https://datadoghq.atlassian.net/browse/PROF-15691)

Unsure? Have a question? Request a review!


[PROF-15691]: https://datadoghq.atlassian.net/browse/PROF-15691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ