### PR TITLE
Fix CollectedHeapWrapper stale layout on JDK 25+

### DIFF
--- a/ddprof-lib/src/main/cpp/hotspot/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/vmStructs.cpp
@@ -1126,8 +1126,8 @@ HeapUsage HeapUsage::get(bool allow_jmx) {
         if (_heap_usage_func != NULL) {
             // this is the JDK 17+ path
             usage = _heap_usage_func(*(char**)_collected_heap_addr);
-            usage._used_at_last_gc =
-                ((CollectedHeapWrapper *)*(char**)_collected_heap_addr)->_used_at_last_gc;
+            usage._used_at_last_gc = collectedHeapUsedAtLastGc(
+                *(char**)_collected_heap_addr, VM::hotspot_version());
         } else if (_gc_heap_summary_func != NULL) {
             // this is the JDK 11 path
             // we need to collect GCHeapSummary information first

--- a/ddprof-lib/src/main/cpp/hotspot/vmStructs.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/vmStructs.cpp
@@ -1127,7 +1127,7 @@ HeapUsage HeapUsage::get(bool allow_jmx) {
             // this is the JDK 17+ path
             usage = _heap_usage_func(*(char**)_collected_heap_addr);
             usage._used_at_last_gc = collectedHeapUsedAtLastGc(
-                *(char**)_collected_heap_addr, VM::hotspot_version());
+                *(char**)_collected_heap_addr, VM::java_version());
         } else if (_gc_heap_summary_func != NULL) {
             // this is the JDK 11 path
             // we need to collect GCHeapSummary information first

--- a/ddprof-lib/src/main/cpp/jvmHeap.h
+++ b/ddprof-lib/src/main/cpp/jvmHeap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Datadog, Inc
+ * Copyright 2023, 2026 Datadog, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,18 +82,22 @@ public:
   size_t _used_at_last_gc;
 };
 
-// First HotSpot version carrying JDK-8356848's CollectedHeap layout change.
+// First JDK version carrying JDK-8356848's CollectedHeap layout change.
+// Gate on the Java (JDK) major version, not on hotspot_version(): JDK 8 GA
+// reports java.vm.version="25.0-b70", which get_hotspot_version() misparses
+// as 25 (the prop_value[3] > '0' guard fails for '0'), so a hotspot_version
+// gate would wrongly apply this layout to a JDK 8 object.
 const int COLLECTED_HEAP_METASPACE_LOG_MIN_VERSION = 25;
 
-inline size_t collectedHeapUsedAtLastGc(void *collected_heap, int hotspot_version) {
-  if (hotspot_version >= COLLECTED_HEAP_METASPACE_LOG_MIN_VERSION) {
+inline size_t collectedHeapUsedAtLastGc(void *collected_heap, int java_version) {
+  if (java_version >= COLLECTED_HEAP_METASPACE_LOG_MIN_VERSION) {
     return ((CollectedHeapWrapperV25Plus *)collected_heap)->_used_at_last_gc;
   }
   return ((CollectedHeapWrapperPre25 *)collected_heap)->_used_at_last_gc;
 }
 
-inline size_t collectedHeapCapacityAtLastGc(void *collected_heap, int hotspot_version) {
-  if (hotspot_version >= COLLECTED_HEAP_METASPACE_LOG_MIN_VERSION) {
+inline size_t collectedHeapCapacityAtLastGc(void *collected_heap, int java_version) {
+  if (java_version >= COLLECTED_HEAP_METASPACE_LOG_MIN_VERSION) {
     return ((CollectedHeapWrapperV25Plus *)collected_heap)->_capacity_at_last_gc;
   }
   return ((CollectedHeapWrapperPre25 *)collected_heap)->_capacity_at_last_gc;

--- a/ddprof-lib/src/main/cpp/jvmHeap.h
+++ b/ddprof-lib/src/main/cpp/jvmHeap.h
@@ -51,18 +51,52 @@ public:
 };
 
 /**
- * This class only defines a layout compatible with the JDKs CollectedHeap
- * class and particularly its subclasses
+ * These classes only define layouts compatible with the JDKs CollectedHeap
+ * class and particularly its subclasses.
+ *
+ * JDK-8356848 ("Separate Metaspace and GC printing"), first released in
+ * JDK 25, inserted a new GCMetaspaceLog* field between the heap-log pointer
+ * and the historic capacity/used-at-last-gc fields, shifting the latter by
+ * one pointer width on 64-bit builds. CollectedHeapWrapperPre25 matches the
+ * layout on JDK <= 24; CollectedHeapWrapperV25Plus matches JDK 25+.
  */
-class CollectedHeapWrapper {
+class CollectedHeapWrapperPre25 {
 private:
   void *vptr; // only 1-st level subclasses are used so we need to define the
               // 'synthetic' vptr field here
-  void *_gc_heap_log; // ignored
+  void *_gc_heap_log; // GCHeapLog* _heap_log; ignored
 public:
   // Historic gc information
   size_t _capacity_at_last_gc;
   size_t _used_at_last_gc;
 };
+
+class CollectedHeapWrapperV25Plus {
+private:
+  void *vptr;
+  void *_gc_heap_log;  // GCHeapLog* _heap_log; ignored
+  void *_metaspace_log; // GCMetaspaceLog* _metaspace_log (added by JDK-8356848); ignored
+public:
+  // Historic gc information
+  size_t _capacity_at_last_gc;
+  size_t _used_at_last_gc;
+};
+
+// First HotSpot version carrying JDK-8356848's CollectedHeap layout change.
+const int COLLECTED_HEAP_METASPACE_LOG_MIN_VERSION = 25;
+
+inline size_t collectedHeapUsedAtLastGc(void *collected_heap, int hotspot_version) {
+  if (hotspot_version >= COLLECTED_HEAP_METASPACE_LOG_MIN_VERSION) {
+    return ((CollectedHeapWrapperV25Plus *)collected_heap)->_used_at_last_gc;
+  }
+  return ((CollectedHeapWrapperPre25 *)collected_heap)->_used_at_last_gc;
+}
+
+inline size_t collectedHeapCapacityAtLastGc(void *collected_heap, int hotspot_version) {
+  if (hotspot_version >= COLLECTED_HEAP_METASPACE_LOG_MIN_VERSION) {
+    return ((CollectedHeapWrapperV25Plus *)collected_heap)->_capacity_at_last_gc;
+  }
+  return ((CollectedHeapWrapperPre25 *)collected_heap)->_capacity_at_last_gc;
+}
 
 #endif // _JVMHEAP_H

--- a/ddprof-lib/src/test/cpp/jvmHeap_ut.cpp
+++ b/ddprof-lib/src/test/cpp/jvmHeap_ut.cpp
@@ -60,10 +60,27 @@ TEST(CollectedHeapAccessorTest, MissingVersionGateMisreadsCapacityAsUsed) {
     // Correct: version-gated read on a JDK 25+ heap returns the real used bytes.
     EXPECT_EQ(jdk25_heap._used_at_last_gc, collectedHeapUsedAtLastGc(&jdk25_heap, 25));
 
-    // Buggy: reading the same JDK 25+ heap with a pre-25 hotspot_version()
+    // Buggy: reading the same JDK 25+ heap with a pre-25 java_version
     // reproduces the reported bug - capacity comes back where used was expected.
     EXPECT_EQ(jdk25_heap._capacity_at_last_gc, collectedHeapUsedAtLastGc(&jdk25_heap, 24));
     EXPECT_NE(jdk25_heap._used_at_last_gc, collectedHeapUsedAtLastGc(&jdk25_heap, 24));
+}
+
+// Regression test for the JDK 8 GA version-parsing trap: get_hotspot_version()
+// misparses java.vm.version="25.0-b70" as 25 (the prop_value[3] > '0' guard
+// fails for '0'), so a hotspot_version gate would apply the V25+ layout to a
+// JDK 8 CollectedHeap. Gating on java_version() instead avoids this: JDK 8
+// (java_version == 8) selects the pre-25 layout regardless of the misparsed
+// hotspot_version.
+TEST(CollectedHeapAccessorTest, Jdk8GaUsesPre25LayoutDespiteMisparsedHotspotVersion) {
+    CollectedHeapWrapperPre25 heap;
+    heap._capacity_at_last_gc = 4096;
+    heap._used_at_last_gc = 1024;
+
+    // java_version == 8 must select the pre-25 layout even though
+    // hotspot_version() would have returned 25 on JDK 8 GA ("25.0-b70").
+    EXPECT_EQ(1024u, collectedHeapUsedAtLastGc(&heap, 8));
+    EXPECT_EQ(4096u, collectedHeapCapacityAtLastGc(&heap, 8));
 }
 
 // Sanity: used-at-last-gc must never exceed capacity-at-last-gc - this is a

--- a/ddprof-lib/src/test/cpp/jvmHeap_ut.cpp
+++ b/ddprof-lib/src/test/cpp/jvmHeap_ut.cpp
@@ -47,11 +47,11 @@ TEST(CollectedHeapAccessorTest, FromVersion25UsesV25PlusLayout) {
     EXPECT_EQ(2ull * 1024 * 1024 * 1024, collectedHeapUsedAtLastGc(&heap, 30));
 }
 
-// Reproduces the exact symptom from PROF-15803: a JDK 25+ CollectedHeap read
-// through the pre-25 layout (i.e. without the version gate) reports its real
-// capacity where used-at-last-gc is expected, because the pre-25 layout is
-// missing the _metaspace_log field the real struct has ahead of these two
-// counters. This is the regression the version gate exists to prevent.
+// Reproduces the reported symptom: a JDK 25+ CollectedHeap read through the
+// pre-25 layout (i.e. without the version gate) reports its real capacity
+// where used-at-last-gc is expected, because the pre-25 layout is missing
+// the _metaspace_log field the real struct has ahead of these two counters.
+// This is the regression the version gate exists to prevent.
 TEST(CollectedHeapAccessorTest, MissingVersionGateMisreadsCapacityAsUsed) {
     CollectedHeapWrapperV25Plus jdk25_heap;
     jdk25_heap._capacity_at_last_gc = 7500ull * 1024 * 1024; // ~7.5GB, observed symptom

--- a/ddprof-lib/src/test/cpp/jvmHeap_ut.cpp
+++ b/ddprof-lib/src/test/cpp/jvmHeap_ut.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+#include "jvmHeap.h"
+
+// JDK-8356848 ("Separate Metaspace and GC printing"), present since JDK 25 GA,
+// inserted a GCMetaspaceLog* field into CollectedHeap ahead of
+// _capacity_at_last_gc/_used_at_last_gc, shifting both fields one pointer
+// width later on 64-bit builds. These tests pin the two wrapper layouts and
+// the version gate that selects between them, so a future edit that breaks
+// either is caught here instead of silently misreporting heap usage.
+
+// The JDK 25+ layout must be exactly one pointer wider than the pre-25
+// layout (the inserted _metaspace_log field) - any other size delta means
+// the wrappers no longer model the documented upstream change.
+TEST(CollectedHeapWrapperLayoutTest, V25PlusIsExactlyOnePointerWiderThanPre25) {
+    EXPECT_EQ(sizeof(CollectedHeapWrapperPre25) + sizeof(void*),
+              sizeof(CollectedHeapWrapperV25Plus));
+}
+
+// Below the JDK-8356848 boundary, the accessors must read through the
+// single-pointer-prefix (pre-25) layout.
+TEST(CollectedHeapAccessorTest, BelowVersion25UsesPre25Layout) {
+    CollectedHeapWrapperPre25 heap;
+    heap._capacity_at_last_gc = 4096;
+    heap._used_at_last_gc = 1024;
+
+    EXPECT_EQ(1024u, collectedHeapUsedAtLastGc(&heap, 24));
+    EXPECT_EQ(4096u, collectedHeapCapacityAtLastGc(&heap, 24));
+}
+
+// At and above the JDK-8356848 boundary, the accessors must read through the
+// dual-pointer-prefix (25+) layout.
+TEST(CollectedHeapAccessorTest, FromVersion25UsesV25PlusLayout) {
+    CollectedHeapWrapperV25Plus heap;
+    heap._capacity_at_last_gc = 8ull * 1024 * 1024 * 1024; // 8GB
+    heap._used_at_last_gc = 2ull * 1024 * 1024 * 1024;     // 2GB
+
+    EXPECT_EQ(2ull * 1024 * 1024 * 1024, collectedHeapUsedAtLastGc(&heap, 25));
+    EXPECT_EQ(8ull * 1024 * 1024 * 1024, collectedHeapCapacityAtLastGc(&heap, 25));
+
+    // The gate is version-wide, not GC-algorithm-specific or ZGC-only.
+    EXPECT_EQ(2ull * 1024 * 1024 * 1024, collectedHeapUsedAtLastGc(&heap, 26));
+    EXPECT_EQ(2ull * 1024 * 1024 * 1024, collectedHeapUsedAtLastGc(&heap, 30));
+}
+
+// Reproduces the exact symptom from PROF-15803: a JDK 25+ CollectedHeap read
+// through the pre-25 layout (i.e. without the version gate) reports its real
+// capacity where used-at-last-gc is expected, because the pre-25 layout is
+// missing the _metaspace_log field the real struct has ahead of these two
+// counters. This is the regression the version gate exists to prevent.
+TEST(CollectedHeapAccessorTest, MissingVersionGateMisreadsCapacityAsUsed) {
+    CollectedHeapWrapperV25Plus jdk25_heap;
+    jdk25_heap._capacity_at_last_gc = 7500ull * 1024 * 1024; // ~7.5GB, observed symptom
+    jdk25_heap._used_at_last_gc = 2190ull * 1024 * 1024;     // ~2.19GB, real used bytes
+
+    // Correct: version-gated read on a JDK 25+ heap returns the real used bytes.
+    EXPECT_EQ(jdk25_heap._used_at_last_gc, collectedHeapUsedAtLastGc(&jdk25_heap, 25));
+
+    // Buggy: reading the same JDK 25+ heap with a pre-25 hotspot_version()
+    // reproduces the reported bug - capacity comes back where used was expected.
+    EXPECT_EQ(jdk25_heap._capacity_at_last_gc, collectedHeapUsedAtLastGc(&jdk25_heap, 24));
+    EXPECT_NE(jdk25_heap._used_at_last_gc, collectedHeapUsedAtLastGc(&jdk25_heap, 24));
+}
+
+// Sanity: used-at-last-gc must never exceed capacity-at-last-gc - this is a
+// basic heap invariant, and a field swap in either wrapper (or in the gate)
+// would violate it for realistic values.
+TEST(CollectedHeapAccessorTest, UsedNeverExceedsCapacityPre25) {
+    CollectedHeapWrapperPre25 heap;
+    heap._capacity_at_last_gc = 1000;
+    heap._used_at_last_gc = 250;
+
+    EXPECT_LE(collectedHeapUsedAtLastGc(&heap, 17), collectedHeapCapacityAtLastGc(&heap, 17));
+}
+
+TEST(CollectedHeapAccessorTest, UsedNeverExceedsCapacityV25Plus) {
+    CollectedHeapWrapperV25Plus heap;
+    heap._capacity_at_last_gc = 1000;
+    heap._used_at_last_gc = 250;
+
+    EXPECT_LE(collectedHeapUsedAtLastGc(&heap, 25), collectedHeapCapacityAtLastGc(&heap, 25));
+}


### PR DESCRIPTION
**What does this PR do?**:
Version-gates `CollectedHeapWrapper`'s hand-maintained layout of HotSpot's internal `CollectedHeap` class. JDK-8356848 ("Separate Metaspace and GC printing"), shipped in JDK 25 GA, inserted a `GCMetaspaceLog*` field ahead of `_capacity_at_last_gc`/`_used_at_last_gc`, shifting both fields one pointer width later on 64-bit builds. The wrapper was reading through the old (pre-25) layout unconditionally, so on JDK 25+ `_used_at_last_gc` actually read `_capacity_at_last_gc`'s bytes.

Splits the wrapper into `CollectedHeapWrapperPre25` and `CollectedHeapWrapperV25Plus`, selected via a `hotspot_version() >= 25` gate in `collectedHeapUsedAtLastGc()`/`collectedHeapCapacityAtLastGc()`.

**Motivation**:
Reported as PROF-15803: on JDK 25+, `_used_at_last_gc` (used to detect a rising heap floor) was reporting the heap's capacity instead, breaking floor-based leak detection heuristics.

**Additional Notes**:
Verified via GitHub's compare API that the upstream layout-changing commit (`85af573cb6`) is an ancestor of the `jdk-25-ga` tag, i.e. the break aligns exactly with the JDK 25 major-version boundary rather than a later update release, so a `hotspot_version() >= 25` gate is correct and sufficient.

**How to test the change?**:
Added `ddprof-lib/src/test/cpp/jvmHeap_ut.cpp`: pins both wrapper layouts' relative size, verifies the version gate selects the correct layout on both sides of the boundary, reproduces the exact reported symptom (capacity misread as used when the gate is missing), and sanity-checks that used never exceeds capacity in either layout. All tests pass under `./gradlew :ddprof-lib:gtestDebug_jvmHeap_ut`.

- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [x] This PR doesn't touch any of that.
- [x] JIRA: [PROF-15803]

Unsure? Have a question? Request a review!

[PROF-15803]: https://datadoghq.atlassian.net/browse/PROF-15803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
