### PR TITLE
Protect HotspotSupport::resolve() with longjmp

### DIFF
--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -134,6 +134,17 @@
   X(SAFECOPY_FAILED, "safecopy_failed")                                       \
   X(SAFEFETCH_FAILED, "safefetch_failed")                                     \
   X(STACKWALK_LONGJMP_RECOVERED, "stackwalk_longjmp_recovered")               \
+  /* Dump-time raw-Method* resolution (HotspotSupport::resolve, reached only    \
+   * for cstack=vm + fjmethodid=false frames). NOT additive with               \
+   * STACKWALK_LONGJMP_RECOVERED: checkFault() bumps that one unconditionally  \
+   * before every siglongjmp, so each fault counted here is counted there too. \
+   * Subtract, never sum. Non-zero means stale HotSpot metadata (GC or class   \
+   * unloading) reached the dump thread; the frame serializes as "unknown". */ \
+  X(METHOD_RESOLVE_FAULT_RECOVERED, "method_resolve_fault_recovered")         \
+  /* Symbol length/body rejected during the same resolution: unreadable,       \
+   * empty, or longer than the fixed dump-time buffers in hotspotSupport.cpp.  \
+   * The frame serializes as "unknown". */                                     \
+  X(METHOD_RESOLVE_SYMBOL_UNREADABLE, "method_resolve_symbol_unreadable")     \
   /* Strict subset of SAMPLES_DROPPED_THREAD_LOCAL, not an independent count: \
    * ThreadLocalDataPool::claim() increments this on capacity exhaustion, and \
    * every acquireCurrent() caller that gets nullptr back -- for this or any  \

--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -141,9 +141,11 @@
    * Subtract, never sum. Non-zero means stale HotSpot metadata (GC or class   \
    * unloading) reached the dump thread; the frame serializes as "unknown". */ \
   X(METHOD_RESOLVE_FAULT_RECOVERED, "method_resolve_fault_recovered")         \
-  /* Symbol length/body rejected during the same resolution: unreadable,       \
-   * empty, or longer than the fixed dump-time buffers in hotspotSupport.cpp.  \
-   * The frame serializes as "unknown". */                                     \
+  /* Symbol length/body rejected during the same resolution: unreadable body,  \
+   * empty (recycled slot), or over MAX_SYMBOL_LEN. A name that merely exceeds \
+   * the fixed inline buffers in hotspotSupport.cpp's ResolvedNames still      \
+   * resolves via its malloc fallback and does not land here. The frame        \
+   * serializes as "unknown". */                                               \
   X(METHOD_RESOLVE_SYMBOL_UNREADABLE, "method_resolve_symbol_unreadable")     \
   /* Strict subset of SAMPLES_DROPPED_THREAD_LOCAL, not an independent count: \
    * ThreadLocalDataPool::claim() increments this on capacity exhaustion, and \

--- a/ddprof-lib/src/main/cpp/guards.cpp
+++ b/ddprof-lib/src/main/cpp/guards.cpp
@@ -104,3 +104,39 @@ CriticalSection::~CriticalSection() {
         _thread_ptr->exitCriticalSection();
     }
 }
+
+
+// Reads the currently installed landing pad, asserting the non-null contract
+// *before* the pointer is dereferenced. This lives in a helper rather than the
+// constructor body because the mem-initialiser for _prev runs first, so an
+// assert in the body would only fire after the deref it is meant to guard.
+static sigjmp_buf* prevJmpCtxOf(ProfiledThread* pt) {
+    assert(pt != nullptr);
+    return pt->getJmpCtx();
+}
+
+JmpCtxScope::JmpCtxScope(ProfiledThread* pt) : _pt(pt), _prev(prevJmpCtxOf(pt)) {}
+
+// Unconditional store, deliberately not guarded by an "already restored" flag;
+// see restore().
+JmpCtxScope::~JmpCtxScope() {
+    _pt->setJmpCtx(_prev);
+}
+
+void JmpCtxScope::install(sigjmp_buf* ctx) {
+    _pt->setJmpCtx(ctx);
+}
+
+// Idempotent with the destructor by construction: _prev is const, so this is
+// the same store every time it runs. No mutable "restored" flag is used -- and
+// none may be added -- because this object is an automatic local of the frame
+// that owns the sigjmp_buf, so any member mutated between sigsetjmp() and
+// siglongjmp() would have an indeterminate value at the landing pad.
+//
+// Nesting stays correct without a flag: scopes are automatic objects, so
+// construction/destruction is strictly LIFO and each constructor snapshots
+// getJmpCtx() at its own construction time. An outer scope's destructor can
+// therefore never clobber a context installed by an inner one.
+void JmpCtxScope::restore() {
+    _pt->setJmpCtx(_prev);
+}

--- a/ddprof-lib/src/main/cpp/guards.cpp
+++ b/ddprof-lib/src/main/cpp/guards.cpp
@@ -120,7 +120,7 @@ JmpCtxScope::JmpCtxScope(ProfiledThread* pt) : _pt(pt), _prev(prevJmpCtxOf(pt)) 
 // Unconditional store, deliberately not guarded by an "already restored" flag;
 // see restore().
 JmpCtxScope::~JmpCtxScope() {
-    _pt->setJmpCtx(_prev);
+   restore();
 }
 
 void JmpCtxScope::install(sigjmp_buf* ctx) {

--- a/ddprof-lib/src/main/cpp/guards.h
+++ b/ddprof-lib/src/main/cpp/guards.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <cstddef>
+#include <setjmp.h>
 #include <signal.h>
 #include <pthread.h>
 
@@ -190,6 +191,61 @@ public:
 
     // Check if this instance successfully entered the critical section
     bool entered() const { return _entered; }
+};
+
+// RAII for the per-thread siglongjmp landing pad (ProfiledThread::_jmp_buf)
+// that Profiler::checkFault() jumps through.
+//
+// The previous landing pad must be reinstated on *every* exit from the frame
+// that owns the sigjmp_buf -- normal return, a siglongjmp back into it, or an
+// exception unwinding out of it -- because checkFault() will happily jump into
+// a landing pad whose stack frame has already been popped. Hand-rolled
+// "setJmpCtx(prev) before each return" only covers the returns the author
+// remembered.
+//
+// Both members are const and initialised before the owning frame calls
+// sigsetjmp(), and install()/restore() mutate only the ProfiledThread, so the
+// guard's own state is never modified between sigsetjmp() and siglongjmp().
+// Reading it from the landing pad is therefore well defined -- unlike a plain
+// non-volatile local, whose value after siglongjmp is indeterminate if it was
+// assigned in the meantime.
+//
+// Usage:
+//   sigjmp_buf ctx;
+//   JmpCtxScope jmp_scope(prof_thread);       // pt must be non-null
+//   if (sigsetjmp(ctx, 1) != 0) {             // savemask=1: see note below
+//     SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP();
+//     jmp_scope.restore();                    // disarm before anything else
+//     return recovery_value;
+//   }
+//   jmp_scope.install(&ctx);
+//   ... risky work ...
+//
+// The one unsupported pattern: calling restore() and then installing a
+// different sigjmp_buf in the same frame without a fresh JmpCtxScope. The
+// guard only ever reinstates the context that was live when it was
+// constructed, so use one scope per sigjmp_buf.
+//
+// savemask must be 1: the siglongjmp originates inside the SIGSEGV handler,
+// where the kernel has SIGSEGV blocked, so without restoring the saved mask the
+// signal would stay blocked and the next fault on this thread would be fatal.
+class JmpCtxScope {
+public:
+    // `pt` must be non-null.
+    explicit JmpCtxScope(ProfiledThread* pt);
+    ~JmpCtxScope();
+    // Publish `ctx` as this thread's landing pad; call after sigsetjmp()
+    // returns 0.
+    void install(sigjmp_buf* ctx);
+    // Reinstate the previous landing pad now. Idempotent with the destructor,
+    // so it is safe (and required) to call from the sigsetjmp landing pad
+    // before touching anything that could fault again.
+    void restore();
+    JmpCtxScope(const JmpCtxScope&)            = delete;
+    JmpCtxScope& operator=(const JmpCtxScope&) = delete;
+private:
+    ProfiledThread* const _pt;
+    sigjmp_buf* const _prev;
 };
 
 /**

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
@@ -1437,6 +1437,165 @@ bool HotspotSupport::loadMethodIDsIfNeededImpl(jvmtiEnv *jvmti, JNIEnv *jni, jcl
     return JVMSupport::loadMethodIDsImpl(jvmti, jni, klass);
 }
 
+// Fixed dump-time buffers, replacing the malloc/free trio this function used to
+// carry. HotSpot's Symbol length field is a u2, so the VM permits up to 65535
+// bytes; these caps trade that theoretical maximum for zero heap traffic on the
+// dump path and, more importantly, for having no cleanup obligation inside the
+// crash-protected region -- a siglongjmp out of resolve() cannot leak anything.
+// 4096 mirrors Lookup::resolveVTableReceiverCached (flightRecorder.cpp), which
+// reads the same Symbol bodies on the same thread. A symbol over its cap reports
+// METHOD_RESOLVE_SYMBOL_UNREADABLE and serializes as "unknown" -- the same
+// outcome as a class FindClass cannot see.
+static const size_t MAX_KLASS_NAME_LEN  = 4096;  // internal names; realistically < 256
+static const size_t MAX_METHOD_NAME_LEN =  512;  // realistically < 64
+// A descriptor can in principle exceed this (255 argument *slots*, each able to
+// carry an arbitrarily long L...; type name), so this cap is a fidelity choice,
+// not a proof: over-cap descriptors serialize as "unknown" rather than being
+// truncated. METHOD_RESOLVE_SYMBOL_UNREADABLE makes it visible if that bites.
+static const size_t MAX_SIGNATURE_LEN   = 4096;
+
+// Copies a Symbol's body into a fixed buffer, NUL-terminating it.
+// Must be called with crash protection installed: length() and body()
+// dereference the Symbol directly with no safefetch.
+static bool copySymbolBody(VMSymbol* sym, char* dst, size_t cap) {
+  unsigned len = sym->length();  // raw u2 deref; PC stays inside this library
+  // A method name, descriptor or class name is never empty; 0 means the Symbol
+  // slot has been recycled. `>=` leaves room for the NUL.
+  if (len == 0 || len >= cap) {
+    return false;
+  }
+  const char* body = sym->body();
+  if (!SafeAccess::safeCopy(dst, body, len)) {
+    return false;
+  }
+  dst[len] = '\0';
+  return true;
+}
+
+// The three names resolve() needs, owned by resolve()'s frame so that the
+// metadata walk has no cleanup obligation of its own.
+struct ResolvedNames {
+  char method_name[MAX_METHOD_NAME_LEN];
+  char method_signature[MAX_SIGNATURE_LEN];
+  char klass_name[MAX_KLASS_NAME_LEN];
+};
+
+// PHASE 1 -- the raw HotSpot metadata walk. MUST run with a jmp ctx installed:
+// every step is a raw *(void**)(this + offset) whose target may have been freed
+// by GC or class unloading since the sample was taken. Deliberately contains no
+// JNI, no JVMTI and no allocation, so the whole protected region stays inside
+// this library, where Profiler::checkFault() can actually recover.
+//
+// Returns false if the metadata is unusable. On success either *out_id holds an
+// already-valid jmethodID (and `names` is untouched), or *out_id is null and
+// `names` has been filled in for the JNI lookup the caller does afterwards.
+static bool readMethodNames(const void* method, VMMethod** out_vm_method,
+                            jmethodID* out_id, ResolvedNames* names) {
+  *out_vm_method = nullptr;
+  *out_id = nullptr;
+
+  VMMethod* vm_method = VMMethod::cast_or_null(method);
+  if (vm_method == nullptr) {
+    return false;
+  }
+  *out_vm_method = vm_method;
+
+  // May have been populated by following code or JMETHODID_NOT_WALKABLE
+  jmethodID method_id = vm_method->validatedId();
+  if (isValidJMethodID(method_id)) {
+    *out_id = method_id;
+    return true;
+  }
+
+  VMConstMethod* const_method = vm_method->constMethod_or_null();
+  if (const_method == nullptr) {
+    return false;
+  }
+
+  VMConstantPool* const_pool = const_method->constants_or_null();
+  if (const_pool == nullptr) {
+    return false;
+  }
+
+  VMSymbol* name_sym = const_method->name();
+  VMSymbol* sig_sym = const_method->signature();
+  VMKlass* klass = const_pool->holder_or_null();
+
+  if (name_sym == nullptr || sig_sym == nullptr || klass == nullptr) {
+    return false;
+  }
+
+  VMSymbol* klass_sym = klass->name();
+  if (klass_sym == nullptr) {
+    return false;
+  }
+
+  if (!copySymbolBody(name_sym, names->method_name, sizeof(names->method_name)) ||
+      !copySymbolBody(sig_sym, names->method_signature, sizeof(names->method_signature)) ||
+      !copySymbolBody(klass_sym, names->klass_name, sizeof(names->klass_name))) {
+    Counters::increment(METHOD_RESOLVE_SYMBOL_UNREADABLE);
+    return false;
+  }
+  return true;
+}
+
+// PHASE 2 -- the JNI/JVMTI lookup, reading only the buffers phase 1 filled.
+// MUST run with crash protection *off*. Two reasons, both about siglongjmp
+// unwinding frames it must not:
+//   - A fault inside libjvm.so is unrecoverable anyway (checkFault() only
+//     recovers PCs inside this library), so a landing pad buys nothing here.
+//   - FindClass() loads the class when it is not already loaded, which
+//     synchronously runs our own JVMTI ClassPrepare callback ->
+//     patchClassLoaderData(), which holds the JVM's ClassLoaderData mutex. That
+//     code *is* in this library, so with a pad installed a fault there would
+//     siglongjmp out of a JVMTI callback with a JVM lock held, an abandoned JNI
+//     local frame and unbalanced safepoint state -- trading a crash for a
+//     JVM-wide deadlock.
+// vm_method->validatedId() below is safefetch-based, so it is safe unprotected.
+static jmethodID lookupMethodIdViaJni(VMMethod* vm_method, const ResolvedNames& names) {
+  jmethodID method_id = nullptr;
+  const char* method_name = names.method_name;
+  const char* method_signature = names.method_signature;
+  const char* klass_name = names.klass_name;
+
+  JNIEnv *jni = VM::jni();
+  jclass clz = jni->FindClass(klass_name);
+  if (clz == nullptr) {
+    jni->ExceptionClear();
+  } else {
+    method_id = jni->GetMethodID(clz, method_name, method_signature);
+    if (method_id == nullptr) {
+      jni->ExceptionClear();
+      method_id = jni->GetStaticMethodID(clz, method_name, method_signature);
+      if (method_id == nullptr) {
+        jni->ExceptionClear();
+        // JNI GetMethodID/GetStaticMethodID cannot look up <clinit> because
+        // the JVM intentionally hides class initializers from JNI callers.
+        // Fall back to JVMTI GetClassMethods, which covers all methods
+        // including <clinit> and forces jmethodID slot allocation for them.
+        // After the call, re-read the ID directly from VM metadata.
+        if (strcmp(method_name, "<clinit>") == 0) {
+          jvmtiEnv* jvmti = VM::jvmti();
+          if (jvmti != nullptr) {
+            jint count = 0;
+            jmethodID* methods = nullptr;
+            if (jvmti->GetClassMethods(clz, &count, &methods) == JVMTI_ERROR_NONE) {
+              jmethodID validated = vm_method->validatedId();
+              if (isValidJMethodID(validated)) {
+                method_id = validated;
+              }
+              jvmti->Deallocate((unsigned char*)methods);
+            }
+          }
+        }
+      }
+    }
+    jni->DeleteLocalRef(clz);
+  }
+
+  return method_id;
+}
+
 // This method only resolves methods that are loaded by system class loaders
 jmethodID HotspotSupport::resolve(const void* method) {
   assert(VM::isHotspot());
@@ -1448,92 +1607,63 @@ jmethodID HotspotSupport::resolve(const void* method) {
     return nullptr;
   }
 
-  VMMethod* vm_method = VMMethod::cast_or_null(method);
-  if (vm_method == nullptr) {
+  // The Method* was captured at sample time; GC or class unloading may have
+  // freed the metadata since, so every dereference below can fault. Install a
+  // landing pad and report the method as unresolved instead of taking the JVM
+  // down mid-dump -- nullptr is already a first-class result for our caller
+  // (Lookup::resolveMethod serializes it as the shared unknown method).
+  //
+  // Runs on the JFR dump thread (Profiler::dump/stop), not in a signal handler.
+  // acquireCurrent() rather than current() because JNI_OnUnload reaches
+  // Profiler::stop() without priming TLS.
+  ProfiledThread* prof_thread = ProfiledThread::acquireCurrent();
+  if (prof_thread == nullptr) {
+    // No landing pad available, so refuse to touch metadata that may be stale
+    // rather than risk crashing. Reached only on an unprimed shutdown path or
+    // when the thread-local pool is exhausted.
+    Counters::increment(SAMPLES_DROPPED_THREAD_LOCAL);
     return nullptr;
   }
 
-  // May have been populated by following code or JMETHODID_NOT_WALKABLE
-  jmethodID method_id = vm_method->validatedId();
-  if (isValidJMethodID(method_id)) {
-    return method_id;
-  }
+  // Buffers live in this frame so phase 1 has nothing to clean up. None of the
+  // locals below are read on the recovery path, so none of them need to be
+  // volatile despite being assigned between sigsetjmp() and a possible
+  // siglongjmp.
+  ResolvedNames names;
+  VMMethod* vm_method = nullptr;
+  jmethodID existing_id = nullptr;
+  bool walked = false;
 
-  VMConstMethod* const_method = vm_method->constMethod_or_null();
-  if (const_method == nullptr) {
+  {
+    sigjmp_buf crash_protection_ctx;
+    // Chained via JmpCtxScope: the dump thread can be interrupted by a sampling
+    // signal whose walkVM() installs its own context, so the previous landing
+    // pad must be reinstated on every exit path from this frame.
+    JmpCtxScope jmp_scope(prof_thread);
+    // savemask must be 1: the siglongjmp originates inside segvHandler, where
+    // the kernel has SIGSEGV blocked, so without restoring the saved mask the
+    // signal would stay blocked and the next fault on this thread would be
+    // fatal.
+    if (sigsetjmp(crash_protection_ctx, 1) != 0) {
+      // checkFault() does a siglongjmp from inside segvHandler, bypassing
+      // segvHandler's SignalHandlerScope destructor. Compensate, then disarm
+      // before touching anything that could fault again.
+      SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP();
+      jmp_scope.restore();
+      Counters::increment(METHOD_RESOLVE_FAULT_RECOVERED);
+      return nullptr;
+    }
+    jmp_scope.install(&crash_protection_ctx);
+
+    walked = readMethodNames(method, &vm_method, &existing_id, &names);
+  }
+  // --- crash protection is off from here on; see lookupMethodIdViaJni() ---
+
+  if (!walked) {
     return nullptr;
   }
-
-  VMConstantPool* const_pool = const_method->constants_or_null();
-  if (const_pool == nullptr) {
-    return nullptr;
+  if (existing_id != nullptr) {
+    return existing_id;
   }
-
-  VMSymbol* name_sym = const_method->name();
-  VMSymbol* sig_sym = const_method->signature();
-  VMKlass* klass = const_pool->holder_or_null();
-
-  if (name_sym == nullptr || sig_sym == nullptr || klass == nullptr) {
-    return nullptr;
-  }
-
-  VMSymbol* klass_sym = klass->name();
-  if (klass_sym == nullptr) {
-    return nullptr;
-  }
-
-  method_id = nullptr;
-  char* method_name = (char*)malloc(name_sym->length() + 1);
-  char* method_signature = (char*)malloc(sig_sym->length() + 1);
-  int klass_name_len = klass_sym->length();
-  char* klass_name = (char*)malloc(klass_name_len + 1);
-  if (method_name !=nullptr && method_signature != nullptr && klass_name != nullptr) {
-      memcpy(method_name, name_sym->body(), name_sym->length());
-      method_name[name_sym->length()] = '\0';
-      memcpy(method_signature, sig_sym->body(), sig_sym->length());
-      method_signature[sig_sym->length()] = '\0';
-      memcpy(klass_name, klass_sym->body(), klass_name_len);
-      klass_name[klass_name_len] = '\0';
-
-      JNIEnv *jni = VM::jni();
-      jclass clz = jni->FindClass(klass_name);
-      if (clz == nullptr) {
-        jni->ExceptionClear();
-      } else {
-        method_id = jni->GetMethodID(clz, method_name, method_signature);
-        if (method_id == nullptr) {
-          jni->ExceptionClear();
-          method_id = jni->GetStaticMethodID(clz, method_name, method_signature);
-          if (method_id == nullptr) {
-            jni->ExceptionClear();
-            // JNI GetMethodID/GetStaticMethodID cannot look up <clinit> because
-            // the JVM intentionally hides class initializers from JNI callers.
-            // Fall back to JVMTI GetClassMethods, which covers all methods
-            // including <clinit> and forces jmethodID slot allocation for them.
-            // After the call, re-read the ID directly from VM metadata.
-            if (strcmp(method_name, "<clinit>") == 0) {
-              jvmtiEnv* jvmti = VM::jvmti();
-              if (jvmti != nullptr) {
-                jint count = 0;
-                jmethodID* methods = nullptr;
-                if (jvmti->GetClassMethods(clz, &count, &methods) == JVMTI_ERROR_NONE) {
-                  jmethodID validated = vm_method->validatedId();
-                  if (isValidJMethodID(validated)) {
-                    method_id = validated;
-                  }
-                  jvmti->Deallocate((unsigned char*)methods);
-                }
-              }
-            }
-          }
-        }
-        jni->DeleteLocalRef(clz);
-      }
-  }
-
-  free(method_name);
-  free(method_signature);
-  free(klass_name);
-
-  return method_id;
+  return lookupMethodIdViaJni(vm_method, names);
 }

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
@@ -1449,11 +1449,11 @@ class ResolvedNames {
   // allocation just because it went through the malloc path instead.
   static constexpr size_t MAX_SYMBOL_LEN = 64 * 1024;
 
-  // Fixed-size fast-path buffers for the common case, sized so that a
-  // realistic name/signature/class name never needs to allocate. 4096 mirrors
-  // Lookup::resolveVTableReceiverCached (flightRecorder.cpp), which reads the
-  // same Symbol bodies on the same thread; it is a precedent to stay
-  // consistent with, not a JVM-spec limit.
+  // Fixed-size fast-path buffers for the common case, sized generously above
+  // the realistic common-case length for each field (see the per-field
+  // comments below) but deliberately not so generous that the malloc
+  // fallback in setImpl() never engages -- these caps are meant to be hit
+  // occasionally so that path stays exercised.
   // HotSpot's Symbol length field is a u2, so the VM permits up to 65535 bytes.
   // A name/descriptor that overflows its fixed buffer falls back to malloc
   // (see ResolvedNames::setImpl), up to MAX_SYMBOL_LEN below; beyond that it is
@@ -1551,6 +1551,9 @@ bool ResolvedNames::setImpl(char* short_name, char* volatile& long_name, size_t 
   char* dest = short_name;
   if (len >= short_limit) {
     long_name = (char*)malloc(len + 1);
+    if (long_name == nullptr) {
+        return false;   // caller bumps METHOD_RESOLVE_SYMBOL_UNREADABLE
+    }
     dest = long_name;
   }
 
@@ -1649,7 +1652,22 @@ static bool readMethodNames(const void* method, VMMethod** out_vm_method,
 //     local frame and unbalanced safepoint state -- trading a crash for a
 //     JVM-wide deadlock.
 // vm_method->validatedId() below is safefetch-based, so it is safe unprotected.
-jmethodID lookupMethodIdViaJni(VMMethod* vm_method, const ResolvedNames& names) {
+//
+// A plain, TU-local helper -- like readMethodNames() -- rather than a
+// HotspotSupport member or friend: it never touches HotspotSupport's private
+// state directly, so nothing about it, including ResolvedNames (a type
+// defined entirely in this file with no header of its own), needs to be
+// declared in hotspotSupport.h. The <clinit> fallback needs the private
+// HotspotSupport::loadMethodIDsIfNeededImpl(), so resolve() -- which does
+// have access, being a member -- passes it in as a plain function pointer
+// instead of this function calling it directly.
+//
+// Returns a jmethodID valid for as long as the declaring class stays loaded
+// (the same ownership/lifetime jmethodIDs always have in this codebase -- no
+// release call is needed), or nullptr if the method could not be found via
+// JNI/JVMTI.
+static jmethodID lookupMethodIdViaJni(VMMethod* vm_method, const ResolvedNames& names,
+                                       bool (*loadMethodIDsIfNeededImpl)(jvmtiEnv*, JNIEnv*, jclass, bool)) {
   jmethodID method_id = nullptr;
   const char* method_name = names.methodName();
   const char* method_signature = names.methodSignature();
@@ -1677,7 +1695,7 @@ jmethodID lookupMethodIdViaJni(VMMethod* vm_method, const ResolvedNames& names) 
         if (strcmp(method_name, "<clinit>") == 0) {
           jvmtiEnv* jvmti = VM::jvmti();
           if (jvmti != nullptr) {
-            if (HotspotSupport::loadMethodIDsIfNeededImpl(jvmti, jni, clz, true /*load all*/)) {
+            if (loadMethodIDsIfNeededImpl(jvmti, jni, clz, true /*load all*/)) {
               jmethodID validated = vm_method->validatedId();
               if (isValidJMethodID(validated)) {
                 method_id = validated;
@@ -1763,5 +1781,5 @@ jmethodID HotspotSupport::resolve(const void* method) {
   if (existing_id != nullptr) {
     return existing_id;
   }
-  return lookupMethodIdViaJni(vm_method, names);
+  return lookupMethodIdViaJni(vm_method, names, &HotspotSupport::loadMethodIDsIfNeededImpl);
 }

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
@@ -1437,28 +1437,6 @@ bool HotspotSupport::loadMethodIDsIfNeededImpl(jvmtiEnv *jvmti, JNIEnv *jni, jcl
     return JVMSupport::loadMethodIDsImpl(jvmti, jni, klass);
 }
 
-// Fixed-size fast-path buffers for the common case, sized so that a
-// realistic name/signature/class name never needs to allocate. 4096 mirrors
-// Lookup::resolveVTableReceiverCached (flightRecorder.cpp), which reads the
-// same Symbol bodies on the same thread; it is a precedent to stay
-// consistent with, not a JVM-spec limit.
-// HotSpot's Symbol length field is a u2, so the VM permits up to 65535 bytes.
-// A name/descriptor that overflows its fixed buffer falls back to malloc
-// (see ResolvedNames::setImpl), up to MAX_SYMBOL_LEN below; beyond that it is
-// rejected and the frame serializes as "unknown" -- METHOD_RESOLVE_SYMBOL_UNREADABLE
-// makes that visible if it bites. Unlike the old stack-only design, the malloc
-// fallback means this is no longer a leak-proof region: siglongjmp out of
-// resolve() bypasses ~ResolvedNames(), so the fault-recovery path must call
-// ResolvedNames::release() explicitly (see resolve()) to free any buffer
-// allocated before the fault.
-static const size_t MAX_KLASS_NAME_LEN  = 1024;  // internal names; realistically < 256
-static const size_t MAX_METHOD_NAME_LEN =  512;  // realistically < 64
-// A descriptor can in principle exceed this (255 argument *slots*, each able to
-// carry an arbitrarily long L...; type name), so this cap is a fidelity choice,
-// not a proof: over-cap descriptors serialize as "unknown" rather than being
-// truncated. METHOD_RESOLVE_SYMBOL_UNREADABLE makes it visible if that bites.
-static const size_t MAX_SIGNATURE_LEN   = 1024;
-
 // The three names resolve() needs, owned by resolve()'s frame. Each name has
 // a fixed-size inline buffer for the common case, with a malloc'd fallback
 // (up to MAX_SYMBOL_LEN) for names that don't fit -- see release() for why
@@ -1466,12 +1444,34 @@ static const size_t MAX_SIGNATURE_LEN   = 1024;
 class ResolvedNames {
   // Hard ceiling for the malloc fallback in setImpl(), independent of which
   // field is being resolved. Not a JVM/class-file limit (Symbol::length() is
-  // a u2, so up to 65535 is legal) -- chosen to match MAX_KLASS_NAME_LEN and
-  // MAX_SIGNATURE_LEN above, so a name that would already have been rejected
+  // a u2, so up to 65535 is legal) -- a name that would already have been rejected
   // as too long for those fields' fixed buffers doesn't get an unbounded
   // allocation just because it went through the malloc path instead.
-  static constexpr size_t MAX_SYMBOL_LEN = 4 * 1024;
-private:
+  static constexpr size_t MAX_SYMBOL_LEN = 64 * 1024;
+
+  // Fixed-size fast-path buffers for the common case, sized so that a
+  // realistic name/signature/class name never needs to allocate. 4096 mirrors
+  // Lookup::resolveVTableReceiverCached (flightRecorder.cpp), which reads the
+  // same Symbol bodies on the same thread; it is a precedent to stay
+  // consistent with, not a JVM-spec limit.
+  // HotSpot's Symbol length field is a u2, so the VM permits up to 65535 bytes.
+  // A name/descriptor that overflows its fixed buffer falls back to malloc
+  // (see ResolvedNames::setImpl), up to MAX_SYMBOL_LEN below; beyond that it is
+  // rejected and the frame serializes as "unknown" -- METHOD_RESOLVE_SYMBOL_UNREADABLE
+  // makes that visible if it bites. Unlike the old stack-only design, the malloc
+  // fallback means this is no longer a leak-proof region: siglongjmp out of
+  // resolve() bypasses ~ResolvedNames(), so the fault-recovery path must call
+  // ResolvedNames::release() explicitly (see resolve()) to free any buffer
+  // allocated before the fault.
+  static constexpr size_t MAX_KLASS_NAME_LEN  = 1024;  // internal names; realistically < 256
+  static constexpr size_t MAX_METHOD_NAME_LEN =  512;  // realistically < 64
+  // A descriptor can in principle exceed this (255 argument *slots*, each able to
+  // carry an arbitrarily long L...; type name), so this cap is a fidelity choice,
+  // not a proof: over-cap descriptors serialize as "unknown" rather than being
+  // truncated. METHOD_RESOLVE_SYMBOL_UNREADABLE makes it visible if that bites.
+  static constexpr size_t MAX_SIGNATURE_LEN   = 1024;
+
+  private:
   // volatile: resolve() mutates these (via setMethodName/setMethodSignature/
   // setKlassName, called through readMethodNames()) between sigsetjmp() and a
   // possible siglongjmp() out of a fault, then release() reads them back at

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
@@ -1451,13 +1451,13 @@ bool HotspotSupport::loadMethodIDsIfNeededImpl(jvmtiEnv *jvmti, JNIEnv *jni, jcl
 // resolve() bypasses ~ResolvedNames(), so the fault-recovery path must call
 // ResolvedNames::release() explicitly (see resolve()) to free any buffer
 // allocated before the fault.
-static const size_t MAX_KLASS_NAME_LEN  = 4096;  // internal names; realistically < 256
+static const size_t MAX_KLASS_NAME_LEN  = 1024;  // internal names; realistically < 256
 static const size_t MAX_METHOD_NAME_LEN =  512;  // realistically < 64
 // A descriptor can in principle exceed this (255 argument *slots*, each able to
 // carry an arbitrarily long L...; type name), so this cap is a fidelity choice,
 // not a proof: over-cap descriptors serialize as "unknown" rather than being
 // truncated. METHOD_RESOLVE_SYMBOL_UNREADABLE makes it visible if that bites.
-static const size_t MAX_SIGNATURE_LEN   = 4096;
+static const size_t MAX_SIGNATURE_LEN   = 1024;
 
 // The three names resolve() needs, owned by resolve()'s frame. Each name has
 // a fixed-size inline buffer for the common case, with a malloc'd fallback
@@ -1472,15 +1472,22 @@ class ResolvedNames {
   // allocation just because it went through the malloc path instead.
   static constexpr size_t MAX_SYMBOL_LEN = 4 * 1024;
 private:
-  char*     _long_method_name;
-  char*     _long_method_signature;
-  char*     _long_klass_name;
+  // volatile: resolve() mutates these (via setMethodName/setMethodSignature/
+  // setKlassName, called through readMethodNames()) between sigsetjmp() and a
+  // possible siglongjmp() out of a fault, then release() reads them back at
+  // the landing pad to decide what to free. Per the setjmp/longjmp rules
+  // (C11 7.13.2.1p3, inherited by C++), a non-volatile automatic local
+  // modified in that window has an indeterminate value after longjmp;
+  // volatile is what makes release()'s reads on the recovery path defined.
+  char* volatile _long_method_name;
+  char* volatile _long_method_signature;
+  char* volatile _long_klass_name;
 
   char _method_name[MAX_METHOD_NAME_LEN];
   char _method_signature[MAX_SIGNATURE_LEN];
   char _klass_name[MAX_KLASS_NAME_LEN];
 
-  bool setImpl(char* short_name, char*& long_name, size_t short_limit, VMSymbol* sym);
+  bool setImpl(char* short_name, char* volatile& long_name, size_t short_limit, VMSymbol* sym);
 public:
   ResolvedNames();
   ~ResolvedNames();
@@ -1533,7 +1540,7 @@ void ResolvedNames::release() {
   }
 }
 
-bool ResolvedNames::setImpl(char* short_name, char*& long_name, size_t short_limit, VMSymbol* sym) {
+bool ResolvedNames::setImpl(char* short_name, char* volatile& long_name, size_t short_limit, VMSymbol* sym) {
   unsigned len = sym->length();  // raw u2 deref; PC stays inside this library
   // A method name, descriptor or class name is never empty; 0 means the Symbol
   // slot has been recycled. `>=` leaves room for the NUL.

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
@@ -202,7 +202,7 @@ void HotspotSupport::fillJavaFrame(ASGCT_CallFrame& frame, FrameTypeId type, int
         fillFrame(frame, type, bci, method_id);
     } else if (method_id != nullptr) {
         fillFrame(frame, type, bci, method_id);
-    } else if (!VM::arguments()._force_jmethodID) {
+    } else if (!Profiler::instance()->forceJmethodID()) {
         // fjmethodid=false: the user opted into the raw Method* path. nullptr
         // means no jmethodID is available — either the klass was deliberately
         // not primed (ids == NULL) or the cache was shrunk by a redefine
@@ -1411,7 +1411,7 @@ bool HotspotSupport::loadMethodIDsIfNeededImpl(jvmtiEnv *jvmti, JNIEnv *jni, jcl
         jobject cl = nullptr;
         // Hidden/lambda classes can be unloaded, fallback to use jmethodIDs, so preload them.
         if (!isHiddenClass(jvmti, klass) &&
-            jvmti->GetClassLoader(klass, &cl) == JVMTI_ERROR_NONE && 
+            jvmti->GetClassLoader(klass, &cl) == JVMTI_ERROR_NONE &&
             isSystemClassLoader(jni, cl)) {
             char* signature_ptr = nullptr;
             if (jvmti->GetClassSignature(klass, &signature_ptr, nullptr) == JVMTI_ERROR_NONE) {
@@ -1552,7 +1552,7 @@ static bool readMethodNames(const void* method, VMMethod** out_vm_method,
 //     local frame and unbalanced safepoint state -- trading a crash for a
 //     JVM-wide deadlock.
 // vm_method->validatedId() below is safefetch-based, so it is safe unprotected.
-static jmethodID lookupMethodIdViaJni(VMMethod* vm_method, const ResolvedNames& names) {
+jmethodID lookupMethodIdViaJni(VMMethod* vm_method, const ResolvedNames& names) {
   jmethodID method_id = nullptr;
   const char* method_name = names.method_name;
   const char* method_signature = names.method_signature;
@@ -1571,20 +1571,20 @@ static jmethodID lookupMethodIdViaJni(VMMethod* vm_method, const ResolvedNames& 
         jni->ExceptionClear();
         // JNI GetMethodID/GetStaticMethodID cannot look up <clinit> because
         // the JVM intentionally hides class initializers from JNI callers.
-        // Fall back to JVMTI GetClassMethods, which covers all methods
-        // including <clinit> and forces jmethodID slot allocation for them.
+        // Fall back to loadMethodIDsIfNeededImpl(), which covers all methods
+        // including <clinit> and forces jmethodID slot allocation for them
+        // (going through this helper, rather than calling GetClassMethods
+        // directly, ensures the JDK-8062116 patchClassLoaderData() workaround
+        // is applied here too, same as every other jmethodID-preload path).
         // After the call, re-read the ID directly from VM metadata.
         if (strcmp(method_name, "<clinit>") == 0) {
           jvmtiEnv* jvmti = VM::jvmti();
           if (jvmti != nullptr) {
-            jint count = 0;
-            jmethodID* methods = nullptr;
-            if (jvmti->GetClassMethods(clz, &count, &methods) == JVMTI_ERROR_NONE) {
+            if (HotspotSupport::loadMethodIDsIfNeededImpl(jvmti, jni, clz, true /*load all*/)) {
               jmethodID validated = vm_method->validatedId();
               if (isValidJMethodID(validated)) {
                 method_id = validated;
               }
-              jvmti->Deallocate((unsigned char*)methods);
             }
           }
         }

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
@@ -1437,15 +1437,20 @@ bool HotspotSupport::loadMethodIDsIfNeededImpl(jvmtiEnv *jvmti, JNIEnv *jni, jcl
     return JVMSupport::loadMethodIDsImpl(jvmti, jni, klass);
 }
 
-// Fixed dump-time buffers, replacing the malloc/free trio this function used to
-// carry. HotSpot's Symbol length field is a u2, so the VM permits up to 65535
-// bytes; these caps trade that theoretical maximum for zero heap traffic on the
-// dump path and, more importantly, for having no cleanup obligation inside the
-// crash-protected region -- a siglongjmp out of resolve() cannot leak anything.
-// 4096 mirrors Lookup::resolveVTableReceiverCached (flightRecorder.cpp), which
-// reads the same Symbol bodies on the same thread. A symbol over its cap reports
-// METHOD_RESOLVE_SYMBOL_UNREADABLE and serializes as "unknown" -- the same
-// outcome as a class FindClass cannot see.
+// Fixed-size fast-path buffers for the common case, sized so that a
+// realistic name/signature/class name never needs to allocate. 4096 mirrors
+// Lookup::resolveVTableReceiverCached (flightRecorder.cpp), which reads the
+// same Symbol bodies on the same thread; it is a precedent to stay
+// consistent with, not a JVM-spec limit.
+// HotSpot's Symbol length field is a u2, so the VM permits up to 65535 bytes.
+// A name/descriptor that overflows its fixed buffer falls back to malloc
+// (see ResolvedNames::setImpl), up to MAX_SYMBOL_LEN below; beyond that it is
+// rejected and the frame serializes as "unknown" -- METHOD_RESOLVE_SYMBOL_UNREADABLE
+// makes that visible if it bites. Unlike the old stack-only design, the malloc
+// fallback means this is no longer a leak-proof region: siglongjmp out of
+// resolve() bypasses ~ResolvedNames(), so the fault-recovery path must call
+// ResolvedNames::release() explicitly (see resolve()) to free any buffer
+// allocated before the fault.
 static const size_t MAX_KLASS_NAME_LEN  = 4096;  // internal names; realistically < 256
 static const size_t MAX_METHOD_NAME_LEN =  512;  // realistically < 64
 // A descriptor can in principle exceed this (255 argument *slots*, each able to
@@ -1454,37 +1459,124 @@ static const size_t MAX_METHOD_NAME_LEN =  512;  // realistically < 64
 // truncated. METHOD_RESOLVE_SYMBOL_UNREADABLE makes it visible if that bites.
 static const size_t MAX_SIGNATURE_LEN   = 4096;
 
-// Copies a Symbol's body into a fixed buffer, NUL-terminating it.
-// Must be called with crash protection installed: length() and body()
-// dereference the Symbol directly with no safefetch.
-static bool copySymbolBody(VMSymbol* sym, char* dst, size_t cap) {
+// The three names resolve() needs, owned by resolve()'s frame. Each name has
+// a fixed-size inline buffer for the common case, with a malloc'd fallback
+// (up to MAX_SYMBOL_LEN) for names that don't fit -- see release() for why
+// that fallback needs explicit cleanup on the crash-recovery path.
+class ResolvedNames {
+  // Hard ceiling for the malloc fallback in setImpl(), independent of which
+  // field is being resolved. Not a JVM/class-file limit (Symbol::length() is
+  // a u2, so up to 65535 is legal) -- chosen to match MAX_KLASS_NAME_LEN and
+  // MAX_SIGNATURE_LEN above, so a name that would already have been rejected
+  // as too long for those fields' fixed buffers doesn't get an unbounded
+  // allocation just because it went through the malloc path instead.
+  static constexpr size_t MAX_SYMBOL_LEN = 4 * 1024;
+private:
+  char*     _long_method_name;
+  char*     _long_method_signature;
+  char*     _long_klass_name;
+
+  char _method_name[MAX_METHOD_NAME_LEN];
+  char _method_signature[MAX_SIGNATURE_LEN];
+  char _klass_name[MAX_KLASS_NAME_LEN];
+
+  bool setImpl(char* short_name, char*& long_name, size_t short_limit, VMSymbol* sym);
+public:
+  ResolvedNames();
+  ~ResolvedNames();
+  void release();
+
+  bool setMethodName(VMSymbol* sym);
+  bool setMethodSignature(VMSymbol* sym);
+  bool setKlassName(VMSymbol* sym);
+
+  const char* methodName() const {
+    return _long_method_name != nullptr ? _long_method_name : _method_name;
+  }
+
+  const char* methodSignature() const {
+    return _long_method_signature != nullptr ? _long_method_signature : _method_signature;
+  }
+
+  const char* klassName() const {
+    return _long_klass_name != nullptr ? _long_klass_name : _klass_name;
+  }
+};
+
+ResolvedNames::ResolvedNames() :
+  _long_method_name(nullptr),
+  _long_method_signature(nullptr),
+  _long_klass_name(nullptr) {
+}
+
+ResolvedNames::~ResolvedNames() {
+    release();
+}
+
+void ResolvedNames::release() {
+  // Must be idempotent: resolve()'s fault-recovery path calls this explicitly
+  // (siglongjmp bypasses ~ResolvedNames()), and then the destructor runs it
+  // again on the same object when resolve() returns normally afterward.
+  // Nulling out each pointer after freeing makes the second call a no-op
+  // instead of a double free.
+  if (_long_method_name != nullptr) {
+    free(_long_method_name);
+    _long_method_name = nullptr;
+  }
+  if (_long_method_signature != nullptr) {
+    free(_long_method_signature);
+    _long_method_signature = nullptr;
+  }
+  if (_long_klass_name != nullptr) {
+    free(_long_klass_name);
+    _long_klass_name = nullptr;
+  }
+}
+
+bool ResolvedNames::setImpl(char* short_name, char*& long_name, size_t short_limit, VMSymbol* sym) {
   unsigned len = sym->length();  // raw u2 deref; PC stays inside this library
   // A method name, descriptor or class name is never empty; 0 means the Symbol
   // slot has been recycled. `>=` leaves room for the NUL.
-  if (len == 0 || len >= cap) {
+  if (len == 0 || len >= MAX_SYMBOL_LEN) {
     return false;
   }
-  const char* body = sym->body();
-  if (!SafeAccess::safeCopy(dst, body, len)) {
+
+  char* dest = short_name;
+  if (len >= short_limit) {
+    long_name = (char*)malloc(len + 1);
+    dest = long_name;
+  }
+
+  if (SafeAccess::safeCopy(dest, sym->body(), len)) {
+    dest[len] = '\0';
+    return true;
+  } else {
     return false;
   }
-  dst[len] = '\0';
-  return true;
 }
 
-// The three names resolve() needs, owned by resolve()'s frame so that the
-// metadata walk has no cleanup obligation of its own.
-struct ResolvedNames {
-  char method_name[MAX_METHOD_NAME_LEN];
-  char method_signature[MAX_SIGNATURE_LEN];
-  char klass_name[MAX_KLASS_NAME_LEN];
-};
+bool ResolvedNames::setMethodName(VMSymbol* sym) {
+  return setImpl(_method_name, _long_method_name, MAX_METHOD_NAME_LEN, sym);
+
+}
+bool ResolvedNames::setMethodSignature(VMSymbol* sym) {
+  return setImpl(_method_signature, _long_method_signature, MAX_SIGNATURE_LEN, sym);
+}
+
+bool ResolvedNames::setKlassName(VMSymbol* sym) {
+  return setImpl(_klass_name, _long_klass_name, MAX_KLASS_NAME_LEN, sym);
+}
+
 
 // PHASE 1 -- the raw HotSpot metadata walk. MUST run with a jmp ctx installed:
 // every step is a raw *(void**)(this + offset) whose target may have been freed
 // by GC or class unloading since the sample was taken. Deliberately contains no
-// JNI, no JVMTI and no allocation, so the whole protected region stays inside
-// this library, where Profiler::checkFault() can actually recover.
+// JNI and no JVMTI, so the whole protected region stays inside this library,
+// where Profiler::checkFault() can actually recover. It can allocate, via
+// ResolvedNames::setImpl()'s malloc fallback for over-sized names -- that
+// allocation is self-contained (glibc malloc doesn't call back into JNI/JVMTI),
+// but it does mean a fault after the allocation needs explicit freeing, since
+// siglongjmp out of this scope bypasses ~ResolvedNames() (see resolve()).
 //
 // Returns false if the metadata is unusable. On success either *out_id holds an
 // already-valid jmethodID (and `names` is untouched), or *out_id is null and
@@ -1530,9 +1622,7 @@ static bool readMethodNames(const void* method, VMMethod** out_vm_method,
     return false;
   }
 
-  if (!copySymbolBody(name_sym, names->method_name, sizeof(names->method_name)) ||
-      !copySymbolBody(sig_sym, names->method_signature, sizeof(names->method_signature)) ||
-      !copySymbolBody(klass_sym, names->klass_name, sizeof(names->klass_name))) {
+  if (!names->setMethodName(name_sym) || !names->setMethodSignature(sig_sym) || !names->setKlassName(klass_sym)) {
     Counters::increment(METHOD_RESOLVE_SYMBOL_UNREADABLE);
     return false;
   }
@@ -1554,9 +1644,9 @@ static bool readMethodNames(const void* method, VMMethod** out_vm_method,
 // vm_method->validatedId() below is safefetch-based, so it is safe unprotected.
 jmethodID lookupMethodIdViaJni(VMMethod* vm_method, const ResolvedNames& names) {
   jmethodID method_id = nullptr;
-  const char* method_name = names.method_name;
-  const char* method_signature = names.method_signature;
-  const char* klass_name = names.klass_name;
+  const char* method_name = names.methodName();
+  const char* method_signature = names.methodSignature();
+  const char* klass_name = names.klassName();
 
   JNIEnv *jni = VM::jni();
   jclass clz = jni->FindClass(klass_name);
@@ -1625,10 +1715,6 @@ jmethodID HotspotSupport::resolve(const void* method) {
     return nullptr;
   }
 
-  // Buffers live in this frame so phase 1 has nothing to clean up. None of the
-  // locals below are read on the recovery path, so none of them need to be
-  // volatile despite being assigned between sigsetjmp() and a possible
-  // siglongjmp.
   ResolvedNames names;
   VMMethod* vm_method = nullptr;
   jmethodID existing_id = nullptr;
@@ -1650,6 +1736,11 @@ jmethodID HotspotSupport::resolve(const void* method) {
       // before touching anything that could fault again.
       SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP();
       jmp_scope.restore();
+      // siglongjmp bypasses ~ResolvedNames(), so a name that was already
+      // malloc'd (in setImpl()'s over-sized-name fallback) before the fault
+      // would otherwise leak. release() is idempotent, so it's safe that the
+      // destructor also runs it when resolve() returns below.
+      names.release();
       Counters::increment(METHOD_RESOLVE_FAULT_RECOVERED);
       return nullptr;
     }

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.h
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.h
@@ -18,9 +18,16 @@
 
 class ProfiledThread;
 class VMMethod;
+struct ResolvedNames;
 
 class HotspotSupport {
     friend class JVMSupport;
+    friend class HotspotSupportTestAccessor;
+    // lookupMethodIdViaJni() is a free function (not a HotspotSupport member)
+    // so that HotspotSupport::resolve() can install/tear down crash protection
+    // around it without exposing that split as public API; it still needs
+    // loadMethodIDsIfNeededImpl() for the <clinit> fallback below.
+    friend jmethodID lookupMethodIdViaJni(VMMethod* vm_method, const ResolvedNames& names);
 
 private:
     static int walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.h
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.h
@@ -18,22 +18,16 @@
 
 class ProfiledThread;
 class VMMethod;
-class ResolvedNames;
 
 class HotspotSupport {
     friend class JVMSupport;
     friend class HotspotSupportTestAccessor;
-    // lookupMethodIdViaJni() is a free function (not a HotspotSupport member)
-    // so that HotspotSupport::resolve() can install/tear down crash protection
-    // around it without exposing that split as public API; it still needs
-    // loadMethodIDsIfNeededImpl() for the <clinit> fallback below.
-    friend jmethodID lookupMethodIdViaJni(VMMethod* vm_method, const ResolvedNames& names);
 
 private:
     static int walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
                       StackWalkFeatures features, EventType event_type,
                       const void* pc, uintptr_t sp, uintptr_t fp, int lock_index, bool* truncated);
-    static int walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
+    static int walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
                       StackWalkFeatures features, EventType event_type,
                       int lock_index, bool* truncated = nullptr);
 

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.h
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.h
@@ -18,7 +18,7 @@
 
 class ProfiledThread;
 class VMMethod;
-struct ResolvedNames;
+class ResolvedNames;
 
 class HotspotSupport {
     friend class JVMSupport;

--- a/ddprof-lib/src/main/cpp/jvmSupport.cpp
+++ b/ddprof-lib/src/main/cpp/jvmSupport.cpp
@@ -71,10 +71,6 @@ void JVMSupport::setLoadState(JMethodIDLoadStats state) {
 
 void JVMSupport::initExecution(Arguments& args, jvmtiEnv* jvmti, JNIEnv* jni) {
     JMethodIDLoadStats current_state = getLoadState();
-    // Already setup by previous execution
-    if (current_state == Fully_loaded) {
-        return;
-    }
 
     bool load_all = true;
     if (VM::isHotspot()) {

--- a/ddprof-lib/src/main/cpp/jvmSupport.h
+++ b/ddprof-lib/src/main/cpp/jvmSupport.h
@@ -31,6 +31,7 @@ class JVMSupport {
     };
 
     friend class HotspotSupport;
+    friend class JVMSupportTestAccessor;
 
     static Mutex _initialization_lock;
     static volatile JMethodIDLoadStats jmethodID_load_state;

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1586,6 +1586,7 @@ Error Profiler::start(Arguments &args, bool reset) {
   _cpu_engine = selectCpuEngine(args);
   _wall_engine = selectWallEngine(args);
   _cstack = args._cstack;
+  _force_jmethodID = args._force_jmethodID;
   if (_cstack == CSTACK_DEFAULT) {
     if (VMStructs::hasStackStructs() && OS::isLinux()) {
       _cstack = CSTACK_VM;

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -140,6 +140,7 @@ private:
   StackWalkFeatures _features;
   int _safe_mode;
   CStack _cstack;
+  bool _force_jmethodID;
 
   volatile jvmtiEventMode _thread_events_state;
 
@@ -227,6 +228,7 @@ public:
         _start_time(0), _stop_time(0), _epoch(0), _timer_id(NULL),
         _total_samples(0), _sample_seq(0), _failures(), _class_map_lock(),
         _max_stack_depth(0), _features(), _safe_mode(0), _cstack(CSTACK_NO),
+        _force_jmethodID(true),
         _thread_events_state(JVMTI_DISABLE), _libs(Libraries::instance()),
         _num_context_attributes(0), _omit_stacktraces(false),
         _remote_symbolication(false), _sanity_check_failed(false),
@@ -276,6 +278,10 @@ public:
 
   inline CStack cstackMode() const {
     return _cstack;
+  }
+
+  inline bool forceJmethodID() const {
+    return _force_jmethodID;
   }
 
   inline const StackWalkFeatures& stackWalkFeatures() const {

--- a/ddprof-lib/src/test/cpp/hotspotMethodId_ut.cpp
+++ b/ddprof-lib/src/test/cpp/hotspotMethodId_ut.cpp
@@ -5,12 +5,23 @@
 
 #include <gtest/gtest.h>
 
+#include "../../main/cpp/counters.h"
 #include "../../main/cpp/flightRecorder.h"
 #include "../../main/cpp/hotspot/hotspotSupport.h"
 #include "../../main/cpp/hotspot/vmStructs.h"
+#include "../../main/cpp/os.h"
+#include "../../main/cpp/profiler.h"
+#include "../../main/cpp/threadLocalData.inline.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <new>
+
+#ifdef __linux__
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
 
 // Test-only friend accessor for VM internals. It exists solely so this test
 // can exercise HotSpot's rejected-jmethodID handling.
@@ -43,6 +54,70 @@ public:
     }
 
     ~VMStructsTestAccessor() { _restore(_saved); }
+
+    // Offsets beyond the id() set, needed to walk a fake Method* all the way to
+    // its name/signature/class Symbols the way HotspotSupport::resolve() does.
+    struct SymbolOffsets {
+        int constmethod_name_index;
+        int constmethod_sig_index;
+        int klass_name;
+        int symbol_length;
+        int symbol_body;
+    };
+
+    // cast_or_null() / VMConstantPool::base() need non-zero type sizes, which
+    // normally come from gHotSpotVMTypes and therefore stay 0 without a live
+    // JVM. Every field is asserted > 0 by the code under test, so tests that
+    // reach cast_or_null must set them.
+    struct TypeSizes {
+        uint64_t method;
+        uint64_t const_method;
+        uint64_t constant_pool;
+        uint64_t klass;
+        uint64_t symbol;
+    };
+
+    // Scoped override for the symbol-walk offsets and the type sizes, kept
+    // separate from the ctor above so the existing id() tests are unaffected.
+    class SymbolLayout {
+    public:
+        SymbolLayout(const SymbolOffsets& o, const TypeSizes& t) {
+            _saved_offsets = {
+                VMStructs::_constmethod_name_index_offset,
+                VMStructs::_constmethod_sig_index_offset,
+                VMStructs::_klass_name_offset,
+                VMStructs::_symbol_length_offset,
+                VMStructs::_symbol_body_offset,
+            };
+            _saved_sizes = {
+                VMStructs::TYPE_SIZE_NAME(VMMethod),
+                VMStructs::TYPE_SIZE_NAME(VMConstMethod),
+                VMStructs::TYPE_SIZE_NAME(VMConstantPool),
+                VMStructs::TYPE_SIZE_NAME(VMKlass),
+                VMStructs::TYPE_SIZE_NAME(VMSymbol),
+            };
+            _apply(o, t);
+        }
+
+        ~SymbolLayout() { _apply(_saved_offsets, _saved_sizes); }
+
+    private:
+        SymbolOffsets _saved_offsets;
+        TypeSizes _saved_sizes;
+
+        static void _apply(const SymbolOffsets& o, const TypeSizes& t) {
+            VMStructs::_constmethod_name_index_offset = o.constmethod_name_index;
+            VMStructs::_constmethod_sig_index_offset = o.constmethod_sig_index;
+            VMStructs::_klass_name_offset = o.klass_name;
+            VMStructs::_symbol_length_offset = o.symbol_length;
+            VMStructs::_symbol_body_offset = o.symbol_body;
+            VMStructs::TYPE_SIZE_NAME(VMMethod) = t.method;
+            VMStructs::TYPE_SIZE_NAME(VMConstMethod) = t.const_method;
+            VMStructs::TYPE_SIZE_NAME(VMConstantPool) = t.constant_pool;
+            VMStructs::TYPE_SIZE_NAME(VMKlass) = t.klass;
+            VMStructs::TYPE_SIZE_NAME(VMSymbol) = t.symbol;
+        }
+    };
 
 private:
     struct SavedOffsets {
@@ -237,3 +312,307 @@ TEST(HotspotMethodIdTest, IdReturnsValidIdForPopulatedSlot) {
     VMMethod* vm_method = reinterpret_cast<VMMethod*>(&md.method);
     EXPECT_EQ(vm_method->id(), expected);
 }
+
+#ifdef __linux__
+
+// ---------------------------------------------------------------------------
+// HotspotSupport::resolve() crash protection
+//
+// resolve() turns a raw Method* captured at sample time into a jmethodID on the
+// JFR dump thread. GC or class unloading can free that metadata in between, so
+// every dereference in the walk (constMethod -> constants -> name/signature ->
+// holder -> klass->name, then Symbol length/body) can fault. resolve() installs
+// a sigsetjmp landing pad via JmpCtxScope so Profiler::checkFault() recovers and
+// resolve() reports the method as unresolved (nullptr) instead of taking the JVM
+// down mid-dump.
+//
+// checkFault() gates recovery on the faulting pc lying inside the profiler
+// library's address range. setupSignalHandlers() never runs in this gtest binary
+// (the library sources are linked straight into the executable), so the range
+// stays (0, 0) and checkFault takes its "not initialized" fallback, recovering
+// unconditionally without ever evaluating the comparison. SetUp() therefore
+// installs a fabricated range via the UNIT_TEST-only
+// Profiler::setAddressRangeForTest(), anchored on two exported symbols from
+// hotspotSupport.cpp so it brackets that translation unit's whole text --
+// including the file-static helpers, whose addresses a test cannot take. This
+// covers the acceptance half of the gate only; the rejection half is already
+// tested for real by
+// StackWalkerCrashRecoveryTest.CheckFaultRejectsFaultOutsideProfilerRange.
+//
+// In a DEBUG build these tests additionally pin the crashProtectionActive()
+// interaction (vmStructs.h:33-45): VMStructs::at() asserts
+// `crashProtectionActive() || SafeAccess::isReadable(ptr)`, which without an
+// installed jmp ctx raises SIGABRT -- uncatchable by crash protection -- so
+// DEBUG builds used to die here where release survived. Passing in both
+// gtestDebug_ and gtestRelease_ is the evidence that the two now converge.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Two adjacent pages; the second is PROT_NONE. Fake metadata lives at the start
+// of the first, so an offset of kPageSize lands on the guard page.
+constexpr size_t kPageSize = 4096;
+
+// Layout of the fake metadata used by the resolve() tests. Sizes are the values
+// VMConstantPool::base() and cast_or_null() need; they only have to be non-zero
+// and consistent with the struct layouts below.
+constexpr VMStructsTestAccessor::TypeSizes RESOLVE_TYPE_SIZES = {
+    /*method*/        sizeof(void*),
+    /*const_method*/  2 * sizeof(void*),
+    /*constant_pool*/ sizeof(void*),   // base() = cpool + this, i.e. &symbols[0]
+    /*klass*/         sizeof(void*),
+    /*symbol*/        8,
+};
+
+constexpr VMStructsTestAccessor::SymbolOffsets RESOLVE_SYMBOL_OFFSETS = {
+    /*constmethod_name_index*/ 8,
+    /*constmethod_sig_index*/  10,
+    /*klass_name*/             0,
+    /*symbol_length*/          0,
+    /*symbol_body*/            2,
+};
+
+// jmethod_ids deliberately points at a separate, always-null field rather than
+// aliasing klass_name at offset 0: VMMethod::id() reads the jmethodID cache
+// through that offset, and pointing it at the class-name Symbol would make id()
+// read a length and a "jmethodID" out of the Symbol's body. That value passes
+// isValidJMethodID(), so resolve() would early-return with garbage and never
+// reach the symbol-copy code these tests are about.
+constexpr VMStructsTestAccessor::Offsets RESOLVE_OFFSETS = {
+    /*method_constmethod*/    0,
+    /*constmethod_constants*/ 0,
+    /*constmethod_idnum*/     12,
+    /*pool_holder*/           0,
+    /*jmethod_ids*/           sizeof(void*),
+};
+
+// Mirrors RESOLVE_*_OFFSETS above. `symbols` must directly follow `holder`
+// because VMConstantPool::base() is `this + VMConstantPool::type_size()`.
+struct ResolveFakes {
+    struct Method {
+        void* const_method;
+    } method;
+    struct ConstMethod {
+        void* cpool;
+        uint16_t name_index;
+        uint16_t sig_index;
+        uint16_t idnum;
+        uint16_t pad;
+    } const_method;
+    struct ConstantPool {
+        void* holder;
+        intptr_t symbols[4];
+    } cpool;
+    struct Klass {
+        void* name_symbol;   // klass_name offset 0
+        void* jmethod_ids;   // stays null so VMMethod::id() reports "no cache"
+    } klass;
+    struct Symbol {
+        uint16_t length;
+        char body[64];
+    } name_sym, sig_sym, klass_sym;
+
+    // Wires the chain up so resolve() walks Method -> ConstMethod -> ConstantPool
+    // -> {name, signature} Symbols and ConstantPool -> Klass -> class-name Symbol.
+    void link() {
+        method.const_method = &const_method;
+        const_method.cpool = &cpool;
+        const_method.name_index = 1;
+        const_method.sig_index = 2;
+        const_method.idnum = 0;
+        cpool.holder = &klass;
+        cpool.symbols[1] = (intptr_t)&name_sym;
+        cpool.symbols[2] = (intptr_t)&sig_sym;
+        klass.name_symbol = &klass_sym;
+    }
+
+    static void setSymbol(Symbol& s, const char* text) {
+        s.length = (uint16_t)strlen(text);
+        memcpy(s.body, text, s.length);
+    }
+};
+
+} // namespace
+
+class HotspotResolveCrashProtectionTest : public ::testing::Test {
+protected:
+    // Generous enough to bracket hotspotSupport.cpp's compiled text in any build
+    // config, while staying far below the distance to unrelated libraries.
+    static constexpr uintptr_t kRangeMargin = 512 * 1024;
+
+    void SetUp() override {
+        ProfiledThread::initCurrentThread();
+        _pt = ProfiledThread::current();
+        ASSERT_NE(nullptr, _pt);
+        ASSERT_FALSE(_pt->isProtected());
+
+        _orig_segv = OS::replaceSigsegvHandler(Profiler::segvHandler);
+        _orig_bus = OS::replaceSigbusHandler(Profiler::busHandler);
+
+        _region = mmap(nullptr, 2 * kPageSize, PROT_READ | PROT_WRITE,
+                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        ASSERT_NE(MAP_FAILED, _region);
+        ASSERT_EQ(0, mprotect((char*)_region + kPageSize, kPageSize, PROT_NONE));
+
+        // Two exported symbols from hotspotSupport.cpp, far apart in that TU.
+        uintptr_t a = (uintptr_t)&HotspotSupport::resolve;
+        uintptr_t b = (uintptr_t)&HotspotSupport::walkJavaStack;
+        _range_lo = std::min(a, b) - kRangeMargin;
+        _range_hi = std::max(a, b) + kRangeMargin;
+        Profiler::setAddressRangeForTest(_range_lo, _range_hi);
+    }
+
+    void TearDown() override {
+        Profiler::resetAddressRangeForTest();
+        munmap(_region, 2 * kPageSize);
+        OS::replaceSigsegvHandler(_orig_segv);
+        OS::replaceSigbusHandler(_orig_bus);
+        ProfiledThread::release();
+    }
+
+    ProfiledThread* _pt = nullptr;
+    void* _region = nullptr;
+    SigAction _orig_segv = nullptr;
+    SigAction _orig_bus = nullptr;
+    uintptr_t _range_lo = 0;
+    uintptr_t _range_hi = 0;
+};
+
+// The core guarantee: a SIGSEGV on stale metadata inside resolve() comes back as
+// nullptr ("unknown method") rather than killing the process.
+//
+// How this test fails if the protection is ever removed differs by config, so
+// don't read a clean release run as the only evidence: in DEBUG the at() assert
+// aborts, while in release neither orig_segvHandler nor OS::getSegvChainTarget()
+// is set in a gtest binary, so segvHandler returns, the faulting instruction
+// re-executes and the test hangs instead of failing.
+TEST_F(HotspotResolveCrashProtectionTest, ResolveRecoversFromFaultInsteadOfCrashing) {
+    HotspotMethodIdVMHotspotGuard hotspot;
+    // method_constmethod = kPageSize puts the very first raw dereference of the
+    // walk on the guard page. cast_or_null() still succeeds beforehand because it
+    // only validates [ptr, ptr + VMMethod::type_size()), which stays on the
+    // readable page -- the fault comes from the offset, not the pointer.
+    VMStructsTestAccessor::Offsets faulting = RESOLVE_OFFSETS;
+    faulting.method_constmethod = (int)kPageSize;
+    VMStructsTestAccessor offsets(faulting);
+    VMStructsTestAccessor::SymbolLayout layout(RESOLVE_SYMBOL_OFFSETS, RESOLVE_TYPE_SIZES);
+
+    long long before = Counters::getCounter(METHOD_RESOLVE_FAULT_RECOVERED);
+
+    // VMMethod::id() reads the same offset through SafeAccess first, so it
+    // returns the sentinel rather than faulting; resolve() then falls through to
+    // constMethod_or_null(), whose raw *(void**) deref is what actually faults.
+    EXPECT_EQ(nullptr, HotspotSupport::resolve(_region));
+
+    EXPECT_EQ(before + 1, Counters::getCounter(METHOD_RESOLVE_FAULT_RECOVERED));
+    // The landing pad must hand the previous (here: absent) context back.
+    EXPECT_FALSE(_pt->isProtected());
+}
+
+// Recovery must be repeatable: checkFault() calls resetCrashHandler() before
+// jumping precisely because the siglongjmp skips exitCrashHandler(), so a run of
+// faults must not exhaust CRASH_HANDLER_NESTING_LIMIT.
+TEST_F(HotspotResolveCrashProtectionTest, ResolveRecoversRepeatedly) {
+    HotspotMethodIdVMHotspotGuard hotspot;
+    VMStructsTestAccessor::Offsets faulting = RESOLVE_OFFSETS;
+    faulting.method_constmethod = (int)kPageSize;
+    VMStructsTestAccessor offsets(faulting);
+    VMStructsTestAccessor::SymbolLayout layout(RESOLVE_SYMBOL_OFFSETS, RESOLVE_TYPE_SIZES);
+
+    long long before = Counters::getCounter(METHOD_RESOLVE_FAULT_RECOVERED);
+    for (int i = 0; i < 10; i++) {
+        EXPECT_EQ(nullptr, HotspotSupport::resolve(_region));
+        EXPECT_FALSE(_pt->isProtected());
+    }
+    EXPECT_EQ(before + 10, Counters::getCounter(METHOD_RESOLVE_FAULT_RECOVERED));
+}
+
+// A Symbol whose body straddles the guard page is rejected by copySymbolBody's
+// SafeAccess::isReadableRange() probe before memcpy() is reached -- a fault
+// inside an out-of-line libc memcpy would have a pc outside the profiler range
+// and so would NOT be recoverable. No JNI is reached on this path, which is why
+// the test is safe without a live JVM.
+TEST_F(HotspotResolveCrashProtectionTest, ResolveReturnsNullForUnreadableSymbolBody) {
+    HotspotMethodIdVMHotspotGuard hotspot;
+    VMStructsTestAccessor offsets(RESOLVE_OFFSETS);
+    VMStructsTestAccessor::SymbolLayout layout(RESOLVE_SYMBOL_OFFSETS, RESOLVE_TYPE_SIZES);
+
+    ResolveFakes* f = new (_region) ResolveFakes{};
+    f->link();
+    ResolveFakes::setSymbol(f->name_sym, "someMethod");
+    ResolveFakes::setSymbol(f->sig_sym, "()V");
+    // Put the class-name Symbol's header flush against the end of the readable
+    // page: exactly VMSymbol::type_size() bytes, so VMSymbol::cast_or_null()'s
+    // own isReadableRange() check still passes and the rejection has to come from
+    // copySymbolBody(). The declared length then runs the body off the page.
+    char* edge = (char*)_region + kPageSize - RESOLVE_TYPE_SIZES.symbol;
+    *(uint16_t*)(edge + RESOLVE_SYMBOL_OFFSETS.symbol_length) = 100;
+    f->klass.name_symbol = edge;
+
+    long long before = Counters::getCounter(METHOD_RESOLVE_SYMBOL_UNREADABLE);
+    long long faults_before = Counters::getCounter(METHOD_RESOLVE_FAULT_RECOVERED);
+
+    EXPECT_EQ(nullptr, HotspotSupport::resolve(&f->method));
+
+    EXPECT_EQ(before + 1, Counters::getCounter(METHOD_RESOLVE_SYMBOL_UNREADABLE));
+    // Rejected by the readability probe, not by recovering from a real fault.
+    EXPECT_EQ(faults_before, Counters::getCounter(METHOD_RESOLVE_FAULT_RECOVERED));
+    EXPECT_FALSE(_pt->isProtected());
+}
+
+// A Symbol longer than the fixed dump-time buffer is reported as unresolved
+// rather than truncated or copied out of bounds. Pins the cap behaviour so a
+// future change to the buffer sizes is a deliberate test edit.
+TEST_F(HotspotResolveCrashProtectionTest, ResolveReturnsNullForOverlongSymbol) {
+    HotspotMethodIdVMHotspotGuard hotspot;
+    VMStructsTestAccessor offsets(RESOLVE_OFFSETS);
+    VMStructsTestAccessor::SymbolLayout layout(RESOLVE_SYMBOL_OFFSETS, RESOLVE_TYPE_SIZES);
+
+    ResolveFakes* f = new (_region) ResolveFakes{};
+    f->link();
+    ResolveFakes::setSymbol(f->sig_sym, "()V");
+    ResolveFakes::setSymbol(f->klass_sym, "java/lang/Object");
+    f->name_sym.length = 0xFFFF;  // far above MAX_METHOD_NAME_LEN
+
+    long long before = Counters::getCounter(METHOD_RESOLVE_SYMBOL_UNREADABLE);
+
+    EXPECT_EQ(nullptr, HotspotSupport::resolve(&f->method));
+
+    EXPECT_EQ(before + 1, Counters::getCounter(METHOD_RESOLVE_SYMBOL_UNREADABLE));
+    EXPECT_FALSE(_pt->isProtected());
+}
+
+// An empty Symbol means the slot has been recycled; treat it as unresolvable
+// rather than handing FindClass an empty string.
+TEST_F(HotspotResolveCrashProtectionTest, ResolveReturnsNullForEmptySymbol) {
+    HotspotMethodIdVMHotspotGuard hotspot;
+    VMStructsTestAccessor offsets(RESOLVE_OFFSETS);
+    VMStructsTestAccessor::SymbolLayout layout(RESOLVE_SYMBOL_OFFSETS, RESOLVE_TYPE_SIZES);
+
+    ResolveFakes* f = new (_region) ResolveFakes{};
+    f->link();
+    ResolveFakes::setSymbol(f->sig_sym, "()V");
+    ResolveFakes::setSymbol(f->klass_sym, "java/lang/Object");
+    f->name_sym.length = 0;
+
+    long long before = Counters::getCounter(METHOD_RESOLVE_SYMBOL_UNREADABLE);
+
+    EXPECT_EQ(nullptr, HotspotSupport::resolve(&f->method));
+
+    EXPECT_EQ(before + 1, Counters::getCounter(METHOD_RESOLVE_SYMBOL_UNREADABLE));
+    EXPECT_FALSE(_pt->isProtected());
+}
+
+// The sentinel is mapped to nullptr before any metadata is touched, so it must
+// not acquire a ProfiledThread or install a landing pad at all.
+TEST_F(HotspotResolveCrashProtectionTest, ResolveShortCircuitsSentinelWithoutProtection) {
+    HotspotMethodIdVMHotspotGuard hotspot;
+    long long before = Counters::getCounter(METHOD_RESOLVE_FAULT_RECOVERED);
+
+    EXPECT_EQ(nullptr, HotspotSupport::resolve((const void*)JMETHODID_NOT_WALKABLE));
+
+    EXPECT_EQ(before, Counters::getCounter(METHOD_RESOLVE_FAULT_RECOVERED));
+    EXPECT_FALSE(_pt->isProtected());
+}
+
+#endif // __linux__

--- a/ddprof-lib/src/test/cpp/hotspotMethodId_ut.cpp
+++ b/ddprof-lib/src/test/cpp/hotspotMethodId_ut.cpp
@@ -12,11 +12,13 @@
 #include "../../main/cpp/os.h"
 #include "../../main/cpp/profiler.h"
 #include "../../main/cpp/threadLocalData.inline.h"
+#include "../../main/cpp/vmEntry.h"
 
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <new>
+#include <string>
 
 #ifdef __linux__
 #include <sys/mman.h>
@@ -29,6 +31,8 @@ class VMTestAccessor {
 public:
     static bool getHotspot() { return VM::_hotspot; }
     static void setHotspot(bool value) { VM::_hotspot = value; }
+    static JavaVM* getVm() { return VM::_vm; }
+    static void setVm(JavaVM* vm) { VM::_vm = vm; }
 };
 
 // Test-only friend accessor for VMStructs protected static offsets.
@@ -439,6 +443,73 @@ struct ResolveFakes {
     }
 };
 
+// Minimal fake JavaVM/JNIEnv so HotspotSupport::resolve()'s unprotected JNI
+// phase (lookupMethodIdViaJni) can run to completion without a live JVM.
+// FindClass always reports success against an opaque, never-dereferenced
+// jclass; GetMethodID/GetStaticMethodID record the name/signature they were
+// called with and report "not found" -- the same real-world path resolve()
+// takes for a method it can't find -- so nothing beyond that is exercised.
+// Recording the arguments is what lets a test prove the malloc-fallback path
+// copied the right bytes, rather than just checking resolve() didn't crash.
+class ScopedFakeJni {
+public:
+    ScopedFakeJni() : _saved_vm(VMTestAccessor::getVm()) {
+        _jni_tbl = JNINativeInterface_{};
+        _jni_tbl.FindClass = &findClass;
+        _jni_tbl.ExceptionClear = &exceptionClear;
+        _jni_tbl.GetMethodID = &getMethodId;
+        _jni_tbl.GetStaticMethodID = &getMethodId;
+        _jni_tbl.DeleteLocalRef = &deleteLocalRef;
+        _jni_env.functions = &_jni_tbl;
+
+        _vm_tbl = JNIInvokeInterface_{};
+        _vm_tbl.GetEnv = &getEnv;
+        _vm.functions = &_vm_tbl;
+
+        s_instance = this;
+        VMTestAccessor::setVm(reinterpret_cast<JavaVM*>(&_vm));
+    }
+
+    ~ScopedFakeJni() {
+        VMTestAccessor::setVm(_saved_vm);
+        s_instance = nullptr;
+    }
+
+    int getMethodIdCalls() const { return _get_method_id_calls; }
+    const std::string& lastMethodName() const { return _last_method_name; }
+    const std::string& lastMethodSignature() const { return _last_method_sig; }
+
+private:
+    static jclass JNICALL findClass(JNIEnv*, const char*) {
+        return reinterpret_cast<jclass>(&s_instance->_fake_class);
+    }
+    static jmethodID JNICALL getMethodId(JNIEnv*, jclass, const char* name, const char* sig) {
+        s_instance->_get_method_id_calls++;
+        s_instance->_last_method_name = name != nullptr ? name : "";
+        s_instance->_last_method_sig = sig != nullptr ? sig : "";
+        return nullptr;
+    }
+    static void JNICALL exceptionClear(JNIEnv*) {}
+    static void JNICALL deleteLocalRef(JNIEnv*, jobject) {}
+    static jint JNICALL getEnv(JavaVM*, void** penv, jint) {
+        *penv = reinterpret_cast<JNIEnv*>(&s_instance->_jni_env);
+        return JNI_OK;
+    }
+
+    static ScopedFakeJni* s_instance;
+
+    JavaVM* _saved_vm;
+    JNINativeInterface_ _jni_tbl{};
+    JNIEnv_ _jni_env{};
+    JNIInvokeInterface_ _vm_tbl{};
+    JavaVM_ _vm{};
+    int _fake_class = 0;  // address-only sentinel; never dereferenced
+    int _get_method_id_calls = 0;
+    std::string _last_method_name;
+    std::string _last_method_sig;
+};
+ScopedFakeJni* ScopedFakeJni::s_instance = nullptr;
+
 } // namespace
 
 class HotspotResolveCrashProtectionTest : public ::testing::Test {
@@ -567,10 +638,12 @@ TEST_F(HotspotResolveCrashProtectionTest, ResolveReturnsNullForUnreadableSymbolB
     EXPECT_FALSE(_pt->isProtected());
 }
 
-// A Symbol longer than the fixed dump-time buffer is reported as unresolved
-// rather than truncated or copied out of bounds. Pins the cap behaviour so a
-// future change to the buffer sizes is a deliberate test edit.
-TEST_F(HotspotResolveCrashProtectionTest, ResolveReturnsNullForOverlongSymbol) {
+// A method name longer than the fixed inline buffer (MAX_METHOD_NAME_LEN,
+// 512 bytes) but fully readable must take ResolvedNames::setImpl()'s malloc
+// fallback and still resolve successfully through to the JNI phase, with the
+// full, correctly NUL-terminated name -- not get rejected the way a name
+// this size would be by the *unreadable*-body case below.
+TEST_F(HotspotResolveCrashProtectionTest, ResolveUsesMallocFallbackForOversizedButReadableName) {
     HotspotMethodIdVMHotspotGuard hotspot;
     VMStructsTestAccessor offsets(RESOLVE_OFFSETS);
     VMStructsTestAccessor::SymbolLayout layout(RESOLVE_SYMBOL_OFFSETS, RESOLVE_TYPE_SIZES);
@@ -579,7 +652,73 @@ TEST_F(HotspotResolveCrashProtectionTest, ResolveReturnsNullForOverlongSymbol) {
     f->link();
     ResolveFakes::setSymbol(f->sig_sym, "()V");
     ResolveFakes::setSymbol(f->klass_sym, "java/lang/Object");
-    f->name_sym.length = 0xFFFF;  // far above MAX_METHOD_NAME_LEN
+
+    // Longer than MAX_METHOD_NAME_LEN (512) but well under the 16-bit range a
+    // real Symbol::length() can report, and fully readable. Written past
+    // ResolveFakes' own footprint in the same mapped page so it doesn't
+    // clobber sig_sym/klass_sym, then wired in as the name Symbol in place of
+    // f->name_sym (whose fixed body[64] is too small to hold it).
+    const std::string long_name(600, 'm');
+    char* long_symbol = (char*)_region + 1024;
+    *(uint16_t*)(long_symbol + RESOLVE_SYMBOL_OFFSETS.symbol_length) = (uint16_t)long_name.size();
+    memcpy(long_symbol + RESOLVE_SYMBOL_OFFSETS.symbol_body, long_name.data(), long_name.size());
+    f->cpool.symbols[1] = (intptr_t)long_symbol;  // name_index slot, see link()
+
+    ScopedFakeJni fake_jni;
+
+    long long unreadable_before = Counters::getCounter(METHOD_RESOLVE_SYMBOL_UNREADABLE);
+    long long fault_before = Counters::getCounter(METHOD_RESOLVE_FAULT_RECOVERED);
+
+    // The fake JNI's GetMethodID reports "not found", so resolve() itself
+    // still returns nullptr -- the point of this test is what it does on the
+    // way there, checked below.
+    EXPECT_EQ(nullptr, HotspotSupport::resolve(&f->method));
+
+    // Phase 1 accepted the name via the malloc fallback (no rejection, no
+    // fault) and reached phase 2, which called GetMethodID with the fully
+    // copied name -- proof the fallback copied all 600 bytes and
+    // NUL-terminated them correctly rather than truncating to the inline
+    // buffer or leaving it uninitialized.
+    EXPECT_EQ(unreadable_before, Counters::getCounter(METHOD_RESOLVE_SYMBOL_UNREADABLE));
+    EXPECT_EQ(fault_before, Counters::getCounter(METHOD_RESOLVE_FAULT_RECOVERED));
+    // GetMethodID and GetStaticMethodID share this mock and both report "not
+    // found", so lookupMethodIdViaJni() falls through from one to the other --
+    // two calls, both carrying the same (correct) captured name/signature.
+    EXPECT_EQ(2, fake_jni.getMethodIdCalls());
+    EXPECT_EQ(long_name, fake_jni.lastMethodName());
+    EXPECT_EQ("()V", fake_jni.lastMethodSignature());
+    EXPECT_FALSE(_pt->isProtected());
+}
+
+// NOTE for reviewers: a companion test asserting the *hard* MAX_SYMBOL_LEN
+// ceiling (`len >= MAX_SYMBOL_LEN` in ResolvedNames::setImpl) rejects a
+// symbol is intentionally not included here. VMSymbol::length() returns
+// `unsigned short` (vmStructs.h), so the largest value it can ever produce is
+// 65535 -- which is already below MAX_SYMBOL_LEN (64 * 1024 = 65536). That
+// branch cannot be reached through a real Symbol length field as currently
+// typed; forging a >=65536 "length" in the test would require bypassing the
+// u2 width the fake is deliberately modeling, which would pin a value that
+// can't occur in production rather than real cap behavior. Flagging this as
+// a probable dead branch (or a MAX_SYMBOL_LEN that should be 65536 -> 65535,
+// or the comparison that should be `>` semantics some other way) rather than
+// writing a test around it -- worth confirming with whoever added the check
+// what it was meant to guard against.
+//
+// What *is* pinned below is the related, reachable case: a Symbol at the
+// largest value the field can actually hold (0xFFFF) whose body is not fully
+// readable is rejected by the SafeAccess probe in copySymbolBody(), the same
+// mechanism as ResolveReturnsNullForUnreadableSymbolBody above, just at the
+// boundary length instead of a short one.
+TEST_F(HotspotResolveCrashProtectionTest, ResolveRejectsUnreadableSymbolAtMaxLength) {
+    HotspotMethodIdVMHotspotGuard hotspot;
+    VMStructsTestAccessor offsets(RESOLVE_OFFSETS);
+    VMStructsTestAccessor::SymbolLayout layout(RESOLVE_SYMBOL_OFFSETS, RESOLVE_TYPE_SIZES);
+
+    ResolveFakes* f = new (_region) ResolveFakes{};
+    f->link();
+    ResolveFakes::setSymbol(f->sig_sym, "()V");
+    ResolveFakes::setSymbol(f->klass_sym, "java/lang/Object");
+    f->name_sym.length = 0xFFFF;  // max value a real u2 length field can hold
 
     long long before = Counters::getCounter(METHOD_RESOLVE_SYMBOL_UNREADABLE);
 

--- a/ddprof-lib/src/test/cpp/hotspotMethodId_ut.cpp
+++ b/ddprof-lib/src/test/cpp/hotspotMethodId_ut.cpp
@@ -350,8 +350,15 @@ TEST(HotspotMethodIdTest, IdReturnsValidIdForPopulatedSlot) {
 namespace {
 
 // Two adjacent pages; the second is PROT_NONE. Fake metadata lives at the start
-// of the first, so an offset of kPageSize lands on the guard page.
-constexpr size_t kPageSize = 4096;
+// of the first, so an offset of kPageSize() lands on the guard page.
+// Must be the real OS page size, not a hardcoded 4096: mmap()/mprotect() need
+// page-aligned addresses and sizes, and on arm64 Linux the page size can be
+// 16384 or 65536, not 4096. A function rather than a namespace-scope const:
+// OS::page_size is itself a dynamically-initialized static in another
+// translation unit, and cross-TU static init order is unspecified, so caching
+// it in another static here could read it before it's set. Calling through a
+// function defers the read to test-run time, well after all static init.
+size_t kPageSize() { return OS::page_size; }
 
 // Layout of the fake metadata used by the resolve() tests. Sizes are the values
 // VMConstantPool::base() and cast_or_null() need; they only have to be non-zero
@@ -449,10 +456,10 @@ protected:
         _orig_segv = OS::replaceSigsegvHandler(Profiler::segvHandler);
         _orig_bus = OS::replaceSigbusHandler(Profiler::busHandler);
 
-        _region = mmap(nullptr, 2 * kPageSize, PROT_READ | PROT_WRITE,
+        _region = mmap(nullptr, 2 * kPageSize(), PROT_READ | PROT_WRITE,
                        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         ASSERT_NE(MAP_FAILED, _region);
-        ASSERT_EQ(0, mprotect((char*)_region + kPageSize, kPageSize, PROT_NONE));
+        ASSERT_EQ(0, mprotect((char*)_region + kPageSize(), kPageSize(), PROT_NONE));
 
         // Two exported symbols from hotspotSupport.cpp, far apart in that TU.
         uintptr_t a = (uintptr_t)&HotspotSupport::resolve;
@@ -464,7 +471,7 @@ protected:
 
     void TearDown() override {
         Profiler::resetAddressRangeForTest();
-        munmap(_region, 2 * kPageSize);
+        munmap(_region, 2 * kPageSize());
         OS::replaceSigsegvHandler(_orig_segv);
         OS::replaceSigbusHandler(_orig_bus);
         ProfiledThread::release();
@@ -493,7 +500,7 @@ TEST_F(HotspotResolveCrashProtectionTest, ResolveRecoversFromFaultInsteadOfCrash
     // only validates [ptr, ptr + VMMethod::type_size()), which stays on the
     // readable page -- the fault comes from the offset, not the pointer.
     VMStructsTestAccessor::Offsets faulting = RESOLVE_OFFSETS;
-    faulting.method_constmethod = (int)kPageSize;
+    faulting.method_constmethod = (int)kPageSize();
     VMStructsTestAccessor offsets(faulting);
     VMStructsTestAccessor::SymbolLayout layout(RESOLVE_SYMBOL_OFFSETS, RESOLVE_TYPE_SIZES);
 
@@ -515,7 +522,7 @@ TEST_F(HotspotResolveCrashProtectionTest, ResolveRecoversFromFaultInsteadOfCrash
 TEST_F(HotspotResolveCrashProtectionTest, ResolveRecoversRepeatedly) {
     HotspotMethodIdVMHotspotGuard hotspot;
     VMStructsTestAccessor::Offsets faulting = RESOLVE_OFFSETS;
-    faulting.method_constmethod = (int)kPageSize;
+    faulting.method_constmethod = (int)kPageSize();
     VMStructsTestAccessor offsets(faulting);
     VMStructsTestAccessor::SymbolLayout layout(RESOLVE_SYMBOL_OFFSETS, RESOLVE_TYPE_SIZES);
 
@@ -545,7 +552,7 @@ TEST_F(HotspotResolveCrashProtectionTest, ResolveReturnsNullForUnreadableSymbolB
     // page: exactly VMSymbol::type_size() bytes, so VMSymbol::cast_or_null()'s
     // own isReadableRange() check still passes and the rejection has to come from
     // copySymbolBody(). The declared length then runs the body off the page.
-    char* edge = (char*)_region + kPageSize - RESOLVE_TYPE_SIZES.symbol;
+    char* edge = (char*)_region + kPageSize() - RESOLVE_TYPE_SIZES.symbol;
     *(uint16_t*)(edge + RESOLVE_SYMBOL_OFFSETS.symbol_length) = 100;
     f->klass.name_symbol = edge;
 

--- a/ddprof-lib/src/test/cpp/hotspotSupport_ut.cpp
+++ b/ddprof-lib/src/test/cpp/hotspotSupport_ut.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026, Datadog, Inc
+ */
+
+#include <gtest/gtest.h>
+#include "../../main/cpp/hotspot/hotspotSupport.h"
+#include "../../main/cpp/gtest_crash_handler.h"
+
+static constexpr char HOTSPOT_SUPPORT_TEST_NAME[] = "HotspotSupportTest";
+class HotspotSupportGlobalSetup {
+public:
+    HotspotSupportGlobalSetup()  { installGtestCrashHandler<HOTSPOT_SUPPORT_TEST_NAME>(); }
+    ~HotspotSupportGlobalSetup() { restoreDefaultSignalHandlers(); }
+};
+static HotspotSupportGlobalSetup hotspot_support_global_setup;
+
+// ---------------------------------------------------------------------------
+// HotspotSupportTestAccessor — friend of HotspotSupport, exposes the private
+// loadMethodIDsIfNeededImpl() so the regression test for the <clinit>
+// resolve() fallback (which now routes through it, instead of calling
+// jvmti->GetClassMethods directly) can exercise it without a live JVM.
+// ---------------------------------------------------------------------------
+class HotspotSupportTestAccessor {
+public:
+    static bool loadMethodIDsIfNeededImpl(jvmtiEnv *jvmti, JNIEnv *jni, jclass klass, bool load_all) {
+        return HotspotSupport::loadMethodIDsIfNeededImpl(jvmti, jni, klass, load_all);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Mock JVMTI infrastructure. With load_all=true, loadMethodIDsIfNeededImpl()
+// skips its hidden-class/system-classloader checks entirely and calls
+// patchClassLoaderData() (a no-op here, since VM::hotspot_version() defaults
+// to 0 -- not 8 -- in this gtest binary with no live JVM attached) followed
+// by JVMSupport::loadMethodIDsImpl(), whose only JVMTI calls are
+// GetClassMethods and Deallocate.
+// ---------------------------------------------------------------------------
+static int g_get_class_methods_calls = 0;
+
+static jvmtiError JNICALL mock_GetClassMethods_ok(jvmtiEnv*, jclass, jint* method_count_ptr, jmethodID** methods_ptr) {
+    g_get_class_methods_calls++;
+    *method_count_ptr = 0;
+    *methods_ptr = nullptr;
+    return JVMTI_ERROR_NONE;
+}
+static jvmtiError JNICALL mock_Deallocate_noop(jvmtiEnv*, unsigned char*) {
+    return JVMTI_ERROR_NONE;
+}
+
+class HotspotSupportLoadMethodIDsTest : public ::testing::Test {
+protected:
+    jvmtiInterface_1_ tbl{};
+    _jvmtiEnv mock_jvmti{};
+
+    void SetUp() override {
+        g_get_class_methods_calls = 0;
+        tbl = jvmtiInterface_1_{};
+        tbl.GetClassMethods = &mock_GetClassMethods_ok;
+        tbl.Deallocate = &mock_Deallocate_noop;
+        mock_jvmti.functions = &tbl;
+    }
+};
+
+TEST_F(HotspotSupportLoadMethodIDsTest, LoadAllSucceedsAndCallsGetClassMethodsOnce) {
+    jclass fake_klass = reinterpret_cast<jclass>(0x1);
+
+    bool result = HotspotSupportTestAccessor::loadMethodIDsIfNeededImpl(
+        &mock_jvmti, /*jni=*/nullptr, fake_klass, /*load_all=*/true);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(1, g_get_class_methods_calls)
+        << "the <clinit> resolve() fallback must go through this exact path "
+           "(load_all=true), which is what now applies patchClassLoaderData() "
+           "before allocating jmethodIDs";
+}

--- a/ddprof-lib/src/test/cpp/hotspot_crash_protection_ut.cpp
+++ b/ddprof-lib/src/test/cpp/hotspot_crash_protection_ut.cpp
@@ -25,6 +25,8 @@
  *   A. ProfiledThread thread-type classification (isJavaThread fast path)
  *   B. Crash-handler nesting depth (ProfiledThread crash handler state)
  *   C. sigjmp_buf chaining across nested/interrupted walkVM() calls
+ *  C2. JmpCtxScope, the RAII form of that protocol (used by
+ *      HotspotSupport::resolve())
  *   F. HotspotSupport::walkJavaStack()'s AsyncSampleMutex release on a
  *      recovered fault
  */
@@ -34,6 +36,7 @@
 #include "profiler.h"
 
 #include "asyncSampleMutex.h"
+#include "guards.h"
 #include "jvmThread.h"
 #include "safeAccess.h"
 #include "os.h"
@@ -325,6 +328,161 @@ TEST_F(JmpCtxChainingTest, FaultInInnerFrameDoesNotDisturbOuterFrame) {
     EXPECT_EQ(1, inner_landed);
     EXPECT_EQ(0, outer_landed) << "the fault must not have unwound past the inner frame";
     EXPECT_FALSE(_pt->isProtected());
+}
+
+// ---------------------------------------------------------------------------
+// C2. JmpCtxScope — the RAII form of the protocol section C tests by hand.
+//
+// HotspotSupport::resolve() uses it; walkVM/walkJavaStack/walkFP/walkDwarf still
+// hand-roll the same save/install/restore. These tests assert the guard
+// reproduces that protocol store-for-store, which is what makes migrating those
+// four call sites a mechanical change rather than a risky one.
+//
+// The class's members are both const by design (guards.h): they are initialised
+// before the owning frame calls sigsetjmp() and are never written afterwards, so
+// reading them from a landing pad is well defined -- unlike a plain non-volatile
+// local assigned in between, whose value after siglongjmp is indeterminate.
+// ---------------------------------------------------------------------------
+
+// Construction only snapshots the current landing pad; it must not arm anything.
+TEST_F(JmpCtxChainingTest, JmpCtxScopeCtorDoesNotInstall) {
+    sigjmp_buf ctx;
+    {
+        JmpCtxScope scope(_pt);
+        EXPECT_FALSE(_pt->isProtected());
+        EXPECT_EQ(nullptr, _pt->getJmpCtx());
+        scope.install(&ctx);
+        EXPECT_EQ(&ctx, _pt->getJmpCtx());
+    }
+    EXPECT_FALSE(_pt->isProtected());
+}
+
+// The whole point of the guard: scope exit reinstates the previous context even
+// though no explicit restore() call was written.
+TEST_F(JmpCtxChainingTest, JmpCtxScopeExitRestoresWithoutExplicitCall) {
+    sigjmp_buf outer;
+    _pt->setJmpCtx(&outer);
+
+    {
+        sigjmp_buf inner;
+        JmpCtxScope scope(_pt);
+        scope.install(&inner);
+        EXPECT_EQ(&inner, _pt->getJmpCtx());
+    }
+
+    EXPECT_EQ(&outer, _pt->getJmpCtx());
+    _pt->setJmpCtx(nullptr);
+}
+
+// restore() and the destructor must be interchangeable and safe to run in
+// sequence: _prev is const, so both make the identical store.
+TEST_F(JmpCtxChainingTest, JmpCtxScopeRestoreThenDtorIsIdempotent) {
+    sigjmp_buf outer;
+    _pt->setJmpCtx(&outer);
+
+    {
+        sigjmp_buf inner;
+        JmpCtxScope scope(_pt);
+        scope.install(&inner);
+        scope.restore();
+        EXPECT_EQ(&outer, _pt->getJmpCtx());
+        scope.restore();  // explicitly redundant
+        EXPECT_EQ(&outer, _pt->getJmpCtx());
+    }  // destructor makes the same store a third time
+
+    EXPECT_EQ(&outer, _pt->getJmpCtx());
+    _pt->setJmpCtx(nullptr);
+}
+
+// Nested scopes must unwind strictly LIFO, each handing back exactly the context
+// that was live when it was constructed.
+TEST_F(JmpCtxChainingTest, JmpCtxScopeNestedScopesUnwindLIFO) {
+    sigjmp_buf outer_ctx;
+    sigjmp_buf inner_ctx;
+
+    {
+        JmpCtxScope outer(_pt);
+        outer.install(&outer_ctx);
+        EXPECT_EQ(&outer_ctx, _pt->getJmpCtx());
+
+        {
+            JmpCtxScope inner(_pt);
+            inner.install(&inner_ctx);
+            EXPECT_EQ(&inner_ctx, _pt->getJmpCtx());
+        }
+
+        EXPECT_EQ(&outer_ctx, _pt->getJmpCtx())
+            << "inner scope must hand the outer's context back";
+    }
+
+    EXPECT_FALSE(_pt->isProtected());
+}
+
+// Real sigsetjmp/siglongjmp: the RAII port of
+// FaultInInnerFrameDoesNotDisturbOuterFrame above.
+TEST_F(JmpCtxChainingTest, JmpCtxScopeFaultInInnerScopeDoesNotDisturbOuter) {
+    sigjmp_buf outer_ctx;
+    int outer_landed = 0;
+    int inner_landed = 0;
+
+    JmpCtxScope outer_scope(_pt);
+    if (sigsetjmp(outer_ctx, 1) != 0) {
+        outer_landed++;
+        outer_scope.restore();
+    } else {
+        outer_scope.install(&outer_ctx);
+
+        // --- inner protected call, interrupted mid-flight by a fault ---
+        {
+            sigjmp_buf inner_ctx;
+            JmpCtxScope inner_scope(_pt);
+            if (sigsetjmp(inner_ctx, 1) != 0) {
+                inner_landed++;
+                inner_scope.restore();
+            } else {
+                inner_scope.install(&inner_ctx);
+                // Simulate checkFault(): siglongjmp through whatever is
+                // installed. This must land in the inner frame, not the outer.
+                siglongjmp(*_pt->getJmpCtx(), 1);
+                FAIL() << "unreachable: siglongjmp does not return";
+            }
+        }
+
+        EXPECT_EQ(&outer_ctx, _pt->getJmpCtx())
+            << "outer frame's context must survive the inner frame's fault";
+        outer_scope.restore();
+    }
+
+    EXPECT_EQ(1, inner_landed);
+    EXPECT_EQ(0, outer_landed) << "the fault must not have unwound past the inner frame";
+    EXPECT_FALSE(_pt->isProtected());
+}
+
+// The failure mode the guard exists to prevent: a landing pad that forgets to
+// disarm. checkFault() would happily jump into a landing pad whose frame has
+// already been popped, so the destructor must cover the omission.
+TEST_F(JmpCtxChainingTest, JmpCtxScopeDestructorAloneRestoresAfterLongjmp) {
+    sigjmp_buf outer;
+    _pt->setJmpCtx(&outer);
+    int landed = 0;
+
+    {
+        sigjmp_buf ctx;
+        JmpCtxScope scope(_pt);
+        if (sigsetjmp(ctx, 1) != 0) {
+            landed++;
+            // Deliberately no scope.restore() here.
+        } else {
+            scope.install(&ctx);
+            siglongjmp(*_pt->getJmpCtx(), 1);
+            FAIL() << "unreachable: siglongjmp does not return";
+        }
+    }
+
+    EXPECT_EQ(1, landed);
+    EXPECT_EQ(&outer, _pt->getJmpCtx())
+        << "destructor must disarm even when the landing pad did not";
+    _pt->setJmpCtx(nullptr);
 }
 
 // ---------------------------------------------------------------------------

--- a/ddprof-lib/src/test/cpp/jvmSupport_ut.cpp
+++ b/ddprof-lib/src/test/cpp/jvmSupport_ut.cpp
@@ -250,10 +250,12 @@ protected:
     JNINativeInterface_ jni_tbl{};
     JNIEnv_ mock_jni{};
     bool _orig_hotspot;
+    JVMSupportTestAccessor::LoadState _orig_load_state;
 
     void SetUp() override {
         _orig_hotspot = VMTestAccessor::getHotspot();
         VMTestAccessor::setHotspot(true);
+        _orig_load_state = JVMSupportTestAccessor::getLoadState();
         JVMSupportTestAccessor::setLoadState(JVMSupportTestAccessor::NoLoaded());
 
         jvmti_tbl = jvmtiInterface_1_{};
@@ -270,6 +272,7 @@ protected:
 
     void TearDown() override {
         VMTestAccessor::setHotspot(_orig_hotspot);
+        JVMSupportTestAccessor::setLoadState(_orig_load_state);
     }
 };
 
@@ -286,8 +289,7 @@ TEST_F(JVMSupportRestartTest, SecondStartWithPartialPreloadIsNotBlockedByStaleFu
 
     JVMSupport::initExecution(partial_args, &mock_jvmti, reinterpret_cast<JNIEnv*>(&mock_jni));
 
-    // Fails today: the stale Fully_loaded state short-circuits initExecution()
-    // before shouldPreloadJmethodIDs(partial_args) is ever evaluated, so the
-    // state incorrectly stays Fully_loaded instead of downgrading.
+    // Regression: before the fix, a stale Fully_loaded state short-circuited initExecution()...
+    // so the state stayed Fully_loaded instead of downgrading.
     EXPECT_EQ(JVMSupportTestAccessor::PartialLoaded(), JVMSupportTestAccessor::getLoadState());
 }

--- a/ddprof-lib/src/test/cpp/jvmSupport_ut.cpp
+++ b/ddprof-lib/src/test/cpp/jvmSupport_ut.cpp
@@ -40,12 +40,31 @@ static JvmSupportGlobalSetup jvm_support_global_setup;
 
 // ---------------------------------------------------------------------------
 // VMTestAccessor — friend of VM, lets tests swap VM::_jvmti for a mock so
-// JVMThread::currentThreadSlow() can be exercised without a live JVM.
+// JVMThread::currentThreadSlow() can be exercised without a live JVM. Also
+// lets tests force VM::isHotspot() so JVMSupport::initExecution()'s HotSpot
+// branch can be exercised deterministically.
 // ---------------------------------------------------------------------------
 class VMTestAccessor {
 public:
     static jvmtiEnv* getJvmti() { return VM::_jvmti; }
     static void setJvmti(jvmtiEnv* env) { VM::_jvmti = env; }
+    static bool getHotspot() { return VM::_hotspot; }
+    static void setHotspot(bool v) { VM::_hotspot = v; }
+};
+
+// ---------------------------------------------------------------------------
+// JVMSupportTestAccessor — friend of JVMSupport, lets tests read/reset the
+// private jmethodID_load_state directly instead of only observing its
+// effects through initExecution()'s side effects.
+// ---------------------------------------------------------------------------
+class JVMSupportTestAccessor {
+public:
+    using LoadState = JVMSupport::JMethodIDLoadStats;
+    static LoadState getLoadState() { return JVMSupport::getLoadState(); }
+    static void setLoadState(LoadState s) { JVMSupport::setLoadState(s); }
+    static constexpr LoadState NoLoaded()      { return JVMSupport::No_loaded; }
+    static constexpr LoadState PartialLoaded() { return JVMSupport::Partial_loaded; }
+    static constexpr LoadState FullyLoaded()   { return JVMSupport::Fully_loaded; }
 };
 
 // ---------------------------------------------------------------------------
@@ -192,4 +211,83 @@ TEST(JvmSupportErrorLatchTest, CheckStateStaysBlockedOnceInError) {
     EXPECT_TRUE(has_error);
     EXPECT_STREQ("Profiler encountered fatal error", error.message());
     EXPECT_EQ(ERROR, ProfilerTestAccessor::getState(p));
+}
+
+// ---------------------------------------------------------------------------
+// Regression tests for JVMSupport::initExecution(): a stale jmethodID_load_state
+// left over from a previous execution must not short-circuit before the
+// current Arguments are evaluated (otherwise a restart with fjmethodid=false
+// after a full-preload session silently keeps full-preload mode).
+//
+// initExecution() with load_all=false calls HotspotSupport::initClassloaderInfo(jni),
+// which calls jni->FindClass("java/lang/ClassLoader") first; mocking FindClass
+// to return nullptr makes it take the early-exit path (jni->ExceptionClear(); return;)
+// without touching any other JNI/VMStructs machinery.
+// ---------------------------------------------------------------------------
+static jclass JNICALL mock_FindClass_returns_null(JNIEnv*, const char*) {
+    return nullptr;
+}
+static void JNICALL mock_ExceptionClear_noop(JNIEnv*) {}
+
+static jvmtiError JNICALL mock_GetLoadedClasses_empty(jvmtiEnv*, jint* class_count_ptr, jclass** classes_ptr) {
+    *class_count_ptr = 0;
+    *classes_ptr = nullptr;
+    return JVMTI_ERROR_NONE;
+}
+static jvmtiError JNICALL mock_GetClassMethods_empty(jvmtiEnv*, jclass, jint* method_count_ptr, jmethodID** methods_ptr) {
+    *method_count_ptr = 0;
+    *methods_ptr = nullptr;
+    return JVMTI_ERROR_NONE;
+}
+static jvmtiError JNICALL mock_Deallocate_noop(jvmtiEnv*, unsigned char*) {
+    return JVMTI_ERROR_NONE;
+}
+
+class JVMSupportRestartTest : public ::testing::Test {
+protected:
+    jvmtiInterface_1_ jvmti_tbl{};
+    _jvmtiEnv mock_jvmti{};
+    JNINativeInterface_ jni_tbl{};
+    JNIEnv_ mock_jni{};
+    bool _orig_hotspot;
+
+    void SetUp() override {
+        _orig_hotspot = VMTestAccessor::getHotspot();
+        VMTestAccessor::setHotspot(true);
+        JVMSupportTestAccessor::setLoadState(JVMSupportTestAccessor::NoLoaded());
+
+        jvmti_tbl = jvmtiInterface_1_{};
+        jvmti_tbl.GetLoadedClasses = &mock_GetLoadedClasses_empty;
+        jvmti_tbl.GetClassMethods = &mock_GetClassMethods_empty;
+        jvmti_tbl.Deallocate = &mock_Deallocate_noop;
+        mock_jvmti.functions = &jvmti_tbl;
+
+        jni_tbl = JNINativeInterface_{};
+        jni_tbl.FindClass = &mock_FindClass_returns_null;
+        jni_tbl.ExceptionClear = &mock_ExceptionClear_noop;
+        mock_jni.functions = &jni_tbl;
+    }
+
+    void TearDown() override {
+        VMTestAccessor::setHotspot(_orig_hotspot);
+    }
+};
+
+TEST_F(JVMSupportRestartTest, SecondStartWithPartialPreloadIsNotBlockedByStaleFullyLoaded) {
+    Arguments full_args;
+    full_args._force_jmethodID = true; // -> shouldPreloadJmethodIDs()==true -> Fully_loaded
+
+    JVMSupport::initExecution(full_args, &mock_jvmti, reinterpret_cast<JNIEnv*>(&mock_jni));
+    EXPECT_EQ(JVMSupportTestAccessor::FullyLoaded(), JVMSupportTestAccessor::getLoadState());
+
+    Arguments partial_args;
+    partial_args._force_jmethodID = false;
+    partial_args._cstack = CSTACK_VM; // -> shouldPreloadJmethodIDs()==false -> Partial_loaded
+
+    JVMSupport::initExecution(partial_args, &mock_jvmti, reinterpret_cast<JNIEnv*>(&mock_jni));
+
+    // Fails today: the stale Fully_loaded state short-circuits initExecution()
+    // before shouldPreloadJmethodIDs(partial_args) is ever evaluated, so the
+    // state incorrectly stays Fully_loaded instead of downgrading.
+    EXPECT_EQ(JVMSupportTestAccessor::PartialLoaded(), JVMSupportTestAccessor::getLoadState());
 }


### PR DESCRIPTION
**What does this PR do?**:

Hardens `HotspotSupport::resolve()` — the dump-time fallback that resolves a raw `Method*` to a `jmethodID` when `cstack=vm,fjmethodid=false` — against crashes from stale JVM metadata, and fixes three separate bugs that caused `<clinit>` frames captured under that configuration to always serialize as `"unknown"` instead of resolving correctly:

1. `JVMSupport::initExecution()` short-circuited on a stale `Fully_loaded` state left over from a previous session, so a later `fjmethodid=false` start never re-evaluated whether jmethodID preloading should actually be disabled.
2. The `<clinit>` JVMTI fallback called `GetClassMethods` directly instead of going through `loadMethodIDsIfNeededImpl()`, skipping the JDK-8062116 classloader-data patch that every other preload path applies.
3. `HotspotSupport::fillJavaFrame()` read `VM::arguments()._force_jmethodID` — a global `Arguments` object that's only updated by the command-line agent-attach path, never by the `JavaProfiler.execute()` JNI API. Every session started via the JNI API (which is how the test suite, and most embedding use, starts the profiler) therefore saw a permanently stale `_force_jmethodID`, so un-preloaded methods were always treated as unwalkable and serialized as `"unknown"` instead of taking the intended raw-`Method*` fallback path. Fixed by giving `Profiler` its own `_force_jmethodID` member (mirroring the existing `_cstack` field) set from the actual startup `Arguments`.

Also adds a malloc-backed fallback for method/class/signature names that don't fit the fixed inline buffers used during crash-protected resolution (previously such names silently resolved as `"unknown"` with no fallback), and closes out the correctness gaps that fallback introduced: a double-free on the crash-recovery path (`release()` is now idempotent), a setjmp/longjmp indeterminate-value issue (the malloc'd pointers are now `volatile`, since they're mutated between `sigsetjmp()` and a possible `siglongjmp()` and then read back by the recovery path), and a dead-code fallback (the malloc path was unreachable for class-name/signature since their short-buffer size equaled the hard rejection ceiling — lowered to 1024 so the fallback actually engages).

**Motivation**:

`ClinitResolutionTest` was failing: a class's `<clinit>` frame, sampled while spinning for ~2s under `cpu=1ms,cstack=vm,fjmethodid=false`, never resolved to its real class/method name in the resulting JFR — it always showed as the shared `"unknown"` frame. Root-causing this surfaced the three bugs above, none of which were specific to `<clinit>` — they affect any raw-`Method*` resolution under `fjmethodid=false`, `<clinit>` just happened to be the scenario the test exercised.

**Additional Notes**:

- Fixes (1) and (2) were ported from `paul.fournillon/jmethod_clinit_fix`, adapted to this branch's crash-protection refactor.
- Known, lower-priority items surfaced during review but intentionally not addressed here (happy to split into follow-ups if preferred):
  - Name/signature resolution is still bounded (512/1024/4096 bytes, not the full 65535 the JVM permits) — a deliberate fidelity/complexity tradeoff, not a full fix.
  - `METHOD_RESOLVE_FAULT_RECOVERED` overlaps `STACKWALK_LONGJMP_RECOVERED` for the same fault; nothing enforces the "subtract, never sum" comment, so a naive counter-summing dashboard would double-count.
  - The `<clinit>` fallback's `patchClassLoaderData()` call (JDK 8 only) is now reachable from the dump thread as well as from `ClassPrepare`; a narrow race could invoke it twice for the same class.
  - `resolve()`'s top-level doc comment ("only resolves system-classloader methods") is slightly stale given the `<clinit>` fallback's `load_all=true`; the constraint still holds in practice via the earlier `FindClass` call, so this is cosmetic.

**How to test the change?**:

- `./gradlew :ddprof-lib:gtestDebug_hotspotSupport_ut :ddprof-lib:gtestDebug_jvmSupport_ut` — new/updated unit tests for `JVMSupport::initExecution()`'s stale-state bug and the `<clinit>` fallback's `loadMethodIDsIfNeededImpl()` routing.
- `./gradlew testdebug --tests com.datadoghq.profiler.cpu.ClinitResolutionTest` — the regression test for this bug, passes reliably on the first attempt (previously failed even after all 5 retries).
- `./gradlew testdebug --tests "com.datadoghq.profiler.cpu.*"` — full `cpu` test package, including `VtableReceiverFrameTest`, all passing.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-15786](https://datadoghq.atlassian.net/browse/PROF-15786)

Unsure? Have a question? Request a review!

[PROF-15786]: https://datadoghq.atlassian.net/browse/PROF-15786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
