### PR TITLE
Fix entry resolution for main(String[]) method

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -273,7 +273,7 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         // Clear any exceptions from the reflection calls above
         jniExceptionCheck(jni);
       } else if (strncmp(method_name, "main", 5) == 0 &&
-                 strncmp(method_sig, "(Ljava/lang/String;)V", 21) == 0) {
+                 strncmp(method_sig, "([Ljava/lang/String;)V", 22) == 0) {
         // public static void main(String[] args) - 'public static' translates
         // to modifier bits 0 and 3, hence check for '9'
         entry = true;

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -273,7 +273,7 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         // Clear any exceptions from the reflection calls above
         jniExceptionCheck(jni);
       } else if (strncmp(method_name, "main", 5) == 0 &&
-                 strncmp(method_sig, "(Ljava/lang/String;)V", 21)) {
+                 strncmp(method_sig, "(Ljava/lang/String;)V", 21) == 0) {
         // public static void main(String[] args) - 'public static' translates
         // to modifier bits 0 and 3, hence check for '9'
         entry = true;


### PR DESCRIPTION
**What does this PR do?**:
Fix a logic error in resolving `main(String[])` entry frame.


**Motivation**:
Bug fix.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
Regular CI

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-15781](https://datadoghq.atlassian.net/browse/PROF-15781)

Unsure? Have a question? Request a review!


[PROF-15781]: https://datadoghq.atlassian.net/browse/PROF-15781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ