### PR TITLE
Serialize stale jmethodID frames as <unloaded> instead of jvmtiError

### DIFF
--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -354,7 +354,7 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
     } else {
       Counters::increment(JMETHODID_SKIPPED);
       class_name_id = _classes->lookupDuringDump("", 0, Profiler::maxClassMapSize());
-      method_name_id = _symbols.lookup("jvmtiError");
+      method_name_id = _symbols.lookup("<unloaded>");
       method_sig_id = _symbols.lookup("()L;");
     }
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/CTimerSamplerTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/CTimerSamplerTest.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -55,11 +54,8 @@ public class CTimerSamplerTest extends CStackAwareAbstractProfilerTest {
         verifyCStackSettings();
 
         // Streamed rather than materialized: cpu=100us over this workload can produce tens of
-        // thousands of samples, and every check here is per-event with no need to retain them.
-        long sampleCount = streamEvents("datadog.ExecutionSample", sample -> {
-            String stackTrace = sample.getStackTraceString();
-            assertFalse(stackTrace.contains("jvmtiError"));
-        });
+        // thousands of samples; streamEvents counts them without retaining them in memory.
+        long sampleCount = streamEvents("datadog.ExecutionSample", sample -> { });
         assertTrue(sampleCount > 0, "datadog.ExecutionSample was empty");
     }
 

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/RemoteSymbolicationTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/RemoteSymbolicationTest.java
@@ -18,9 +18,7 @@ import com.datadoghq.profiler.JfrEvent;
 import com.datadoghq.profiler.JfrEvents;
 import com.datadoghq.profiler.JfrFrame;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Integration test for remote symbolication feature.
@@ -110,11 +108,7 @@ public class RemoteSymbolicationTest extends CStackAwareAbstractProfilerTest {
 
                 // Iterate through frames to check for test library frames
                 for (JfrFrame frame : sample.getStackTrace().frames()) {
-                    // Check for jvmtiError in method name
                     String methodName = frame.methodName();
-                    if (methodName != null && methodName.contains("jvmtiError")) {
-                        fail("Found jvmtiError in frame method name: " + methodName);
-                    }
 
                     // Get class name (contains build-id for remote symbolication frames)
                     String className = frame.className();

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/SmokeCpuTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/cpu/SmokeCpuTest.java
@@ -17,7 +17,6 @@ import com.datadoghq.profiler.JfrEvents;
 
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadoghq.profiler.Platform;
@@ -44,7 +43,6 @@ public class SmokeCpuTest extends CStackAwareAbstractProfilerTest {
             // on mac the usage of itimer to drive the sampling provides very unreliable outputs
             for (JfrEvent sample : events) {
                 String stackTrace = sample.getStackTraceString();
-                assertFalse(stackTrace.contains("jvmtiError"));
                 if ("vmx".equals(stackTrace)) {
                     // extra checks to make sure we see the mixed stacktraces
                     assertTrue(stackTrace.contains("JavaCalls::call_virtual()"),
@@ -71,7 +69,6 @@ public class SmokeCpuTest extends CStackAwareAbstractProfilerTest {
         // on mac the usage of itimer to drive the sampling provides very unreliable outputs
         for (JfrEvent sample : events) {
             String stackTrace = sample.getStackTraceString();
-            assertFalse(stackTrace.contains("jvmtiError"));
             if ("vmx".equals(stackTrace)) {
                 // extra checks to make sure we see the mixed stacktraces
                 assertTrue(stackTrace.contains("JavaCalls::call_virtual()"),

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/JMethodIDInvalidationStressTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/JMethodIDInvalidationStressTest.java
@@ -15,6 +15,8 @@
  */
 package com.datadoghq.profiler.memleak;
 
+import com.datadoghq.profiler.JfrEvent;
+import com.datadoghq.profiler.JfrFrame;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -33,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -188,6 +191,22 @@ public class JMethodIDInvalidationStressTest extends AbstractDynamicClassTest {
               + "churn, not just that the JVM didn't crash; if this keeps getting skipped, the "
               + "churn isn't racing unload against resolveMethod/fillJavaMethodInfo tightly "
               + "enough (consider more churn threads or a longer window).");
+
+      // The jmethodid_skipped_count counter is incremented in the exact branch of
+      // Lookup::fillJavaMethodInfo (the JVMTI-resolution-failure 'else') that serializes a
+      // stale-jmethodID frame as '<unloaded>'. line_number_table_unreadable is a separate,
+      // mutually-exclusive branch where the jmethodID *did* resolve to a real method/class name
+      // and only the line-number-table copy failed -- it never produces '<unloaded>'. So the
+      // recording assertion below is only meaningful when skippedDelta > 0; a run that only
+      // triggered the line-table race would otherwise fail spuriously. Gate it accordingly.
+      Assumptions.assumeTrue(skippedDelta > 0,
+          "Churn window hit only the line-number-table race (line_number_table_unreadable delta="
+              + unreadableLineTableDelta + ", jmethodid_skipped_count delta=" + skippedDelta
+              + ") -- the '<unloaded>' label assertion is only meaningful when the"
+              + " JVMTI-resolution-failure branch ran; skipping to avoid a spurious failure.");
+      // Assert that the recording produced by that branch uses the '<unloaded>' label and
+      // never the legacy 'jvmtiError' one -- this fails if the label is reverted to 'jvmtiError'.
+      assertUnloadedFrameLabel(dumpFile);
     } finally {
       running.set(false);
       for (Thread t : churnThreads) {
@@ -215,6 +234,47 @@ public class JMethodIDInvalidationStressTest extends AbstractDynamicClassTest {
       } catch (IOException ignored) {
       }
     }
+  }
+
+  /**
+   * Asserts that the JFR recording produced by the churn window serializes stale-jmethodID
+   * frames as {@code "<unloaded>"} and never as the legacy {@code "jvmtiError"} label.
+   * This is the regression guard for the flightRecorder.cpp remap: reverting the label to
+   * {@code "jvmtiError"} makes this assertion fail. Only stack-trace-bearing event types
+   * are inspected; events without a {@code stackTrace} field are skipped.
+   */
+  private void assertUnloadedFrameLabel(Path recording) throws Exception {
+    AtomicBoolean foundUnloaded = new AtomicBoolean();
+    AtomicBoolean foundLegacy = new AtomicBoolean();
+    AtomicReference<String> legacySample = new AtomicReference<>();
+    for (String eventType : new String[]{"datadog.ExecutionSample", "datadog.AllocationSample"}) {
+      streamEvents(recording, eventType, event -> {
+        if (!event.has(STACK_TRACE)) {
+          return;
+        }
+        for (JfrFrame frame : event.getStackTrace().frames()) {
+          String name = frame.methodName();
+          if (name == null) {
+            continue;
+          }
+          if (name.equals("<unloaded>")) {
+            foundUnloaded.set(true);
+          } else if (name.equals("jvmtiError")) {
+            foundLegacy.set(true);
+            if (legacySample.get() == null) {
+              legacySample.set(event.getStackTraceString());
+            }
+          }
+        }
+      });
+    }
+    assertTrue(foundUnloaded.get(),
+        "Expected at least one frame serialized as '<unloaded>' in " + recording
+            + " (jmethodid_skipped_count fired, so the stale-jmethodID branch ran), "
+            + "but none was found -- the remap to '<unloaded>' may have been reverted.");
+    assertTrue(!foundLegacy.get(),
+        "Found a frame serialized as the legacy 'jvmtiError' label in " + recording
+            + "; expected '<unloaded>'. First offending sample: " + legacySample.get());
   }
 
   private void churnLoop(AtomicBoolean running) {

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/SmokeWallTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock/SmokeWallTest.java
@@ -12,12 +12,10 @@ import com.datadoghq.profiler.junit.CStack;
 import com.datadoghq.profiler.junit.RetryTest;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.params.provider.ValueSource;
-import com.datadoghq.profiler.JfrEvent;
 import com.datadoghq.profiler.JfrEvents;
 
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class SmokeWallTest extends CStackAwareAbstractProfilerTest {
@@ -44,11 +42,6 @@ public class SmokeWallTest extends CStackAwareAbstractProfilerTest {
         verifyCStackSettings();
 
         JfrEvents events = verifyEvents("datadog.MethodSample");
-
-        for (JfrEvent sample : events) {
-            String stackTrace = sample.getStackTraceString();
-            assertFalse(stackTrace.contains("jvmtiError"));
-        }
     }
 
     @Override


### PR DESCRIPTION
**What does this PR do?**:
Remaps the dump-time JVMTI-resolution failure branch in `Lookup::fillJavaMethodInfo` (`flightRecorder.cpp`) to serialize the frame as `<unloaded>` instead of the synthetic `jvmtiError` method name. Removes the now-dead `jvmtiError` assertions from `SmokeCpuTest`, `SmokeWallTest`, `CTimerSamplerTest`, and `RemoteSymbolicationTest`.

**Motivation**:
Profiles in hotdog (non-`remotesym`) showed **all leaf frames** serialized as `jvmtiError` during the early class-churn window (~first 10-15 min), a regression vs v1.49.0.

Root cause is **[JDK-8268406](https://bugs.openjdk.org/browse/JDK-8268406) "Deallocate jmethodID native memory"** (integrated in JDK 26, build b05): jmethodID memory is now **freed** on class unload (pre-26 it was kept alive — the leak this change fixed). The profiler's stale-jmethodID detection relies on dereferencing the jmethodID to verify it still points to the right `Method*`:
- `VMMethod::check_jmethodID_hotspot` (`vmStructs.cpp`): `if (hotspot_version() > 25) return true;` — unconditional, no validation.
- `_can_dereference_jmethod_id = _has_method_structs && hotspot_version() <= 25` (`vmStructs.cpp`): `validatedId()` skips the deref.

Both are disabled for JDK > 25 because the deref no longer aliases a kept-alive `JNIMethodBlock` — it would fault on freed memory. So a stale jmethodID from an unloaded/purged class passes all capture-time gates, reaches `fillJavaMethodInfo` at dump time, `GetMethodDeclaringClass` returns `JVMTI_ERROR_INVALID_METHODID`, and the frame was serialized as `jvmtiError`.

Per the JVMTI spec, retransform does **not** invalidate jmethodIDs (the original ID is repurposed to the new method version). What invalidates them is class unload — and JDK-8268406 changed what "invalidated" means at the memory level. The early-run correlation is class churn (generated accessors, lambda forms, Mockito-generated classes, retransform obsolete-method purge via the JDK-8313816 path) which settles after warmup.

`<unloaded>` is the correct, safe label: the method was present at sample time, its metadata was reclaimed before the JFR dump. It matches the existing angle-bracket synthetic-frame convention (`<remote>`, `<vtable_receiver>`, `<unresolved_vtable_receiver>`). The capture-time `unknown` path (`JMETHODID_NOT_WALKABLE` / null jmethodID) stays distinct, so the two failure modes remain distinguishable in profiles:
- `unknown` — capture-time validation failure (walker couldn't trust the ID).
- `<unloaded>` — dump-time resolution failure (ID was valid at capture, metadata reclaimed by dump).

**Additional Notes**:
- The deref-based stale check is **unrevivable** on JDK ≥ 26 (the jmethodID memory is freed), so this remap is the right fix, not a stopgap. Retaining the raw `Method*` (the alternative) is crash-prone on class unload and reverts #699's safety work; on JDK 26 the `Method*` is freed too.
- The `jvmtiError` label is no longer emitted by any code path, so the per-test assertions against it were dead checks that could never fail — removed rather than kept as sentinels.

**How to test the change?**:
`SmokeCpuTest` + 391 gtests pass (0 failures) on Corretto 26. A reproducing test that forces a class unload during profiling to lock in the `<unloaded>` behavior can be added as a follow-up.

**For Datadog employees**:
- [x] This PR doesn't touch any of that.
- [ ] JIRA: (none)
