### PR TITLE
Protect Lookup::resolveMethod() with siglongjmp

### DIFF
--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -136,19 +136,8 @@
   /* Every siglongjmp recovery, from any protected window, counted centrally  \
    * in Profiler::checkFault(). */                                            \
   X(STACKWALK_LONGJMP_RECOVERED, "stackwalk_longjmp_recovered")               \
-  /* Dump-time raw-Method* resolution (HotspotSupport::resolve, reached only    \
-   * for cstack=vm + fjmethodid=false frames). NOT additive with               \
-   * STACKWALK_LONGJMP_RECOVERED: checkFault() bumps that one unconditionally  \
-   * before every siglongjmp, so each fault counted here is counted there too. \
-   * Subtract, never sum. Non-zero means stale HotSpot metadata (GC or class   \
-   * unloading) reached the dump thread; the frame serializes as "unknown". */ \
+  /* Dump-time method resolution failures. The frame serializes as "unknown". */ \
   X(METHOD_RESOLVE_FAULT_RECOVERED, "method_resolve_fault_recovered")         \
-  /* Subset of the above: recoveries that landed in Lookup::resolveMethod()   \
-   * (flightRecorder.cpp), i.e. faults while symbolicating a Java frame at    \
-   * dump time via fillMethod() rather than during HotspotSupport::resolve()'s\
-   * raw-Method* walk. Counted separately because the two protected windows   \
-   * cover different code and have different root causes. */                 \
-  X(METHOD_RESOLVE_LONGJMP_RECOVERED, "method_resolve_longjmp_recovered")    \
   /* Symbol length/body rejected during the same resolution: unreadable body,  \
    * empty (recycled slot), or over MAX_SYMBOL_LEN. A name that merely exceeds \
    * the fixed inline buffers in hotspotSupport.cpp's ResolvedNames still      \

--- a/ddprof-lib/src/main/cpp/counters.h
+++ b/ddprof-lib/src/main/cpp/counters.h
@@ -133,6 +133,8 @@
   X(SAMPLES_DROPPED_THREAD_LOCAL, "samples_dropped_thread_local")             \
   X(SAFECOPY_FAILED, "safecopy_failed")                                       \
   X(SAFEFETCH_FAILED, "safefetch_failed")                                     \
+  /* Every siglongjmp recovery, from any protected window, counted centrally  \
+   * in Profiler::checkFault(). */                                            \
   X(STACKWALK_LONGJMP_RECOVERED, "stackwalk_longjmp_recovered")               \
   /* Dump-time raw-Method* resolution (HotspotSupport::resolve, reached only    \
    * for cstack=vm + fjmethodid=false frames). NOT additive with               \
@@ -141,6 +143,12 @@
    * Subtract, never sum. Non-zero means stale HotSpot metadata (GC or class   \
    * unloading) reached the dump thread; the frame serializes as "unknown". */ \
   X(METHOD_RESOLVE_FAULT_RECOVERED, "method_resolve_fault_recovered")         \
+  /* Subset of the above: recoveries that landed in Lookup::resolveMethod()   \
+   * (flightRecorder.cpp), i.e. faults while symbolicating a Java frame at    \
+   * dump time via fillMethod() rather than during HotspotSupport::resolve()'s\
+   * raw-Method* walk. Counted separately because the two protected windows   \
+   * cover different code and have different root causes. */                 \
+  X(METHOD_RESOLVE_LONGJMP_RECOVERED, "method_resolve_longjmp_recovered")    \
   /* Symbol length/body rejected during the same resolution: unreadable body,  \
    * empty (recycled slot), or over MAX_SYMBOL_LEN. A name that merely exceeds \
    * the fixed inline buffers in hotspotSupport.cpp's ResolvedNames still      \
@@ -156,6 +164,10 @@
    * samples_dropped_thread_local) to isolate non-pool priming drops, never  \
    * summed. */                                                              \
   X(SAMPLES_DROPPED_TLS_POOL_EXHAUSTED, "thread_local_pool_exhausted")        \
+  /* Lookup::resolveMethod() calls that dropped method resolution,            \
+   * because no ProfiledThread could be allocated for the dump thread (OOM):  \
+   * there is nowhere to publish a landing pad. Expected to stay at 0. */     \
+  X(METHOD_RESOLUTION_DROPPED_TLS, "method_resolution_dropped_tls")           \
   /* writeElement() guards against a corrupted/dangling JfrMetadata tree.     \
    * Root cause is still unconfirmed, so these counters are the durable       \
    * signal for spotting a recurrence. */                                     \

--- a/ddprof-lib/src/main/cpp/faultInjection.cpp
+++ b/ddprof-lib/src/main/cpp/faultInjection.cpp
@@ -23,8 +23,6 @@ void crashNow() {
   __builtin_unreachable();  // the store above never returns.
 }
 
-// The whole translation unit is empty unless fault injection is enabled, so a
-// normal build links a no-op object file.
 #ifdef __FAULT_INJECTION__
 
 #include "counters.h"          // Counters::increment (FAULTS_INJECTED)

--- a/ddprof-lib/src/main/cpp/faultInjection.cpp
+++ b/ddprof-lib/src/main/cpp/faultInjection.cpp
@@ -16,12 +16,15 @@
 
 #include "faultInjection.h"
 
+#if defined(__FAULT_INJECTION__) || defined(DEBUG) 
+
 #include <stdint.h>
 void crashNow() {
   volatile uintptr_t* p = (volatile uintptr_t*)nullptr;
   *p = 0xBAD;
   __builtin_unreachable();  // the store above never returns.
 }
+#endif
 
 #ifdef __FAULT_INJECTION__
 

--- a/ddprof-lib/src/main/cpp/faultInjection.cpp
+++ b/ddprof-lib/src/main/cpp/faultInjection.cpp
@@ -16,6 +16,13 @@
 
 #include "faultInjection.h"
 
+#include <stdint.h>
+void crashNow() {
+  volatile uintptr_t* p = (volatile uintptr_t*)nullptr;
+  *p = 0xBAD;
+  __builtin_unreachable();  // the store above never returns.
+}
+
 // The whole translation unit is empty unless fault injection is enabled, so a
 // normal build links a no-op object file.
 #ifdef __FAULT_INJECTION__

--- a/ddprof-lib/src/main/cpp/faultInjection.h
+++ b/ddprof-lib/src/main/cpp/faultInjection.h
@@ -34,6 +34,17 @@
 //
 //   return INJECT_FAULT_BOOL_LIKELY(dlopen(name, flags) != nullptr);
 //
+// INJECT_CRASH_* goes at the same kind of site as INJECT_FAULT_ADDRESS_*, but it
+// is a statement rather than an expression wrapper: it takes no argument and
+// yields no value.  Instead of substituting a poison address for the caller to
+// dereference -- which a downstream recovery path (SafeAccess safefetch, a
+// sigsetjmp/siglongjmp window) may absorb without a signal ever being raised --
+// it raises the SIGSEGV itself, right at the call site.  Use it to exercise the
+// sigsetjmp/siglongjmp window enclosing the call site, or the top-level crash
+// handler where there is no such window:
+//
+//   INJECT_CRASH_LIKELY();
+//
 // The four tiers name their firing frequency: RARE 0.01%, UNLIKELY 0.1%,
 // LIKELY 1%, HIGH 10%.  See faultInjection.cpp for the poison-address and PRNG
 // details.
@@ -42,6 +53,12 @@
 #define _FAULT_INJECTION_H
 
 #include <cassert>
+
+// Deliberately dereferences nullptr to raise a real SIGSEGV right now,
+// unconditionally (no probability gate, no shouldFire() draw). For exercising
+// crash-handler / recovery paths on demand (e.g. from a test), never from a
+// production code path.
+[[noreturn]] void crashNow();
 
 #ifdef __FAULT_INJECTION__
 
@@ -88,6 +105,22 @@ inline T injectAddress(T ptr, u64 threshold, const char* fn) {
   return ptr;
 }
 
+// Like injectAddress(), but instead of substituting a poison pointer into the
+// expression (leaving recovery to whatever the caller does with it downstream
+// -- SafeAccess safefetch, walkVM's sigsetjmp/siglongjmp), this crashes right
+// here, right now, when the tier fires. Whatever encloses the call site is what
+// gets exercised: the nearest sigsetjmp/siglongjmp window if there is one, the
+// top-level crash handler otherwise.
+//
+// Unlike injectAddress() this wraps no expression -- it takes no pointer and
+// returns nothing, so it is a statement, not a drop-in for an
+// INJECT_FAULT_ADDRESS_* site. It does nothing when the tier does not fire.
+inline void injectCrash(u64 threshold, const char* fn) {
+    if (__builtin_expect(shouldFire(threshold, fn), 0)) {
+        crashNow();
+    }
+}
+
 // Returns orig unchanged, or `faulty` when the tier fires. Unlike
 // injectAddress() (which fakes an input about to be dereferenced), this fakes
 // the *outcome* of a call that already ran for real — e.g. making a
@@ -120,6 +153,16 @@ inline T injectValue(T orig, T faulty, u64 threshold, const char* fn) {
 #define INJECT_FAULT_BOOL_HIGH(v) \
     ::faultinj::injectValue((v), false, ::faultinj::PROB_HIGH, __func__)
 
+#define INJECT_CRASH_RARE() \
+    ::faultinj::injectCrash(::faultinj::PROB_RARE, __func__)
+#define INJECT_CRASH_UNLIKELY() \
+    ::faultinj::injectCrash(::faultinj::PROB_UNLIKELY, __func__)
+#define INJECT_CRASH_LIKELY() \
+    ::faultinj::injectCrash(::faultinj::PROB_LIKELY, __func__)
+#define INJECT_CRASH_HIGH() \
+    ::faultinj::injectCrash(::faultinj::PROB_HIGH, __func__)
+#define INJECT_CRASH_ALWAYS() crashNow()
+
 #else  // __FAULT_INJECTION__ not defined — strict identity, zero cost.
 
 #define INJECT_FAULT_ADDRESS_RARE(ptr)     (ptr)
@@ -131,6 +174,15 @@ inline T injectValue(T orig, T faulty, u64 threshold, const char* fn) {
 #define INJECT_FAULT_BOOL_UNLIKELY(v) (v)
 #define INJECT_FAULT_BOOL_LIKELY(v)   (v)
 #define INJECT_FAULT_BOOL_HIGH(v)     (v)
+
+// ((void)0) rather than nothing, so `INJECT_CRASH_LIKELY();` stays a
+// well-formed expression statement in every context (e.g. as the sole body of
+// an unbraced if/else) instead of collapsing to a stray semicolon.
+#define INJECT_CRASH_RARE()     ((void)0)
+#define INJECT_CRASH_UNLIKELY() ((void)0)
+#define INJECT_CRASH_LIKELY()   ((void)0)
+#define INJECT_CRASH_HIGH()     ((void)0)
+#define INJECT_CRASH_ALWAYS()   ((void)0)
 
 #define NO_INJECTION_ASSERT(a) (assert(a))
 

--- a/ddprof-lib/src/main/cpp/faultInjection.h
+++ b/ddprof-lib/src/main/cpp/faultInjection.h
@@ -161,7 +161,6 @@ inline T injectValue(T orig, T faulty, u64 threshold, const char* fn) {
     ::faultinj::injectCrash(::faultinj::PROB_LIKELY, __func__)
 #define INJECT_CRASH_HIGH() \
     ::faultinj::injectCrash(::faultinj::PROB_HIGH, __func__)
-#define INJECT_CRASH_ALWAYS() crashNow()
 
 #else  // __FAULT_INJECTION__ not defined — strict identity, zero cost.
 

--- a/ddprof-lib/src/main/cpp/faultInjection.h
+++ b/ddprof-lib/src/main/cpp/faultInjection.h
@@ -54,11 +54,13 @@
 
 #include <cassert>
 
+#if defined(__FAULT_INJECTION__) || defined(DEBUG) 
 // Deliberately dereferences nullptr to raise a real SIGSEGV right now,
 // unconditionally (no probability gate, no shouldFire() draw). For exercising
 // crash-handler / recovery paths on demand (e.g. from a test), never from a
 // production code path.
 [[noreturn]] void crashNow();
+#endif 
 
 #ifdef __FAULT_INJECTION__
 
@@ -181,7 +183,6 @@ inline T injectValue(T orig, T faulty, u64 threshold, const char* fn) {
 #define INJECT_CRASH_UNLIKELY() ((void)0)
 #define INJECT_CRASH_LIKELY()   ((void)0)
 #define INJECT_CRASH_HIGH()     ((void)0)
-#define INJECT_CRASH_ALWAYS()   ((void)0)
 
 #define NO_INJECTION_ASSERT(a) (assert(a))
 

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -121,6 +121,8 @@ ResolveMethodState::~ResolveMethodState() {
   release();
 }
 
+// Don't expect following JNI and JVMTI calls to fail, as they are public APIs
+// of JVM
 void ResolveMethodState::release() {
   if (_framePushed) {
     JNIEnv* jni = VM::jni();
@@ -312,13 +314,23 @@ bool Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         jvmtiError line_table_error = jvmti->GetLineNumberTable(method, &line_number_table_size,
                                   &line_number_table);
         
-        bool is_table_readable = line_number_table != nullptr &&
-                                 SafeAccess::isReadableRange(line_number_table, line_number_table_size * sizeof(jvmtiLineNumberEntry));
+        bool is_table_valid = (line_number_table_size >= 0 && line_number_table_size <= MAX_LINE_NUMBER_TABLE_ENTRIES);
+        bool is_table_readable =  (line_number_table != nullptr && is_table_valid &&
+                                   (line_number_table_size > 0 ?
+                                    SafeAccess::isReadableRange(line_number_table, line_number_table_size * sizeof(jvmtiLineNumberEntry)) :
+                                    SafeAccess::isReadable(line_number_table)));
         if (line_table_error != JVMTI_ERROR_NONE ||
-          // On Hotspot, it returns a malloc'd pointer even table size = 0, but there is no point to keep it
-          line_number_table_size == 0) {
-            if (is_table_readable && line_number_table != nullptr) {
+            // On Hotspot, it returns a malloc'd pointer even table size = 0, but there is no point to keep it
+            line_number_table_size == 0 ||
+            // a corrupted table 
+            !is_table_valid ||
+            !is_table_readable) {
+            if (is_table_readable) {
               jvmti->Deallocate((unsigned char*)line_number_table);
+            }
+
+            if (!is_table_valid || !is_table_readable) {
+              Counters::increment(LINE_NUMBER_TABLE_UNREADABLE);
             }
             line_number_table = nullptr;
             line_number_table_size = 0;

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -705,7 +705,7 @@ MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
   }
 
   assert(method_id != nullptr && "Already filtered by caller");
-    // Reinstates the thread's previous landing pad on every exit from this frame,
+  // Reinstates the thread's previous landing pad on every exit from this frame,
   // including a std::bad_alloc thrown by one of the map or dictionary inserts
   // underneath. Leaving ours installed past the end of this frame would leave
   // checkFault() jumping into a dead stack frame.
@@ -726,7 +726,7 @@ MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
     jmp_scope.restore();
     Counters::increment(METHOD_RESOLVE_FAULT_RECOVERED);
     // state.release() may fault. Unfortunately, it faults outside of profiler
-    // code where checkFault() can not absorbs.
+    // code where checkFault() can not absorb.
     state.release();
     // A member, already filled above -- no map lookup, no allocation, and no
     // reliance on a local surviving siglongjmp (the value of a non-volatile

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -329,7 +329,13 @@ bool Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
               jvmti->Deallocate((unsigned char*)line_number_table);
             }
 
-            if (!is_table_valid || !is_table_readable) {
+            // Only a genuinely corrupt/unreadable table output should count
+            // here: JVMTI_ERROR_ABSENT_INFORMATION (compiled without debug
+            // line info) and other non-success errors are ordinary, expected
+            // outcomes with no table to speak of, not corruption -- counting
+            // them would swamp this signal with normal methods and mask real
+            // stale/corrupted-jmethodID failures.
+            if (line_table_error == JVMTI_ERROR_NONE && (!is_table_valid || !is_table_readable)) {
               Counters::increment(LINE_NUMBER_TABLE_UNREADABLE);
             }
             line_number_table = nullptr;

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -167,7 +167,7 @@ void Lookup::cutArguments(char *func) {
 }
 
 void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
-                                bool first_time, bool& framePushed) {
+                                bool first_time, volatile bool& framePushed) {
   JNIEnv *jni = VM::jni();
   if (jni->PushLocalFrame(64) != 0) {
     return;
@@ -639,7 +639,7 @@ MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
   // underneath. Leaving ours installed past the end of this frame would leave
   // checkFault() jumping into a dead stack frame.
   JmpCtxScope jmp_scope(prof_thread);
-  bool framePushed = false;
+  volatile bool framePushed = false;
 
   sigjmp_buf crash_protection_ctx;
   // savemask must be 1: the siglongjmp originates inside segvHandler, where
@@ -1809,7 +1809,7 @@ int Recording::writeMethods(Buffer *buf, Lookup *lookup) {
   // declaration), so the walk above cannot see it. It still has to be emitted:
   // writeStackTraces() wrote its _key for every frame that resolved to it, and a
   // _key absent from this pool is a dangling reference in the chunk.
-  if (marked_count > 0 && lookup->_unknown_method._mark) {
+  if (lookup->_unknown_method._mark) {
     marked_count++;
   }
 

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -167,11 +167,13 @@ void Lookup::cutArguments(char *func) {
 }
 
 void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
-                                bool first_time) {
+                                bool first_time, bool& framePushed) {
   JNIEnv *jni = VM::jni();
   if (jni->PushLocalFrame(64) != 0) {
     return;
   }
+  framePushed = true;
+
   jvmtiEnv *jvmti = VM::jvmti();
 
   jvmtiPhase phase;
@@ -190,10 +192,9 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
   jvmti->GetPhase(&phase);
   if ((phase & (JVMTI_PHASE_START | JVMTI_PHASE_LIVE)) != 0) {
     bool entry = false;
-    bool readable = false;
-    const size_t probe_len = 256;
+    bool valid_method = false;
     if (VMMethod::check_jmethodID(method) &&
-        jvmti->GetMethodDeclaringClass(method, &method_class) == 0 &&
+        jvmti->GetMethodDeclaringClass(method, &method_class) == JVMTI_ERROR_NONE &&
         // GetMethodDeclaringClass may return a jclass wrapping a stale/garbage oop when the class was
         // unloaded between sample capture and dump (TOCTOU race with class unloading). Guard against
         // null handles before calling GetClassSignature.
@@ -205,28 +206,11 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         // when a classloader is unloaded, the jmethodIDs are not freed, but instead marked as -1.
         // The check below mitigates these crashes on J9.
         (!VM::isOpenJ9() || method_class != reinterpret_cast<jclass>(-1)) &&
-        jvmti->GetClassSignature(method_class, &class_name, NULL) == 0 &&
-        jvmti->GetMethodName(method, &method_name, &method_sig, NULL) == 0) {
-      // The JVMTI strings should be non-null and mapped per spec, but crash
-      // telemetry shows both `strncmp` and `jvmti_Deallocate` faulting on them.
-      // Probe each pointer over a range covering the longest prefix
-      // compared below (~50 bytes) plus headroom for strlen, and NULL any that
-      // fails so the unconditional Deallocate block at end of this function
-      // skips it (os::free faults on an unmapped pointer just like strncmp).
-      // Accept a small leak on the corruption path. Probes run independently
-      // so a single bad pointer does not leak its siblings. Best-effort only:
-      // a concurrent munmap between probe and use can still fault; the SIGSEGV
-      // handler is the second line of defence.
-      auto probe = [&](char*& ptr) -> bool {
-        if (ptr == nullptr || !SafeAccess::isReadableRange(ptr, probe_len)) {
-          ptr = nullptr;
-          return false;
-        }
-        return true;
-      };
-      readable = probe(class_name) & probe(method_name) & probe(method_sig);
+        jvmti->GetClassSignature(method_class, &class_name, NULL) == JVMTI_ERROR_NONE &&
+        jvmti->GetMethodName(method, &method_name, &method_sig, NULL) == JVMTI_ERROR_NONE) {
+      valid_method = (class_name != nullptr) && (method_name != nullptr) && (method_sig != nullptr);
     }
-    if (readable) {
+    if (valid_method) {
       const size_t class_name_len = strnlen(class_name, 65536);
       const char* normalized_class_name =
           class_name_len >= 2 ? class_name + 1 : "";
@@ -634,11 +618,28 @@ MethodInfo *Lookup::resolveMethod(ASGCT_CallFrame &frame) {
     return unknown_method;
   }
 
-  // Reinstates the thread's previous landing pad on every exit from this frame,
+  return fillMethod(frame, method_id, bci, prof_thread);
+}
+
+MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
+                               jint bci, ProfiledThread* const prof_thread) {
+
+  assert(prof_thread != nullptr);
+                                  // Resolve native method
+  if (FrameType::isRawPointer(bci)) {
+    method_id = JVMSupport::resolve(frame.method);
+    if (method_id == nullptr) {
+      return unknownMethod();
+    }
+  }
+
+  assert(method_id != nullptr && "Already filtered by caller");
+    // Reinstates the thread's previous landing pad on every exit from this frame,
   // including a std::bad_alloc thrown by one of the map or dictionary inserts
   // underneath. Leaving ours installed past the end of this frame would leave
   // checkFault() jumping into a dead stack frame.
   JmpCtxScope jmp_scope(prof_thread);
+  bool framePushed = false;
 
   sigjmp_buf crash_protection_ctx;
   // savemask must be 1: the siglongjmp originates inside segvHandler, where
@@ -653,26 +654,18 @@ MethodInfo *Lookup::resolveMethod(ASGCT_CallFrame &frame) {
     SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP();
     jmp_scope.restore();
     Counters::increment(METHOD_RESOLVE_LONGJMP_RECOVERED);
+
+    if (framePushed) {
+      JNIEnv* jni = VM::jni();
+      jni->PopLocalFrame(nullptr);
+    }
     // A member, already filled above -- no map lookup, no allocation, and no
     // reliance on a local surviving siglongjmp (the value of a non-volatile
     // local assigned after sigsetjmp() is indeterminate here).
     return &_unknown_method;
   }
   jmp_scope.install(&crash_protection_ctx);
-  return fillMethod(frame, method_id, bci);
-}
 
-MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
-                               jint bci) {
-  // Resolve native method
-  if (FrameType::isRawPointer(bci)) {
-    method_id = JVMSupport::resolve(frame.method);
-    if (method_id == nullptr) {
-      return unknownMethod();
-    }
-  }
-
-  assert(method_id != nullptr && "Already filtered by caller");
 
   // Inject fault to test siglongjmp protection. Sits inside the window
   // resolveMethod() arms around this function, which is the point: this is
@@ -693,14 +686,6 @@ MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
 
   if (!mi->_mark) {
     bool first_time = mi->_key == 0;
-    if (first_time) {
-      // Allocate a method-pool id that is unique among live methods. Must not
-      // be derived from the map size: cleanupUnreferencedMethods() erases
-      // entries, so size()+1 would reissue an id still owned by a surviving
-      // method, producing duplicate ids in the chunk's method constant pool
-      // (PROF-15130). The allocator recycles ids freed on erase instead.
-      mi->_key = _method_map->allocId();
-    }
     if (bci == BCI_ERROR) {
       fillNativeMethodInfo(mi, (const char *)method_id, nullptr);
     } else if (bci == BCI_NATIVE_FRAME) {
@@ -752,7 +737,15 @@ MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
       mi->_type = FRAME_NATIVE;
       mi->_is_entry = false;
     } else {
-      fillJavaMethodInfo(mi, method_id, first_time);
+      fillJavaMethodInfo(mi, method_id, first_time, framePushed);
+    }
+    if (first_time) {
+      // Allocate a method-pool id that is unique among live methods. Must not
+      // be derived from the map size: cleanupUnreferencedMethods() erases
+      // entries, so size()+1 would reissue an id still owned by a surviving
+      // method, producing duplicate ids in the chunk's method constant pool
+      // (PROF-15130). The allocator recycles ids freed on erase instead.
+      mi->_key = _method_map->allocId();
     }
     // Mark last, never before the fill above. The fill walks VM metadata that a
     // concurrent class unload may have freed, so it can siglongjmp straight out
@@ -1816,7 +1809,7 @@ int Recording::writeMethods(Buffer *buf, Lookup *lookup) {
   // declaration), so the walk above cannot see it. It still has to be emitted:
   // writeStackTraces() wrote its _key for every frame that resolved to it, and a
   // _key absent from this pool is a dangling reference in the chunk.
-  if (lookup->_unknown_method._mark) {
+  if (marked_count > 0 && lookup->_unknown_method._mark) {
     marked_count++;
   }
 

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -87,6 +87,14 @@ public:
   char* volatile _class_name;
   char* volatile _method_name;
   char* volatile _method_signature;
+  // GetLineNumberTable()'s JVMTI-owned result, pending Deallocate(). Tracked
+  // here for the same reason as the strings above: it is assigned between
+  // sigsetjmp() and a possible siglongjmp() out of a fault raised by a later
+  // JVMTI/JNI call in fillJavaMethodInfo() (Thread.run/main's FindClass/
+  // GetMethodID/CallBooleanMethod, or this function's own trailing
+  // Deallocate()), so release() must be able to free it on that recovery
+  // path too, not just the strings.
+  unsigned char* volatile _line_number_table;
 
   // Non-copyable
   ResolveMethodState(const ResolveMethodState&) = delete;
@@ -99,7 +107,7 @@ public:
 
 ResolveMethodState::ResolveMethodState() :
   _framePushed(false), _demangled(nullptr), _class_name(nullptr), _method_name(nullptr),
-  _method_signature(nullptr) {
+  _method_signature(nullptr), _line_number_table(nullptr) {
 }
 
 ResolveMethodState::~ResolveMethodState() {
@@ -129,6 +137,10 @@ void ResolveMethodState::release() {
   if (_class_name != nullptr) {
     jvmti->Deallocate((unsigned char*)_class_name);
     _class_name = nullptr;
+  }
+  if (_line_number_table != nullptr) {
+    jvmti->Deallocate(_line_number_table);
+    _line_number_table = nullptr;
   }
 }
 
@@ -292,15 +304,29 @@ bool Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
       if (first_time) {
         jvmtiError line_table_error = jvmti->GetLineNumberTable(method, &line_number_table_size,
                                   &line_number_table);
+        // Mirror into state immediately, before anything else in this
+        // function runs: a later JVMTI/JNI call below (Thread.run/main's
+        // FindClass/GetMethodID/CallBooleanMethod, or this function's own
+        // trailing Deallocate() further down) can fault and siglongjmp out
+        // before line_number_table is otherwise handled, and this local
+        // variable is not tracked by anything the landing pad can see.
+        // state.release() is what frees it on that recovery path.
+        state._line_number_table = (unsigned char *)line_number_table;
+        bool is_table_readable = true;
         // Defensive: if GetLineNumberTable failed, clean up any potentially allocated memory
         // Some buggy JVMTI implementations might allocate despite returning an error
-        if (line_table_error != JVMTI_ERROR_NONE) {
-          if (line_number_table != nullptr) {
+        if (line_table_error != JVMTI_ERROR_NONE ||
+            (line_number_table != nullptr && 
+             !(is_table_readable = SafeAccess::isReadableRange(line_number_table, line_number_table_size * sizeof(jvmtiLineNumberEntry))))) {
+
+          // If the table is not readable, don't try to deallocate it, because it can result in crash.
+          if (line_number_table != nullptr && is_table_readable) {
             // Try to deallocate to prevent leak from buggy JVM
             jvmti->Deallocate((unsigned char *)line_number_table);
           }
           line_number_table = nullptr;
           line_number_table_size = 0;
+          state._line_number_table = nullptr; // already deallocated above, if it was non-null
         }
       }
 
@@ -419,70 +445,12 @@ bool Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
     mi->_sig = method_sig_id;
     mi->_type = FRAME_INTERPRETED;
     mi->_is_entry = entry;
-    if (line_number_table != nullptr) {
-      // Detach from JVMTI lifetime: copy into our own buffer and deallocate
-      // the JVMTI-allocated memory immediately. This keeps _ptr valid even
-      // after the underlying class is unloaded.
-      void *owned_table = nullptr;
-      if (line_number_table_size > 0 &&
-          line_number_table_size <= MAX_LINE_NUMBER_TABLE_ENTRIES) {
-        size_t bytes = (size_t)line_number_table_size * sizeof(jvmtiLineNumberEntry);
-        // GetLineNumberTable() is called on the same possibly-stale jmethodID
-        // that GetMethodDeclaringClass/GetClassSignature/GetMethodName above
-        // were probed for -- the TOCTOU race documented above (class
-        // unloaded between sample capture and dump) applies here just as
-        // much as to those calls, and crash telemetry already showed those
-        // sibling calls returning JVMTI_ERROR_NONE with unmapped string
-        // pointers despite the spec saying the returned array should be a
-        // fresh, caller-owned allocation. A genuinely-valid returned table is
-        // fully decoupled from jmethodID lifetime per the JVMTI spec and
-        // can't be invalidated later by class unload; the actual risk is a
-        // corrupted pointer that happens to alias other live memory at
-        // check-time and stops being mapped moments later. A separate
-        // isReadableRange() probe followed by a plain memcpy() would still
-        // race that window, so copy via safeCopy() instead: it fault-protects
-        // each read as it happens rather than trusting a point-in-time check
-        // before an unprotected copy.
-        owned_table = malloc(bytes);
-        if (owned_table != nullptr) {
-          if (SafeAccess::safeCopy(owned_table, line_number_table, bytes)) {
-            // Hand ownership to mi->_line_number_table immediately, before the
-            // Deallocate() call below (a real, unprotected JVMTI call that can
-            // itself fault on the same possibly-stale jmethodID). mi lives in
-            // *_method_map, which survives a siglongjmp out of this function,
-            // so once owned_table is attached here it can no longer leak even
-            // if the rest of this block never finishes.
-            mi->_line_number_table = std::make_shared<SharedLineNumberTable>(
-                line_number_table_size, owned_table);
-            owned_table = nullptr; // ownership transferred; nothing left to free below
-            Counters::increment(LINE_NUMBER_TABLES);
-            NativeMem::record(NM_LINE_TABLES, (long long)((size_t)line_number_table_size *
-                                                          sizeof(jvmtiLineNumberEntry)));
-          } else {
-            free(owned_table);
-            owned_table = nullptr;
-            line_number_table = nullptr; // make sure the invalid address is not used for jvmti->Deallocate
-            Counters::increment(LINE_NUMBER_TABLE_UNREADABLE);
-          }
-        } else {
-          TEST_LOG("Failed to allocate %zu bytes for line number table copy", bytes);
-        }
-      } else if (line_number_table_size != 0) {
-        // A corrupted size out-param alongside a corrupted pointer is exactly
-        // as plausible as the corrupted-pointer case above (both come from
-        // the same GetLineNumberTable() call on the same stale jmethodID);
-        // an implausible entry count -- including a negative one, since this
-        // is a signed jint and a corrupted value can fall on either side of
-        // zero -- means the pointer can't be trusted for Deallocate() either,
-        // so treat it the same as the unreadable case.
-        line_number_table = nullptr;
-        Counters::increment(LINE_NUMBER_TABLE_UNREADABLE);
-      }
-      if (line_number_table != nullptr) {
-        jvmtiError dealloc_err = jvmti->Deallocate((unsigned char *)line_number_table);
-        assert(dealloc_err == JVMTI_ERROR_NONE && "Unexpected error while deallocating linenumber table");
-      }
-    }
+    mi->_line_number_table = std::make_shared<SharedLineNumberTable>(
+                line_number_table_size, line_number_table);
+    // Increment counter for tracking live line number tables
+    Counters::increment(LINE_NUMBER_TABLES);
+    NativeMem::record(NM_LINE_TABLES, (long long)((size_t)line_number_table_size * sizeof(jvmtiLineNumberEntry)));
+    state._line_number_table = nullptr;
     return true;
   }
   // Phase is neither START nor LIVE (e.g. a record-on-shutdown dump after the

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -72,12 +72,11 @@ SharedLineNumberTable::~SharedLineNumberTable() {
   // Lookup::fillJavaMethodInfo), not a copy -- freed here via
   // jvmti->Deallocate(), not plain free(). On HotSpot, JvmtiEnv
   // Allocate()/Deallocate() are os::malloc()/os::free(), which route through
-  // MemTracker so native-memory-tracking accounting stays correct; freeing
-  // with plain free() instead would desync NMT's byte count from what's
-  // actually live whenever -XX:NativeMemoryTracking is enabled, even though
-  // the underlying memory itself would still be freed correctly.
-  if (_ptr != nullptr) {
-    VM::jvmti()->Deallocate((unsigned char *)_ptr);
+  // native memory tracking; freeing with plain free() can result in crash
+  // whenever -XX:NativeMemoryTracking is enabled, because native memory tracking
+  // adds a header to malloc'd block.
+  if (_table != nullptr) {
+    VM::jvmti()->Deallocate((unsigned char *)_table);
     Counters::decrement(LINE_NUMBER_TABLES);
     // _size is the JVMTI entry count passed at construction (see
     // fillJavaMethodInfo), so the byte size matches the allocation.
@@ -102,7 +101,7 @@ public:
   // handles inline -- but never on the success path, where ownership passes
   // to mi->_line_number_table instead (also freed via jvmti->Deallocate(),
   // just later; see SharedLineNumberTable) and this field is nulled out.
-  unsigned char* volatile _line_number_table;
+  jvmtiLineNumberEntry* volatile _line_number_table;
 
   // Non-copyable
   ResolveMethodState(const ResolveMethodState&) = delete;
@@ -147,7 +146,7 @@ void ResolveMethodState::release() {
     _class_name = nullptr;
   }
   if (_line_number_table != nullptr) {
-    jvmti->Deallocate(_line_number_table);
+    jvmti->Deallocate((unsigned char*)_line_number_table);
     _line_number_table = nullptr;
   }
 }
@@ -312,6 +311,18 @@ bool Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
       if (first_time) {
         jvmtiError line_table_error = jvmti->GetLineNumberTable(method, &line_number_table_size,
                                   &line_number_table);
+        
+        bool is_table_readable = line_number_table != nullptr &&
+                                 SafeAccess::isReadableRange(line_number_table, line_number_table_size * sizeof(jvmtiLineNumberEntry));
+        if (line_table_error != JVMTI_ERROR_NONE ||
+          // On Hotspot, it returns a malloc'd pointer even table size = 0, but there is no point to keep it
+          line_number_table_size == 0) {
+            if (is_table_readable && line_number_table != nullptr) {
+              jvmti->Deallocate((unsigned char*)line_number_table);
+            }
+            line_number_table = nullptr;
+            line_number_table_size = 0;
+        }
         // Mirror into state immediately, before anything else in this
         // function runs: a later JVMTI/JNI call below (Thread.run/main's
         // FindClass/GetMethodID/CallBooleanMethod, or this function's own
@@ -319,23 +330,7 @@ bool Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         // before line_number_table is otherwise handled, and this local
         // variable is not tracked by anything the landing pad can see.
         // state.release() is what frees it on that recovery path.
-        state._line_number_table = (unsigned char *)line_number_table;
-        bool is_table_readable = true;
-        // Defensive: if GetLineNumberTable failed, clean up any potentially allocated memory
-        // Some buggy JVMTI implementations might allocate despite returning an error
-        if (line_table_error != JVMTI_ERROR_NONE ||
-            (line_number_table != nullptr && 
-             !(is_table_readable = SafeAccess::isReadableRange(line_number_table, line_number_table_size * sizeof(jvmtiLineNumberEntry))))) {
-
-          // If the table is not readable, don't try to deallocate it, because it can result in crash.
-          if (line_number_table != nullptr && is_table_readable) {
-            // Try to deallocate to prevent leak from buggy JVM
-            jvmti->Deallocate((unsigned char *)line_number_table);
-          }
-          line_number_table = nullptr;
-          line_number_table_size = 0;
-          state._line_number_table = nullptr; // already deallocated above, if it was non-null
-        }
+        state._line_number_table = line_number_table;
       }
 
       // Check if the frame is Thread.run or inherits from it
@@ -1147,7 +1142,7 @@ void Recording::cleanupUnreferencedMethods() {
       if (mi._age >= AGE_THRESHOLD) {
         // Method hasn't been used for N chunks, safe to remove
         // SharedLineNumberTable will be automatically deallocated via shared_ptr destructor
-        bool has_line_table = (mi._line_number_table != nullptr && mi._line_number_table->_ptr != nullptr);
+        bool has_line_table = (mi._line_number_table != nullptr && mi._line_number_table->_table != nullptr);
         if (has_line_table) {
           removed_with_line_tables++;
         }

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -88,6 +88,10 @@ public:
   char* volatile _method_name;
   char* volatile _method_signature;
 
+  // Non-copyable
+  ResolveMethodState(const ResolveMethodState&) = delete;
+  ResolveMethodState& operator=(const ResolveMethodState&) = delete;
+
   ResolveMethodState();
   ~ResolveMethodState();
   void release();
@@ -215,11 +219,11 @@ void Lookup::cutArguments(char *func) {
   }
 }
 
-void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
+bool Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
                                 bool first_time, ResolveMethodState& state) {
   JNIEnv *jni = VM::jni();
   if (jni->PushLocalFrame(64) != 0) {
-    return;
+    return false;
   }
   state._framePushed = true;
 
@@ -276,7 +280,8 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         }
         return true;
       };
-      readable = probe(class_name) & probe(method_name) & probe(method_sig);    }
+      readable = probe(class_name) & probe(method_name) & probe(method_sig);
+    }
     if (readable) {
       const size_t class_name_len = strnlen(class_name, 65536);
       const char* normalized_class_name =
@@ -440,7 +445,20 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         // before an unprotected copy.
         owned_table = malloc(bytes);
         if (owned_table != nullptr) {
-          if (!SafeAccess::safeCopy(owned_table, line_number_table, bytes)) {
+          if (SafeAccess::safeCopy(owned_table, line_number_table, bytes)) {
+            // Hand ownership to mi->_line_number_table immediately, before the
+            // Deallocate() call below (a real, unprotected JVMTI call that can
+            // itself fault on the same possibly-stale jmethodID). mi lives in
+            // *_method_map, which survives a siglongjmp out of this function,
+            // so once owned_table is attached here it can no longer leak even
+            // if the rest of this block never finishes.
+            mi->_line_number_table = std::make_shared<SharedLineNumberTable>(
+                line_number_table_size, owned_table);
+            owned_table = nullptr; // ownership transferred; nothing left to free below
+            Counters::increment(LINE_NUMBER_TABLES);
+            NativeMem::record(NM_LINE_TABLES, (long long)((size_t)line_number_table_size *
+                                                          sizeof(jvmtiLineNumberEntry)));
+          } else {
             free(owned_table);
             owned_table = nullptr;
             line_number_table = nullptr; // make sure the invalid address is not used for jvmti->Deallocate
@@ -464,16 +482,15 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         jvmtiError dealloc_err = jvmti->Deallocate((unsigned char *)line_number_table);
         assert(dealloc_err == JVMTI_ERROR_NONE && "Unexpected error while deallocating linenumber table");
       }
-      if (owned_table != nullptr) {
-        mi->_line_number_table = std::make_shared<SharedLineNumberTable>(
-            line_number_table_size, owned_table);
-        // Increment counter for tracking live line number tables
-        Counters::increment(LINE_NUMBER_TABLES);
-        NativeMem::record(NM_LINE_TABLES, (long long)((size_t)line_number_table_size *
-                                                      sizeof(jvmtiLineNumberEntry)));
-      }
     }
+    return true;
   }
+  // Phase is neither START nor LIVE (e.g. a record-on-shutdown dump after the
+  // JVM has moved into JVMTI_PHASE_DEAD): none of mi's fields were touched
+  // above, unlike the "readable == false" case inside the branch above (which
+  // still fills mi with the deliberate "<unloaded>" sentinel and returns true
+  // via the return above).
+  return false;
 }
 
 bool Lookup::resolveVTableReceiver(VMSymbol *sym, char *buf, size_t bufsize,
@@ -709,8 +726,9 @@ MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
     // touching anything else.
     SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP();
     jmp_scope.restore();
-    Counters::increment(METHOD_RESOLVE_LONGJMP_RECOVERED);
-
+    Counters::increment(METHOD_RESOLVE_FAULT_RECOVERED);
+    // state.release() may fault. Unfortunately, it faults outside of profiler
+    // code where checkFault() can not absorbs.
     state.release();
     // A member, already filled above -- no map lookup, no allocation, and no
     // reliance on a local surviving siglongjmp (the value of a non-volatile
@@ -739,6 +757,7 @@ MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
 
   if (!mi->_mark) {
     bool first_time = mi->_key == 0;
+    bool filled = true;
     if (bci == BCI_ERROR) {
       fillNativeMethodInfo(mi, (const char *)method_id, nullptr, state);
     } else if (bci == BCI_NATIVE_FRAME) {
@@ -790,27 +809,46 @@ MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
       mi->_type = FRAME_NATIVE;
       mi->_is_entry = false;
     } else {
-      fillJavaMethodInfo(mi, method_id, first_time, state);
+      filled = fillJavaMethodInfo(mi, method_id, first_time, state);
     }
-    if (first_time) {
-      // Allocate a method-pool id that is unique among live methods. Must not
-      // be derived from the map size: cleanupUnreferencedMethods() erases
-      // entries, so size()+1 would reissue an id still owned by a surviving
-      // method, producing duplicate ids in the chunk's method constant pool
-      // (PROF-15130). The allocator recycles ids freed on erase instead.
-      mi->_key = _method_map->allocId();
+    // Mark last, never before the fill above, and only when the fill actually
+    // ran to completion. Two distinct ways the fill can not reach here:
+    //   1. It can siglongjmp straight out of this whole function (fillMethod)
+    //      on stale VM metadata -- ordering alone handles that, since the
+    //      unwind skips this statement (and everything below it) entirely.
+    //   2. fillJavaMethodInfo() can return normally without touching mi at
+    //      all (PushLocalFrame failed, or the JVM isn't in JVMTI_PHASE_START/
+    //      JVMTI_PHASE_LIVE) -- control returns here just like the success
+    //      case, so ordering alone does NOT catch this one; its `filled`
+    //      return value does.
+    // Marking (or allocating a key for) an unfilled row would leave it
+    // permanently stuck as an empty class/name/sig typed FRAME_INTERPRETED:
+    // writeMethods() serializes any marked row, and every later frame with
+    // this key would reuse it via the _mark fast path in resolveMethod(),
+    // rather than retrying the fill. Left unmarked, the row is retried by the
+    // next frame that needs it, and eventually aged out by
+    // cleanupUnreferencedMethods() if nothing ever fills it.
+    if (filled) {
+      if (first_time) {
+        // Allocate a method-pool id that is unique among live methods. Must not
+        // be derived from the map size: cleanupUnreferencedMethods() erases
+        // entries, so size()+1 would reissue an id still owned by a surviving
+        // method, producing duplicate ids in the chunk's method constant pool
+        // (PROF-15130). The allocator recycles ids freed on erase instead.
+        mi->_key = _method_map->allocId();
+      }
+      mi->_mark = true;
+    } else {
+      // Unfilled: mi stays unmarked (see above) for a future frame to retry,
+      // but *this* frame still needs a valid, already-marked row to reference
+      // right now -- the shared unknown-method row, same as every other
+      // resolution-failed path in this function (nullptr method_id above,
+      // raw-pointer resolve failure, the siglongjmp recovery branch).
+      // Returning mi itself here would hand the caller a key of 0 (never
+      // allocated) for a row writeMethods() will never emit, a dangling
+      // method-pool reference in the chunk.
+      return unknownMethod();
     }
-    // Mark last, never before the fill above. The fill walks VM metadata that a
-    // concurrent class unload may have freed, so it can siglongjmp straight out
-    // of this function (and fillJavaMethodInfo() also returns early when
-    // PushLocalFrame fails). Marking up front would leave the row marked but
-    // still default-constructed: writeMethods() serializes any marked row, so
-    // the chunk would gain a method with an empty class/name/sig typed as
-    // FRAME_INTERPRETED, and every later frame with this key would reuse it.
-    // Left unmarked, the row is skipped by writeMethods(), retried by the next
-    // frame that needs it, and eventually aged out by
-    // cleanupUnreferencedMethods(), which recycles its _key.
-    mi->_mark = true;
   }
 
   return mi;

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -192,7 +192,8 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
   jvmti->GetPhase(&phase);
   if ((phase & (JVMTI_PHASE_START | JVMTI_PHASE_LIVE)) != 0) {
     bool entry = false;
-    bool valid_method = false;
+    bool readable = false;
+    const size_t probe_len = 256;
     if (VMMethod::check_jmethodID(method) &&
         jvmti->GetMethodDeclaringClass(method, &method_class) == JVMTI_ERROR_NONE &&
         // GetMethodDeclaringClass may return a jclass wrapping a stale/garbage oop when the class was
@@ -208,9 +209,25 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         (!VM::isOpenJ9() || method_class != reinterpret_cast<jclass>(-1)) &&
         jvmti->GetClassSignature(method_class, &class_name, NULL) == JVMTI_ERROR_NONE &&
         jvmti->GetMethodName(method, &method_name, &method_sig, NULL) == JVMTI_ERROR_NONE) {
-      valid_method = (class_name != nullptr) && (method_name != nullptr) && (method_sig != nullptr);
-    }
-    if (valid_method) {
+      // The JVMTI strings should be non-null and mapped per spec, but crash
+      // telemetry shows both `strncmp` and `jvmti_Deallocate` faulting on them.
+      // Probe each pointer over a range covering the longest prefix
+      // compared below (~50 bytes) plus headroom for strlen, and NULL any that
+      // fails so the unconditional Deallocate block at end of this function
+      // skips it (os::free faults on an unmapped pointer just like strncmp).
+      // Accept a small leak on the corruption path. Probes run independently
+      // so a single bad pointer does not leak its siblings. Best-effort only:
+      // a concurrent munmap between probe and use can still fault; the SIGSEGV
+      // handler is the second line of defence.
+      auto probe = [&](char*& ptr) -> bool {
+        if (ptr == nullptr || !SafeAccess::isReadableRange(ptr, probe_len)) {
+          ptr = nullptr;
+          return false;
+        }
+        return true;
+      };
+      readable = probe(class_name) & probe(method_name) & probe(method_sig);    }
+    if (readable) {
       const size_t class_name_len = strnlen(class_name, 65536);
       const char* normalized_class_name =
           class_name_len >= 2 ? class_name + 1 : "";

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -68,11 +68,16 @@ static inline u64 safeDuration(u64 start_time, u64 end_time) {
 }
 
 SharedLineNumberTable::~SharedLineNumberTable() {
-  // _ptr is a malloc'd copy of the JVMTI line number table (see
-  // Lookup::fillJavaMethodInfo). Freeing here is independent of class
-  // unload, preventing use-after-free in ~SharedLineNumberTable and getLineNumber.
+  // _ptr is the buffer jvmti->GetLineNumberTable() itself returned (see
+  // Lookup::fillJavaMethodInfo), not a copy -- freed here via
+  // jvmti->Deallocate(), not plain free(). On HotSpot, JvmtiEnv
+  // Allocate()/Deallocate() are os::malloc()/os::free(), which route through
+  // MemTracker so native-memory-tracking accounting stays correct; freeing
+  // with plain free() instead would desync NMT's byte count from what's
+  // actually live whenever -XX:NativeMemoryTracking is enabled, even though
+  // the underlying memory itself would still be freed correctly.
   if (_ptr != nullptr) {
-    free(_ptr);
+    VM::jvmti()->Deallocate((unsigned char *)_ptr);
     Counters::decrement(LINE_NUMBER_TABLES);
     // _size is the JVMTI entry count passed at construction (see
     // fillJavaMethodInfo), so the byte size matches the allocation.
@@ -87,13 +92,16 @@ public:
   char* volatile _class_name;
   char* volatile _method_name;
   char* volatile _method_signature;
-  // GetLineNumberTable()'s JVMTI-owned result, pending Deallocate(). Tracked
-  // here for the same reason as the strings above: it is assigned between
-  // sigsetjmp() and a possible siglongjmp() out of a fault raised by a later
-  // JVMTI/JNI call in fillJavaMethodInfo() (Thread.run/main's FindClass/
-  // GetMethodID/CallBooleanMethod, or this function's own trailing
-  // Deallocate()), so release() must be able to free it on that recovery
-  // path too, not just the strings.
+  // GetLineNumberTable()'s result. Tracked here for the same reason as the
+  // strings above: it is assigned between sigsetjmp() and a possible
+  // siglongjmp() out of a fault raised by a later JVMTI/JNI call in
+  // fillJavaMethodInfo() (Thread.run/main's FindClass/GetMethodID/
+  // CallBooleanMethod), and until then this local has no other owner.
+  // release() frees it via jvmti->Deallocate() on that recovery path, and on
+  // the "rejected as unreadable/erroring" path fillJavaMethodInfo() also
+  // handles inline -- but never on the success path, where ownership passes
+  // to mi->_line_number_table instead (also freed via jvmti->Deallocate(),
+  // just later; see SharedLineNumberTable) and this field is nulled out.
   unsigned char* volatile _line_number_table;
 
   // Non-copyable
@@ -445,12 +453,21 @@ bool Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
     mi->_sig = method_sig_id;
     mi->_type = FRAME_INTERPRETED;
     mi->_is_entry = entry;
-    mi->_line_number_table = std::make_shared<SharedLineNumberTable>(
-                line_number_table_size, line_number_table);
-    // Increment counter for tracking live line number tables
-    Counters::increment(LINE_NUMBER_TABLES);
-    NativeMem::record(NM_LINE_TABLES, (long long)((size_t)line_number_table_size * sizeof(jvmtiLineNumberEntry)));
-    state._line_number_table = nullptr;
+    // Only touch mi->_line_number_table when a table was actually fetched
+    // this call (first_time, and GetLineNumberTable succeeded with a
+    // readable result -- see above). Every other call leaves
+    // line_number_table/line_number_table_size at their initial NULL/0,
+    // and mi->_key persists across chunks while only _mark gets cleared, so
+    // a re-fill of an already-known method must not clobber the real table
+    // fetched on its first chunk with an empty one.
+    if (line_number_table != nullptr) {
+      mi->_line_number_table = std::make_shared<SharedLineNumberTable>(
+                  line_number_table_size, line_number_table);
+      // Increment counter for tracking live line number tables
+      Counters::increment(LINE_NUMBER_TABLES);
+      NativeMem::record(NM_LINE_TABLES, (long long)((size_t)line_number_table_size * sizeof(jvmtiLineNumberEntry)));
+      state._line_number_table = nullptr;
+    }
     return true;
   }
   // Phase is neither START nor LIVE (e.g. a record-on-shutdown dump after the

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -547,9 +547,43 @@ u32 Lookup::resolveVTableReceiverCached(void *sym) {
   return class_id;
 }
 
+static const char *const UNKNOWN_METHOD_NAME = "unknown";
+
+// _mark doubles as "already filled in for this chunk" (writeMethods() clears it
+// after serializing), exactly as it does for a MethodMap row.
+MethodInfo *Lookup::unknownMethod() {
+  if (!_unknown_method._mark) {
+    _unknown_method._key = _method_map->unknownMethodId();
+    fillNativeMethodInfo(&_unknown_method, UNKNOWN_METHOD_NAME, nullptr);
+    _unknown_method._mark = true; // last; see the note in fillMethod()
+  }
+  return &_unknown_method;
+}
+
+unsigned long Lookup::methodKey(const ASGCT_CallFrame &frame,
+                                jmethodID method_id, jint bci,
+                                u32 vtable_class_id) {
+  // A null method_id never reaches here -- both callers divert it to
+  // unknownMethod(), which is not a map entry and so has no key.
+  assert(method_id != nullptr);
+  if (bci == BCI_ERROR || bci == BCI_NATIVE_FRAME) {
+    return MethodMap::makeKey(frame.native_function_name);
+  }
+  if (bci == BCI_NATIVE_FRAME_REMOTE) {
+    return MethodMap::makeKey(frame.packed_remote_frame);
+  }
+  if (bci == BCI_VTABLE_RECEIVER) {
+    return MethodMap::makeVTableReceiverKey(vtable_class_id);
+  }
+  [[maybe_unused]] FrameTypeId frame_type = FrameType::decode(bci);
+  assert(frame_type == FRAME_INTERPRETED || frame_type == FRAME_JIT_COMPILED ||
+         frame_type == FRAME_INLINED || frame_type == FRAME_C1_COMPILED ||
+         VM::isOpenJ9()); // OpenJ9 may have bugs that produce invalid frame types
+  return MethodMap::makeKey(method_id);
+}
+
+
 MethodInfo *Lookup::resolveMethod(ASGCT_CallFrame &frame) {
-  static const char* UNKNOWN = "unknown";
-  unsigned long key;
   jint bci = frame.bci;
   jmethodID method_id = frame.method_id;
 
@@ -560,11 +594,90 @@ MethodInfo *Lookup::resolveMethod(ASGCT_CallFrame &frame) {
   if (VM::isHotspot() && method_id == JMETHODID_NOT_WALKABLE) {
     method_id = nullptr;
   }
+  // Fill the shared "unknown" row *before* arming. The recovery branch below
+  // runs with protection already disarmed, so it must not allocate -- a second
+  // fault there would be unrecoverable -- and filling the row does allocate
+  // (symbol/class dictionary inserts). Once filled it stays filled for the rest
+  // of the chunk, so this costs one flag test per call after the first.
+  MethodInfo* unknown_method = unknownMethod();
 
+  // Nothing to symbolicate and nothing that can fault, so no protection is
+  // armed for this case at all.
+  if (method_id == nullptr) {
+    return unknown_method;
+  }
+
+  // Fast path, deliberately unprotected. For anything but a raw-pointer or
+  // BCI_VTABLE_RECEIVER frame, methodKey() reads no VM metadata (see its
+  // comment) and an already-marked row needs no symbolication -- there is
+  // nothing here that can fault, hence nothing to recover from. Worth
+  // special-casing because it is the common case once a chunk is warm, and
+  // arming the protection below is not free: initCurrentThreadSignalSafe()
+  // blocks and unblocks signals and sigsetjmp(..., 1) reads the signal mask,
+  // three syscalls on a loop that runs once per frame per trace.
+  if (!FrameType::isRawPointer(bci) && bci != BCI_VTABLE_RECEIVER) {
+    MethodMap::iterator it = _method_map->find(methodKey(frame, method_id, bci, 0));
+    if (it != _method_map->end() && it->second._mark) {
+      return &it->second;
+    }
+  }
+
+  // Slow path: symbolication reads VM metadata that a concurrent class unload
+  // may already have freed, so wrap it in a siglongjmp window that
+  // Profiler::checkFault() jumps back through on SIGSEGV/SIGBUS.
+  //
+  // Runs on the dump thread (finishChunk), never in a signal handler, so
+  // initCurrentThreadSignalSafe() can only fail on OOM.
+  ProfiledThread *prof_thread = ProfiledThread::initCurrentThreadSignalSafe();
+  if (prof_thread == nullptr) {
+    Counters::increment(METHOD_RESOLUTION_DROPPED_TLS);
+    return unknown_method;
+  }
+
+  // Reinstates the thread's previous landing pad on every exit from this frame,
+  // including a std::bad_alloc thrown by one of the map or dictionary inserts
+  // underneath. Leaving ours installed past the end of this frame would leave
+  // checkFault() jumping into a dead stack frame.
+  JmpCtxScope jmp_scope(prof_thread);
+
+  sigjmp_buf crash_protection_ctx;
+  // savemask must be 1: the siglongjmp originates inside segvHandler, where
+  // the kernel has SIGSEGV blocked, so without restoring the saved mask the
+  // signal would stay blocked and the next fault on this thread would be
+  // fatal.
+  if (sigsetjmp(crash_protection_ctx, 1) != 0) {
+    // checkFault() absorbed a fault raised somewhere in fillMethod() and
+    // jumped back here, bypassing the SIGNAL_HANDLER_GUARD() destructor in
+    // segvHandler()/busHandler(); compensate for it, then disarm before
+    // touching anything else.
+    SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP();
+    jmp_scope.restore();
+    Counters::increment(METHOD_RESOLVE_LONGJMP_RECOVERED);
+    // A member, already filled above -- no map lookup, no allocation, and no
+    // reliance on a local surviving siglongjmp (the value of a non-volatile
+    // local assigned after sigsetjmp() is indeterminate here).
+    return &_unknown_method;
+  }
+  jmp_scope.install(&crash_protection_ctx);
+  return fillMethod(frame, method_id, bci);
+}
+
+MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
+                               jint bci) {
   // Resolve native method
   if (FrameType::isRawPointer(bci)) {
     method_id = JVMSupport::resolve(frame.method);
+    if (method_id == nullptr) {
+      return unknownMethod();
+    }
   }
+
+  assert(method_id != nullptr && "Already filtered by caller");
+
+  // Inject fault to test siglongjmp protection. Sits inside the window
+  // resolveMethod() arms around this function, which is the point: this is
+  // never compiled into a production build (it needs -PenableFaultInjection).
+  INJECT_CRASH_LIKELY();
 
   // BCI_VTABLE_RECEIVER: method holds a VMSymbol* (see vmEntry.h). Resolve
   // to a class_id via the per-dump cache once, then key MethodMap by the
@@ -576,26 +689,9 @@ MethodInfo *Lookup::resolveMethod(ASGCT_CallFrame &frame) {
     vtable_class_id = resolveVTableReceiverCached((void *)method_id);
   }
 
-  if (method_id == nullptr) {
-    key = MethodMap::makeKey(UNKNOWN);
-  } else if (bci == BCI_ERROR || bci == BCI_NATIVE_FRAME) {
-    key = MethodMap::makeKey(frame.native_function_name);
-  } else if (bci == BCI_NATIVE_FRAME_REMOTE) {
-    key = MethodMap::makeKey(frame.packed_remote_frame);
-  } else if (bci == BCI_VTABLE_RECEIVER) {
-    key = MethodMap::makeVTableReceiverKey(vtable_class_id);
-  } else {
-    FrameTypeId frame_type = FrameType::decode(bci);
-    assert(frame_type == FRAME_INTERPRETED || frame_type == FRAME_JIT_COMPILED ||
-           frame_type == FRAME_INLINED || frame_type == FRAME_C1_COMPILED ||
-           VM::isOpenJ9()); // OpenJ9 may have bugs that produce invalid frame types
-    key = MethodMap::makeKey(method_id);
-  }
-
-  MethodInfo *mi = &(*_method_map)[key];
+  MethodInfo *mi = &(*_method_map)[methodKey(frame, method_id, bci, vtable_class_id)];
 
   if (!mi->_mark) {
-    mi->_mark = true;
     bool first_time = mi->_key == 0;
     if (first_time) {
       // Allocate a method-pool id that is unique among live methods. Must not
@@ -605,9 +701,7 @@ MethodInfo *Lookup::resolveMethod(ASGCT_CallFrame &frame) {
       // (PROF-15130). The allocator recycles ids freed on erase instead.
       mi->_key = _method_map->allocId();
     }
-    if (method_id == nullptr) {
-      fillNativeMethodInfo(mi, UNKNOWN, nullptr);
-    } else if (bci == BCI_ERROR) {
+    if (bci == BCI_ERROR) {
       fillNativeMethodInfo(mi, (const char *)method_id, nullptr);
     } else if (bci == BCI_NATIVE_FRAME) {
       const char *name = (const char *)method_id;
@@ -660,6 +754,17 @@ MethodInfo *Lookup::resolveMethod(ASGCT_CallFrame &frame) {
     } else {
       fillJavaMethodInfo(mi, method_id, first_time);
     }
+    // Mark last, never before the fill above. The fill walks VM metadata that a
+    // concurrent class unload may have freed, so it can siglongjmp straight out
+    // of this function (and fillJavaMethodInfo() also returns early when
+    // PushLocalFrame fails). Marking up front would leave the row marked but
+    // still default-constructed: writeMethods() serializes any marked row, so
+    // the chunk would gain a method with an empty class/name/sig typed as
+    // FRAME_INTERPRETED, and every later frame with this key would reuse it.
+    // Left unmarked, the row is skipped by writeMethods(), retried by the next
+    // frame that needs it, and eventually aged out by
+    // cleanupUnreferencedMethods(), which recycles its _key.
+    mi->_mark = true;
   }
 
   return mi;
@@ -1685,6 +1790,18 @@ int Recording::writeStackTraces(Buffer *buf, Lookup *lookup) {
   return trace_count > 0 ? 1 : 0;
 }
 
+// Serializes one method-pool entry and clears its mark, so the next chunk
+// re-resolves it (symbol/class ids are per-chunk).
+static void writeMethodEntry(Buffer *buf, MethodInfo &mi) {
+  mi._mark = false;
+  buf->putVar64(mi._key);
+  buf->putVar64(mi._class);
+  buf->putVar64(mi._name);
+  buf->putVar64(mi._sig);
+  buf->putVar64(mi._modifiers);
+  buf->putVar64(mi.isHidden());
+}
+
 int Recording::writeMethods(Buffer *buf, Lookup *lookup) {
   MethodMap *method_map = lookup->_method_map;
 
@@ -1694,6 +1811,13 @@ int Recording::writeMethods(Buffer *buf, Lookup *lookup) {
     if (it->second._mark) {
       marked_count++;
     }
+  }
+  // Lookup::_unknown_method is deliberately not a map entry (see its
+  // declaration), so the walk above cannot see it. It still has to be emitted:
+  // writeStackTraces() wrote its _key for every frame that resolved to it, and a
+  // _key absent from this pool is a dangling reference in the chunk.
+  if (lookup->_unknown_method._mark) {
+    marked_count++;
   }
 
   if (marked_count == 0) {
@@ -1706,15 +1830,13 @@ int Recording::writeMethods(Buffer *buf, Lookup *lookup) {
        ++it) {
     MethodInfo &mi = it->second;
     if (mi._mark) {
-      mi._mark = false;
-      buf->putVar64(mi._key);
-      buf->putVar64(mi._class);
-      buf->putVar64(mi._name);
-      buf->putVar64(mi._sig);
-      buf->putVar64(mi._modifiers);
-      buf->putVar64(mi.isHidden());
+      writeMethodEntry(buf, mi);
       flushIfNeeded(buf);
     }
+  }
+  if (lookup->_unknown_method._mark) {
+    writeMethodEntry(buf, lookup->_unknown_method);
+    flushIfNeeded(buf);
   }
   return 1;
 }

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -80,9 +80,56 @@ SharedLineNumberTable::~SharedLineNumberTable() {
                                                    sizeof(jvmtiLineNumberEntry)));
   }
 }
+class ResolveMethodState {
+public:
+  volatile bool _framePushed;
+  char* volatile _demangled;
+  char* volatile _class_name;
+  char* volatile _method_name;
+  char* volatile _method_signature;
+
+  ResolveMethodState();
+  ~ResolveMethodState();
+  void release();
+};
+
+ResolveMethodState::ResolveMethodState() :
+  _framePushed(false), _demangled(nullptr), _class_name(nullptr), _method_name(nullptr),
+  _method_signature(nullptr) {
+}
+
+ResolveMethodState::~ResolveMethodState() {
+  release();
+}
+
+void ResolveMethodState::release() {
+  if (_framePushed) {
+    JNIEnv* jni = VM::jni();
+    jni->PopLocalFrame(nullptr);
+    _framePushed = false;
+  }
+
+  if (_demangled != nullptr) {
+    free(_demangled);
+    _demangled = nullptr;
+  }
+  jvmtiEnv* jvmti = VM::jvmti();
+  if (_method_name != nullptr) {
+    jvmti->Deallocate((unsigned char*)_method_name);
+    _method_name = nullptr;
+  }
+  if (_method_signature != nullptr) {
+    jvmti->Deallocate((unsigned char*)_method_signature);
+    _method_signature = nullptr;
+  }
+  if (_class_name != nullptr) {
+    jvmti->Deallocate((unsigned char*)_class_name);
+    _class_name = nullptr;
+  }
+}
 
 void Lookup::fillNativeMethodInfo(MethodInfo *mi, const char *name,
-                                  const char *lib_name) {
+                                  const char *lib_name, ResolveMethodState& state) {
   mi->_class = _classes->lookupDuringDump("", 0, Profiler::maxClassMapSize());
   // TODO return the library name once we figured out how to cooperate with the
   // backend
@@ -100,20 +147,22 @@ void Lookup::fillNativeMethodInfo(MethodInfo *mi, const char *name,
 
   if (name[0] == '_' && name[1] == 'Z') {
     int status;
-    char *demangled = abi::__cxa_demangle(name, NULL, NULL, &status);
-    if (demangled != NULL) {
-      cutArguments(demangled);
+    
+    state._demangled = abi::__cxa_demangle(name, NULL, NULL, &status);
+    if (state._demangled != NULL) {
+      cutArguments(state._demangled);
       mi->_sig = _symbols.lookup("()L;");
       mi->_type = FRAME_CPP;
 
       // Rust legacy demangling
-      if (RustDemangler::is_probably_rust_legacy(demangled)) {
-        std::string rust_demangled = RustDemangler::demangle(demangled);
+      if (RustDemangler::is_probably_rust_legacy(state._demangled)) {
+        std::string rust_demangled = RustDemangler::demangle(state._demangled);
         mi->_name = _symbols.lookup(rust_demangled.c_str());
       } else {
-        mi->_name = _symbols.lookup(demangled);
+        mi->_name = _symbols.lookup(state._demangled);
       }
-      free(demangled);
+      free(state._demangled);
+      state._demangled = nullptr;
       return;
     }
   }
@@ -167,27 +216,28 @@ void Lookup::cutArguments(char *func) {
 }
 
 void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
-                                bool first_time, volatile bool& framePushed) {
+                                bool first_time, ResolveMethodState& state) {
   JNIEnv *jni = VM::jni();
   if (jni->PushLocalFrame(64) != 0) {
     return;
   }
-  framePushed = true;
+  state._framePushed = true;
 
   jvmtiEnv *jvmti = VM::jvmti();
 
   jvmtiPhase phase;
   jclass method_class = NULL;
   // invariant: these strings must remain null, or be assigned by JVMTI
-  char *class_name = nullptr;
-  char *method_name = nullptr;
-  char *method_sig = nullptr;
+  char* volatile &class_name = state._class_name;
+  char* volatile &method_name = state._method_name;
+  char* volatile &method_sig = state._method_signature;
   u32 class_name_id = 0;
   u32 method_name_id = 0;
   u32 method_sig_id = 0;
 
   jint line_number_table_size = 0;
   jvmtiLineNumberEntry *line_number_table = NULL;
+
 
   jvmti->GetPhase(&phase);
   if ((phase & (JVMTI_PHASE_START | JVMTI_PHASE_LIVE)) != 0) {
@@ -207,8 +257,8 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
         // when a classloader is unloaded, the jmethodIDs are not freed, but instead marked as -1.
         // The check below mitigates these crashes on J9.
         (!VM::isOpenJ9() || method_class != reinterpret_cast<jclass>(-1)) &&
-        jvmti->GetClassSignature(method_class, &class_name, NULL) == JVMTI_ERROR_NONE &&
-        jvmti->GetMethodName(method, &method_name, &method_sig, NULL) == JVMTI_ERROR_NONE) {
+        jvmti->GetClassSignature(method_class, (char**)&class_name, NULL) == JVMTI_ERROR_NONE &&
+        jvmti->GetMethodName(method, (char**)&method_name, (char**)&method_sig, NULL) == JVMTI_ERROR_NONE) {
       // The JVMTI strings should be non-null and mapped per spec, but crash
       // telemetry shows both `strncmp` and `jvmti_Deallocate` faulting on them.
       // Probe each pointer over a range covering the longest prefix
@@ -219,7 +269,7 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
       // so a single bad pointer does not leak its siblings. Best-effort only:
       // a concurrent munmap between probe and use can still fault; the SIGSEGV
       // handler is the second line of defence.
-      auto probe = [&](char*& ptr) -> bool {
+      auto probe = [&](char* volatile & ptr) -> bool {
         if (ptr == nullptr || !SafeAccess::isReadableRange(ptr, probe_len)) {
           ptr = nullptr;
           return false;
@@ -423,19 +473,7 @@ void Lookup::fillJavaMethodInfo(MethodInfo *mi, jmethodID method,
                                                       sizeof(jvmtiLineNumberEntry)));
       }
     }
-
-    // strings are null or came from JVMTI
-    if (method_name) {
-      jvmti->Deallocate((unsigned char *)method_name);
-    }
-    if (method_sig) {
-      jvmti->Deallocate((unsigned char *)method_sig);
-    }
-    if (class_name) {
-      jvmti->Deallocate((unsigned char *)class_name);
-    }
   }
-  jni->PopLocalFrame(NULL);
 }
 
 bool Lookup::resolveVTableReceiver(VMSymbol *sym, char *buf, size_t bufsize,
@@ -554,8 +592,9 @@ static const char *const UNKNOWN_METHOD_NAME = "unknown";
 // after serializing), exactly as it does for a MethodMap row.
 MethodInfo *Lookup::unknownMethod() {
   if (!_unknown_method._mark) {
+    ResolveMethodState state;
     _unknown_method._key = _method_map->unknownMethodId();
-    fillNativeMethodInfo(&_unknown_method, UNKNOWN_METHOD_NAME, nullptr);
+    fillNativeMethodInfo(&_unknown_method, UNKNOWN_METHOD_NAME, nullptr, state);
     _unknown_method._mark = true; // last; see the note in fillMethod()
   }
   return &_unknown_method;
@@ -656,7 +695,7 @@ MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
   // underneath. Leaving ours installed past the end of this frame would leave
   // checkFault() jumping into a dead stack frame.
   JmpCtxScope jmp_scope(prof_thread);
-  volatile bool framePushed = false;
+  ResolveMethodState state;
 
   sigjmp_buf crash_protection_ctx;
   // savemask must be 1: the siglongjmp originates inside segvHandler, where
@@ -672,10 +711,7 @@ MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
     jmp_scope.restore();
     Counters::increment(METHOD_RESOLVE_LONGJMP_RECOVERED);
 
-    if (framePushed) {
-      JNIEnv* jni = VM::jni();
-      jni->PopLocalFrame(nullptr);
-    }
+    state.release();
     // A member, already filled above -- no map lookup, no allocation, and no
     // reliance on a local surviving siglongjmp (the value of a non-volatile
     // local assigned after sigsetjmp() is indeterminate here).
@@ -704,11 +740,11 @@ MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
   if (!mi->_mark) {
     bool first_time = mi->_key == 0;
     if (bci == BCI_ERROR) {
-      fillNativeMethodInfo(mi, (const char *)method_id, nullptr);
+      fillNativeMethodInfo(mi, (const char *)method_id, nullptr, state);
     } else if (bci == BCI_NATIVE_FRAME) {
       const char *name = (const char *)method_id;
       fillNativeMethodInfo(mi, name,
-                           Profiler::instance()->getLibraryName(name));
+                           Profiler::instance()->getLibraryName(name), state);
     } else if (bci == BCI_NATIVE_FRAME_REMOTE) {
       // Unpack remote symbolication data using utility struct
       // Layout: pc_offset (44 bits) | mark (3 bits) | lib_index (15 bits)
@@ -736,10 +772,10 @@ MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
         const char* basename = strrchr(s, '/');
         if (basename) basename++; else basename = s;
         snprintf(name_buf, sizeof(name_buf), "[%s+0x%" PRIxPTR "]", basename, pc_offset);
-        fillNativeMethodInfo(mi, name_buf, nullptr);
+        fillNativeMethodInfo(mi, name_buf, nullptr, state);
       } else {
         TEST_LOG("WARNING: Library lookup failed for index %u", lib_index);
-        fillNativeMethodInfo(mi, "unknown_library", nullptr);
+        fillNativeMethodInfo(mi, "unknown_library", nullptr, state);
       }
     } else if (bci == BCI_VTABLE_RECEIVER) {
       // Synthetic vtable-receiver frame: method_id holds a VMSymbol*
@@ -754,7 +790,7 @@ MethodInfo *Lookup::fillMethod(ASGCT_CallFrame &frame, jmethodID method_id,
       mi->_type = FRAME_NATIVE;
       mi->_is_entry = false;
     } else {
-      fillJavaMethodInfo(mi, method_id, first_time, framePushed);
+      fillJavaMethodInfo(mi, method_id, first_time, state);
     }
     if (first_time) {
       // Allocate a method-pool id that is unique among live methods. Must not

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -412,7 +412,12 @@ private:
                             const char *lib_name, ResolveMethodState& state);
   void fillRemoteFrameInfo(MethodInfo *mi, const RemoteFrameInfo *rfi);
   void cutArguments(char *func);
-  void fillJavaMethodInfo(MethodInfo *mi, jmethodID method, bool first_time, ResolveMethodState& state);
+  // Returns false without writing any of mi's fields when there was nothing
+  // to fill (JNI PushLocalFrame failed, or the JVM isn't in JVMTI_PHASE_START/
+  // JVMTI_PHASE_LIVE) -- callers must not mark/allocate a key for mi in that
+  // case. Every other path (including the "<unloaded>" stale-jmethodID
+  // sentinel) fully populates mi and returns true.
+  bool fillJavaMethodInfo(MethodInfo *mi, jmethodID method, bool first_time, ResolveMethodState& state);
   bool has_prefix(const char *str, const char *prefix) const {
     return strncmp(str, prefix, strlen(prefix)) == 0;
   }

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -35,6 +35,7 @@
 #include "vmEntry.h"
 
 class VMSymbol;  // hotspot/vmStructs.h
+class ProfiledThread;
 
 const u64 MAX_JLONG = 0x7fffffffffffffffULL;
 const u64 MIN_JLONG = 0x8000000000000000ULL;
@@ -410,7 +411,7 @@ private:
                             const char *lib_name);
   void fillRemoteFrameInfo(MethodInfo *mi, const RemoteFrameInfo *rfi);
   void cutArguments(char *func);
-  void fillJavaMethodInfo(MethodInfo *mi, jmethodID method, bool first_time);
+  void fillJavaMethodInfo(MethodInfo *mi, jmethodID method, bool first_time, bool& framePushed);
   bool has_prefix(const char *str, const char *prefix) const {
     return strncmp(str, prefix, strlen(prefix)) == 0;
   }
@@ -453,7 +454,8 @@ private:
   // Resolves and fills in the MethodInfo for `frame`. This is the part that
   // reads VM metadata and may therefore fault; resolveMethod() wraps it in the
   // sigsetjmp/siglongjmp window.
-  MethodInfo *fillMethod(ASGCT_CallFrame &frame, jmethodID method_id, jint bci);
+  MethodInfo *fillMethod(ASGCT_CallFrame &frame, jmethodID method_id, jint bci,
+                         ProfiledThread* const prof_thread);
 
   // Materializes _unknown_method for this dump (filling it on first use) and
   // returns it.

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -447,9 +447,9 @@ private:
   // increments VTABLE_RECEIVER_RESOLVE_FAILED.
   u32 resolveVTableReceiverCached(void *sym);
 
-  // The MethodMap row `frame` belongs to. Factored out so resolveMethod()'s
+  // The MethodMap entry `frame` belongs to. Factored out so resolveMethod()'s
   // unprotected fast path and fillMethod()'s protected slow path can never
-  // disagree about which row a frame maps to -- ASGCT_CallFrame's method_id /
+  // disagree about which entry a frame maps to -- ASGCT_CallFrame's method_id /
   // native_function_name / packed_remote_frame / method fields are a union, so
   // the bci branching below is the only thing that gives the payload a meaning.
   //

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -411,7 +411,7 @@ private:
                             const char *lib_name);
   void fillRemoteFrameInfo(MethodInfo *mi, const RemoteFrameInfo *rfi);
   void cutArguments(char *func);
-  void fillJavaMethodInfo(MethodInfo *mi, jmethodID method, bool first_time, bool& framePushed);
+  void fillJavaMethodInfo(MethodInfo *mi, jmethodID method, bool first_time, volatile bool& framePushed);
   bool has_prefix(const char *str, const char *prefix) const {
     return strncmp(str, prefix, strlen(prefix)) == 0;
   }

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -73,9 +73,9 @@ public:
   // so native-memory-tracking accounting stays correct. Per the JVMTI spec
   // this array is a fresh, caller-owned allocation decoupled from the
   // Method's lifetime, so holding onto it is safe across class unload.
-  void *_ptr;
+  jvmtiLineNumberEntry* _table;
 
-  SharedLineNumberTable(int size, void *ptr) : _size(size), _ptr(ptr) {}
+  SharedLineNumberTable(int size, jvmtiLineNumberEntry *ptr) : _size(size), _table(ptr) {}
   ~SharedLineNumberTable();
 };
 

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -171,8 +171,23 @@ public:
     }
   }
 
+  // Pool id for Lookup::_unknown_method, the shared row for frames that could
+  // not be resolved. That row deliberately lives outside this map (see
+  // Lookup::unknownMethod()), so it needs an id that no map entry can ever be
+  // given: drawn from the same counter so it cannot collide, but drawn only
+  // once for the life of the recording and never recycled, since
+  // cleanupUnreferencedMethods() only ever erases -- and frees the ids of --
+  // actual map entries.
+  u32 unknownMethodId() {
+    if (_unknown_method_id == 0) {
+      _unknown_method_id = allocId();
+    }
+    return _unknown_method_id;
+}
+
 private:
   u32 _id_high_water = 0;
+  u32 _unknown_method_id = 0;
   std::vector<u32> _free_ids;
 };
 
@@ -376,6 +391,20 @@ public:
   Dictionary _packages;
   Dictionary _symbols;
 
+  // The single row every frame that could not be resolved collapses onto.
+  //
+  // Deliberately NOT a MethodMap entry: resolveMethod()'s siglongjmp landing pad
+  // hands this row back with crash protection already disarmed, so it must be
+  // reachable without touching the map, whose operator[] allocates a node and
+  // can throw std::bad_alloc.
+  //
+  // Because it is outside the map, the map walk in writeMethods() cannot see it,
+  // so writeMethods() emits it separately. It has to reach the method pool:
+  // writeStackTraces() writes its _key for every frame that resolved to it, and
+  // a _key with no matching pool entry is a dangling reference in the chunk.
+  // Public for that reason, matching _method_map/_symbols above.
+  MethodInfo _unknown_method;
+
 private:
   void fillNativeMethodInfo(MethodInfo *mi, const char *name,
                             const char *lib_name);
@@ -408,6 +437,27 @@ private:
   // bytes) returns the sentinel "<unresolved_vtable_receiver>" class_id and
   // increments VTABLE_RECEIVER_RESOLVE_FAILED.
   u32 resolveVTableReceiverCached(void *sym);
+
+  // The MethodMap row `frame` belongs to. Factored out so resolveMethod()'s
+  // unprotected fast path and fillMethod()'s protected slow path can never
+  // disagree about which row a frame maps to -- ASGCT_CallFrame's method_id /
+  // native_function_name / packed_remote_frame / method fields are a union, so
+  // the bci branching below is the only thing that gives the payload a meaning.
+  //
+  // Reads the union's *value* only: MethodMap::makeKey() hashes a pointer, it
+  // never dereferences it. So for every bci except BCI_VTABLE_RECEIVER -- whose
+  // class_id the caller must resolve from a VMSymbol* first -- computing a key
+  // touches no VM metadata and cannot fault.
+  unsigned long methodKey(const ASGCT_CallFrame &frame, jmethodID method_id,
+                          jint bci, u32 vtable_class_id);
+  // Resolves and fills in the MethodInfo for `frame`. This is the part that
+  // reads VM metadata and may therefore fault; resolveMethod() wraps it in the
+  // sigsetjmp/siglongjmp window.
+  MethodInfo *fillMethod(ASGCT_CallFrame &frame, jmethodID method_id, jint bci);
+
+  // Materializes _unknown_method for this dump (filling it on first use) and
+  // returns it.
+  MethodInfo *unknownMethod();
 
 public:
   Lookup(Recording *rec, MethodMap *method_map, StringDictionary *classes)

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -375,6 +375,7 @@ private:
   void cleanupUnreferencedMethods();
 };
 
+class ResolveMethodState;
 class Lookup {
 public:
   Recording *_rec;
@@ -408,10 +409,10 @@ public:
 
 private:
   void fillNativeMethodInfo(MethodInfo *mi, const char *name,
-                            const char *lib_name);
+                            const char *lib_name, ResolveMethodState& state);
   void fillRemoteFrameInfo(MethodInfo *mi, const RemoteFrameInfo *rfi);
   void cutArguments(char *func);
-  void fillJavaMethodInfo(MethodInfo *mi, jmethodID method, bool first_time, volatile bool& framePushed);
+  void fillJavaMethodInfo(MethodInfo *mi, jmethodID method, bool first_time, ResolveMethodState& state);
   bool has_prefix(const char *str, const char *prefix) const {
     return strncmp(str, prefix, strlen(prefix)) == 0;
   }

--- a/ddprof-lib/src/main/cpp/flightRecorder.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.h
@@ -68,9 +68,11 @@ struct CpuTimes {
 class SharedLineNumberTable {
 public:
   int _size;
-  // Owned malloc'd buffer holding a copy of the JVMTI line number table.
-  // Owning the memory (instead of holding the JVMTI-allocated pointer
-  // directly) keeps lifetime independent of class unload.
+  // The buffer jvmti->GetLineNumberTable() returned, held directly (not a
+  // copy) and freed via jvmti->Deallocate() (see ~SharedLineNumberTable())
+  // so native-memory-tracking accounting stays correct. Per the JVMTI spec
+  // this array is a fresh, caller-owned allocation decoupled from the
+  // Method's lifetime, so holding onto it is safe across class unload.
   void *_ptr;
 
   SharedLineNumberTable(int size, void *ptr) : _size(size), _ptr(ptr) {}

--- a/ddprof-lib/src/main/cpp/flightRecorder.inline.h
+++ b/ddprof-lib/src/main/cpp/flightRecorder.inline.h
@@ -20,11 +20,10 @@ jint MethodInfo::getLineNumber(jint bci) {
 
     int i = 1;
     while (i < _line_number_table->_size &&
-           bci >= ((jvmtiLineNumberEntry *)_line_number_table->_ptr)[i]
-                      .start_location) {
+           bci >= (_line_number_table->_table)[i].start_location) {
       i++;
     }
-    return ((jvmtiLineNumberEntry *)_line_number_table->_ptr)[i - 1]
+    return (_line_number_table->_table)[i - 1]
         .line_number;
 }
 

--- a/ddprof-lib/src/main/cpp/guards.cpp
+++ b/ddprof-lib/src/main/cpp/guards.cpp
@@ -37,21 +37,30 @@ void blockProfilingForExit() {
 
 int getInSignalDepth() {
     ProfiledThread *pt = ProfiledThread::current();
-    return pt != nullptr ? static_cast<int>(pt->signalDepth()) : 0;
+    // Deliberately returns the raw counter, negative values included, so a
+    // pairing bug is visible to tests and diagnostics rather than clamped away.
+    int depth = pt != nullptr ? pt->signalDepth() : 0;
+    assert(depth >= 0 && "Mismatched signal scope");
+    return depth;
 }
 
 bool isInTrackedSignalContext() {
     ProfiledThread *pt = ProfiledThread::current();
-    // null ProfiledThread = no thread context;
-    // the SignalHandlerScope never ran, so we have no positive evidence
-    // of a signal frame.
+    // null ProfiledThread = no thread context; the SignalHandlerScope
+    // never ran, so we have no positive evidence of a signal frame.
+
     // See header comment for the rationale of returning false here.
-    return pt != nullptr && pt->signalDepth() != 0;
+    // `> 0` rather than `!= 0`: a negative depth is a pairing bug (an
+    // unmatched signalHandlerUnwindAfterLongjmp()), not evidence of being in
+    // a signal handler, and must not pin dlopen_hook to the deferred-refresh
+    // path for the rest of the thread's life.
+    return pt != nullptr && pt->signalDepth() > 0;
 }
 
 SignalHandlerScope::SignalHandlerScope(bool shouldRunPriming) : _current(nullptr), _active(true) {
     ProfiledThread *pt = shouldRunPriming ? ProfiledThread::acquireCurrent() : ProfiledThread::current();
     if (pt != nullptr) {
+        DEBUG_ONLY(_signal_depth = pt->signalDepth();)
         _current = pt;
         pt->enterSignalScope();
     } else {
@@ -62,16 +71,14 @@ SignalHandlerScope::SignalHandlerScope(bool shouldRunPriming) : _current(nullptr
 }
 
 SignalHandlerScope::~SignalHandlerScope() {
-    if (!_active) return;
-    if (_current != nullptr) {
-        _current->exitSignalScope();
-    }
+    release();
 }
 
 void SignalHandlerScope::release() {
     if (!_active) return;
     if (_current != nullptr) {
         _current->exitSignalScope();
+        DEBUG_ONLY(assert(_signal_depth == _current->signalDepth());)
     }
     _active = false;
 }
@@ -82,7 +89,6 @@ void signalHandlerUnwindAfterLongjmp() {
         pt->exitSignalScope();
     }
 }
-
 
 CriticalSection::CriticalSection(ProfiledThread* pt) : _entered(false), _thread_ptr(pt) {
     // acquireCurrent() falls back to ThreadLocalDataPool::acquire() (a

--- a/ddprof-lib/src/main/cpp/guards.h
+++ b/ddprof-lib/src/main/cpp/guards.h
@@ -23,6 +23,7 @@
 #include <signal.h>
 #include <pthread.h>
 
+#include "common.h"
 #include "counters.h"
 
 class ProfiledThread;
@@ -95,6 +96,7 @@ public:
 private:
     ProfiledThread* _current;
     bool _active;
+    DEBUG_ONLY(int _signal_depth;)
 };
 
 // Shared drop-path body for the SIGNAL_HANDLER_GUARD_OR_DROP* macros below.

--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
@@ -1489,6 +1489,10 @@ class ResolvedNames {
 
   bool setImpl(char* short_name, char* volatile& long_name, size_t short_limit, VMSymbol* sym);
 public:
+  // Non-copyable
+  ResolvedNames(const ResolvedNames&) = delete;
+  ResolvedNames& operator=(const ResolvedNames&) = delete;
+ 
   ResolvedNames();
   ~ResolvedNames();
   void release();

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -13,6 +13,7 @@
 #include "codeCache.h"
 #include "common.h"
 #include "dictionary.h"
+#include "faultInjection.h"
 #include "stringDictionary.h"
 #include "engine.h"
 #include "event.h"
@@ -525,8 +526,7 @@ public:
     // this is a safe place to do it since this wrapper is used solely from the 'vm' stackwalker implementation
     if (force_stackwalk_crash_env) {
       TEST_LOG("FORCE_SIGSEGV");
-      int* p = nullptr;
-      *p = 1;
+      crashNow();
     }
 #endif
     return Libraries::instance()->findLibraryByAddress(address);

--- a/ddprof-lib/src/main/cpp/threadLocalData.h
+++ b/ddprof-lib/src/main/cpp/threadLocalData.h
@@ -89,7 +89,7 @@ private:
   u64 _park_block_token;
   int _filter_slot_id; // Slot ID for thread filtering
   uint8_t _init_window; // Countdown for JVM thread init race window (PROF-13072)
-  volatile uint8_t _signal_depth; // Nested signal-handler depth (see SignalHandlerScope)
+  volatile int _signal_depth; // Nested signal-handler depth (see SignalHandlerScope)
   // Debug only due to memory overhead
   DEBUG_ONLY(UnwindFailures _unwind_failures;)
   // xorshift64 PRNG state for compile-time fault injection (faultInjection.h).
@@ -192,7 +192,7 @@ public:
     u64 park_block_token;
     int filter_slot_id;
     uint8_t init_window;
-    uint8_t signal_depth;
+    int signal_depth;
     bool in_critical_section;
     bool otel_ctx_initialized;
     u64 otel_local_root_span_id;
@@ -314,7 +314,7 @@ public:
 
   // Signal-handler depth counter used by SignalHandlerScope (guards.h).
   // Atomic operations to prevent another signal interrupt load-modify-store.
-  inline uint8_t signalDepth() const { return __atomic_load_n(&_signal_depth, __ATOMIC_RELAXED); }
+  inline int signalDepth() const { return __atomic_load_n(&_signal_depth, __ATOMIC_RELAXED); }
   inline void enterSignalScope()    { __atomic_fetch_add(&_signal_depth, 1, __ATOMIC_RELAXED); }
   inline void exitSignalScope()     { if (signalDepth() > 0) __atomic_fetch_sub(&_signal_depth, 1, __ATOMIC_RELAXED); }
 

--- a/ddprof-lib/src/main/cpp/threadLocalData.h
+++ b/ddprof-lib/src/main/cpp/threadLocalData.h
@@ -316,7 +316,10 @@ public:
   // Atomic operations to prevent another signal interrupt load-modify-store.
   inline int signalDepth() const { return __atomic_load_n(&_signal_depth, __ATOMIC_RELAXED); }
   inline void enterSignalScope()    { __atomic_fetch_add(&_signal_depth, 1, __ATOMIC_RELAXED); }
-  inline void exitSignalScope()     { if (signalDepth() > 0) __atomic_fetch_sub(&_signal_depth, 1, __ATOMIC_RELAXED); }
+  inline void exitSignalScope()     {
+    int depth = __atomic_fetch_sub(&_signal_depth, 1, __ATOMIC_RELAXED);
+    assert(depth > 0 && "Unmatched exitSignalScope");
+  }
 
 #ifdef __FAULT_INJECTION__
   // One xorshift64 step (Marsaglia 2003), matching PoissonSampler::nextExp.

--- a/ddprof-lib/src/test/cpp/hotspotMethodId_ut.cpp
+++ b/ddprof-lib/src/test/cpp/hotspotMethodId_ut.cpp
@@ -187,7 +187,12 @@ TEST(HotspotMethodIdTest, RejectedMethodIdStaysNonRawAndResolvesToUnknown) {
 
     ASSERT_NE(info, nullptr);
     EXPECT_EQ(info->_type, FRAME_NATIVE);
-    EXPECT_EQ(methods.size(), 1U);
+    // The sentinel is normalised to a null method_id, which resolves to the
+    // shared unknown row. That row lives outside the MethodMap (see
+    // Lookup::_unknown_method), so nothing is inserted for this frame.
+    EXPECT_EQ(info, &lookup._unknown_method);
+    EXPECT_TRUE(methods.empty());
+    EXPECT_NE(info->_key, 0U);  // still needs a pool id to be referenceable}
 }
 
 // ---------------------------------------------------------------------------

--- a/ddprof-lib/src/test/cpp/lineNumberTableCopy_ut.cpp
+++ b/ddprof-lib/src/test/cpp/lineNumberTableCopy_ut.cpp
@@ -12,50 +12,57 @@
 //   ...
 //   Profiler::dump / FlightRecorder::dump
 //
-// Lookup::fillJavaMethodInfo() (inlined into resolveMethod() under -O2/-O3)
-// calls jvmtiEnv::GetLineNumberTable(method, ...) and then copied the
-// result with an unguarded:
-//
-//   memcpy(owned_table, line_number_table, bytes);
-//
-// (flightRecorder.cpp now guards this copy with SafeAccess::safeCopy() -- see
-// below -- so the line numbers of the unguarded version are no longer present
-// in the file; this file's tests reproduce that removed pattern. An earlier
-// version of the fix used a separate SafeAccess::isReadableRange() probe
-// followed by a plain memcpy(), but that still left a check-then-use race:
-// nothing stops the probed memory from becoming invalid in the gap between
-// the probe and the copy. safeCopy() closes that gap by fault-protecting
-// each read as it happens instead of trusting a point-in-time check.)
-//
-// Unlike the class_name/method_name/method_sig strings returned by the
-// preceding JVMTI calls (which ARE probed with SafeAccess::isReadableRange
-// before use, see PR #537 / commit ef13aa29f), the line_number_table pointer
-// is used directly.
-//
-// Per the JVMTI spec, GetLineNumberTable() hands back a freshly-allocated,
-// caller-owned array (hence the Deallocate() call after the copy) that is
-// decoupled from the Method's lifetime -- a spec-compliant implementation
-// cannot invalidate it out from under the caller. The actual risk, per the
-// comments already in fillJavaMethodInfo, is the TOCTOU race documented
-// right there: "GetMethodDeclaringClass may return a jclass wrapping a
+// Lookup::fillJavaMethodInfo() calls jvmtiEnv::GetLineNumberTable(method, ...)
+// on a jmethodID that can be stale (see the TOCTOU race documented right
+// there: "GetMethodDeclaringClass may return a jclass wrapping a
 // stale/garbage oop when the class was unloaded between sample capture and
-// dump" -- a race against class unloading, not tied to any one JVM vendor.
-// That same comment block notes crash telemetry showed GetClassSignature/
-// GetMethodName returning JVMTI_ERROR_NONE with unmapped string pointers
-// despite the spec saying they should be valid (a separate OpenJ9-specific
-// jmethodID-corruption mode is also handled a few lines above, but is not
-// the only source of this). The production crash motivating this file was
-// on a stock HotSpot JDK 11, confirming the race is not OpenJ9-specific.
-// GetLineNumberTable() is called on the exact same jmethodID as
-// GetMethodDeclaringClass/GetClassSignature/GetMethodName, with nothing
-// about it that would exempt it from that same observed failure mode.
+// dump" -- a race against class unloading, not tied to any one JVM vendor;
+// crash telemetry showed GetClassSignature/GetMethodName returning
+// JVMTI_ERROR_NONE with unmapped string pointers despite the spec saying they
+// should be valid, and GetLineNumberTable() is called on that exact same
+// jmethodID with nothing exempting it from the same failure mode). The
+// original, unguarded version of this code trusted the returned
+// pointer/size outright and crashed dereferencing them.
 //
-// These tests isolate the copy step from JVMTI/JNI (which fillJavaMethodInfo
-// requires and which is impractical to fake in a plain gtest) by exercising
-// the exact copy pattern against a pointer whose backing memory is gone --
-// standing in for "GetLineNumberTable() returned a bad pointer" regardless
-// of the precise reason. The result at the memcpy call site is identical
-// either way, so this is sufficient to prove both the crash and the fix.
+// The fix went through two shapes before landing on the current one:
+//   1. An unguarded memcpy() of the returned buffer into a private copy --
+//      crashed exactly like production.
+//   2. A SafeAccess::isReadableRange() probe followed by a plain memcpy() --
+//      closed most of the gap, but still faulted if the source ever became
+//      invalid between the probe and the copy.
+// The current implementation (flightRecorder.cpp, Lookup::fillJavaMethodInfo)
+// does not copy the table at all. Per the JVMTI spec, GetLineNumberTable()
+// hands back a freshly-allocated, caller-owned array decoupled from the
+// Method's lifetime -- a spec-compliant implementation cannot invalidate it
+// out from under the caller once returned -- so instead of copying, the code
+// validates the (pointer, size) pair exactly once and then holds the raw
+// pointer directly for the method's cached lifetime, via
+// std::shared_ptr<SharedLineNumberTable> (see flightRecorder.h), freed with
+// jvmti->Deallocate() when the row is finally evicted. That one-time
+// validation is what these tests exercise:
+//
+//   bool is_table_valid = (size >= 0 && size <= MAX_LINE_NUMBER_TABLE_ENTRIES);
+//   bool is_table_readable = (table != nullptr && is_table_valid &&
+//                             (size > 0 ? SafeAccess::isReadableRange(table, size * sizeof(entry))
+//                                       : SafeAccess::isReadable(table)));
+//
+// MAX_LINE_NUMBER_TABLE_ENTRIES (65535) sanity-bounds the reported size
+// before it drives a byte-count computation: JVM spec SS4.7.3 caps a method's
+// bytecode (code_length) at 65535 bytes (u2), so a well-formed table can
+// never have more entries than that, and a corrupted jmethodID is just as
+// likely to hand back a corrupted size as a corrupted pointer. The ternary on
+// `size > 0` matters in its own right: GetLineNumberTable() legitimately
+// returns size == 0 with a non-null malloc'd pointer on Hotspot, and
+// SafeAccess::isReadableRange() asserts size > 0, so a zero-length table must
+// be probed with the single-address SafeAccess::isReadable() instead, not
+// isReadableRange(ptr, 0).
+//
+// These tests isolate the validation step from JVMTI/JNI (which
+// fillJavaMethodInfo requires and which is impractical to fake in a plain
+// gtest) by exercising the exact validation shape above against buffers
+// standing in for whatever GetLineNumberTable() might hand back -- a valid
+// table, an unmapped one, a zero-size one, and corrupted size values --
+// regardless of the precise reason the JVMTI call produced them.
 
 #include <gtest/gtest.h>
 #include <cstring>
@@ -68,6 +75,23 @@
 #include "safeAccess.h"
 
 namespace {
+
+// Mirrors MAX_LINE_NUMBER_TABLE_ENTRIES in flightRecorder.cpp (not exported;
+// the JVM spec bound it documents is a stable, cross-file constant).
+constexpr jint kMaxLineNumberTableEntries = 65535;
+
+// Mirrors the exact validation Lookup::fillJavaMethodInfo() performs on
+// jvmtiEnv::GetLineNumberTable()'s output before trusting it (see the header
+// comment above). Kept as a free function, rather than calling into
+// fillJavaMethodInfo() itself, because that function also requires a live
+// JNIEnv/jvmtiEnv/jmethodID that a plain gtest cannot supply.
+bool isLineNumberTableReadable(jvmtiLineNumberEntry *table, jint size) {
+  bool is_table_valid = (size >= 0 && size <= kMaxLineNumberTableEntries);
+  return table != nullptr && is_table_valid &&
+         (size > 0 ? SafeAccess::isReadableRange(
+                          table, (size_t)size * sizeof(jvmtiLineNumberEntry))
+                    : SafeAccess::isReadable(table));
+}
 
 // SafeAccess::isReadableRange()/isReadable() rely on SIGSEGV/SIGBUS handlers
 // registered via OS::replaceSigsegvHandler()/replaceSigbusHandler() to catch
@@ -118,11 +142,14 @@ jvmtiLineNumberEntry *makeFakeLineNumberTable(void *page, int count) {
 
 } // namespace
 
-// Reproducer: the code shape that used to be in flightRecorder.cpp's
-// fillJavaMethodInfo() before the fix, with no readability guard before the
-// memcpy. Demonstrates that once the source page is gone, the copy step used
-// by resolveMethod() crashes the process rather than failing gracefully.
-TEST(LineNumberTableCopyRawTest, UnguardedCopyCrashesWhenSourceUnmapped) {
+// Reproducer: trusting GetLineNumberTable()'s (pointer, size) outright, with
+// no readability check, the way the pre-fix code did (and the way
+// MethodInfo::getLineNumber() would if a bad pair were ever cached).
+// Demonstrates that once the source page is gone, a direct read crashes the
+// process rather than failing gracefully -- this is exactly why the
+// validation below must run before the pair is ever handed to
+// SharedLineNumberTable.
+TEST(LineNumberTableCopyRawTest, UnguardedAccessCrashesWhenSourceUnmapped) {
   EXPECT_DEATH(
       {
         long page_size = sysconf(_SC_PAGESIZE);
@@ -137,31 +164,21 @@ TEST(LineNumberTableCopyRawTest, UnguardedCopyCrashesWhenSourceUnmapped) {
 
         // Stand-in for GetLineNumberTable() handing back a bad pointer for a
         // corrupted/stale jmethodID: the backing memory is simply gone by
-        // the time the copy runs.
+        // the time it is read.
         munmap(page, page_size);
 
-        // This mirrors the pre-fix fillJavaMethodInfo() shape verbatim: no
-        // readability check on line_number_table before the copy.
-        size_t bytes =
-            (size_t)line_number_table_size * sizeof(jvmtiLineNumberEntry);
-        void *owned_table = malloc(bytes);
-        memcpy(owned_table, line_number_table, bytes); // <-- crashes here
-        // Force the copied bytes to be observed before free(); otherwise an
-        // optimizing (Release) build can prove owned_table's contents are
-        // never read and eliminate the memcpy as dead code, silently
-        // skipping the very fault this test exists to demonstrate.
-        volatile unsigned char sink = *(volatile unsigned char *)owned_table;
+        // No readability check -- mirrors what MethodInfo::getLineNumber()
+        // does to an already-cached table, and what fillJavaMethodInfo did
+        // before the fix.
+        volatile jint sink = line_number_table[0].line_number; // <-- crashes here
         (void)sink;
-        free(owned_table);
       },
       "");
 }
 
-// Documents the fix: copying via SafeAccess::safeCopy() (which fault-protects
-// each read as it happens, rather than a point-in-time isReadableRange()
-// probe followed by a separate, unprotected memcpy()) turns the crash into a
-// clean, detectable failure with no memory touched past the fault.
-TEST_F(LineNumberTableCopyTest, GuardedCopySkipsSafelyWhenSourceUnmapped) {
+// Documents the fix: probing with SafeAccess::isReadableRange() before ever
+// trusting the pointer turns the crash into a clean, detectable rejection.
+TEST_F(LineNumberTableCopyTest, RejectsUnmappedSource) {
   long page_size = sysconf(_SC_PAGESIZE);
   void *page = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -173,34 +190,68 @@ TEST_F(LineNumberTableCopyTest, GuardedCopySkipsSafelyWhenSourceUnmapped) {
 
   ASSERT_EQ(0, munmap(page, page_size));
 
-  size_t bytes = (size_t)line_number_table_size * sizeof(jvmtiLineNumberEntry);
-  void *owned_table = malloc(bytes);
-  ASSERT_NE(owned_table, nullptr);
-  if (!SafeAccess::safeCopy(owned_table, line_number_table, bytes)) {
-    free(owned_table);
-    owned_table = nullptr;
-  }
-
-  EXPECT_EQ(nullptr, owned_table);
+  EXPECT_FALSE(
+      isLineNumberTableReadable(line_number_table, line_number_table_size));
 }
 
 // Sanity check: the guard must not reject a genuinely valid table, or every
-// real dump would silently lose line-number info.
-TEST_F(LineNumberTableCopyTest, GuardedCopyStillWorksForValidSource) {
+// real dump would silently lose line-number info. Also confirms the current
+// design's core property -- the validated pointer is held as-is, with no
+// private copy -- by wrapping it in SharedLineNumberTable and checking it is
+// the exact same allocation.
+TEST_F(LineNumberTableCopyTest, AcceptsValidSourceAndHoldsItDirectly) {
   jint line_number_table_size = 8;
   jvmtiLineNumberEntry stack_table[8];
   jvmtiLineNumberEntry *line_number_table =
       makeFakeLineNumberTable(stack_table, line_number_table_size);
 
-  size_t bytes = (size_t)line_number_table_size * sizeof(jvmtiLineNumberEntry);
-  void *owned_table = malloc(bytes);
-  ASSERT_NE(owned_table, nullptr);
-  if (!SafeAccess::safeCopy(owned_table, line_number_table, bytes)) {
-    free(owned_table);
-    owned_table = nullptr;
-  }
+  ASSERT_TRUE(
+      isLineNumberTableReadable(line_number_table, line_number_table_size));
 
-  ASSERT_NE(nullptr, owned_table);
-  EXPECT_EQ(0, memcmp(owned_table, line_number_table, bytes));
-  free(owned_table);
+  // SharedLineNumberTable stores the pointer/size verbatim -- no copy -- and
+  // its destructor calls jvmti->Deallocate() rather than free(), so we must
+  // not let it run on this stack-allocated buffer; construct it manually
+  // instead of via make_shared to check the stored fields without invoking
+  // the destructor.
+  SharedLineNumberTable held(line_number_table_size, line_number_table);
+  EXPECT_EQ(line_number_table, held._table);
+  EXPECT_EQ(line_number_table_size, held._size);
+  held._table = nullptr; // prevent ~SharedLineNumberTable() from Deallocate()-ing stack memory
+}
+
+// Regression test: GetLineNumberTable() legitimately returns size == 0 with a
+// non-null malloc'd pointer on Hotspot. SafeAccess::isReadableRange() asserts
+// size > 0, so the validation must probe a zero-size table with
+// SafeAccess::isReadable() instead of isReadableRange(ptr, 0) -- otherwise
+// every method compiled without debug line info would abort the process in
+// any build with assertions enabled (this project's gtest/debug configs).
+TEST_F(LineNumberTableCopyTest, AcceptsZeroSizeTableWithoutRangeCheckAssert) {
+  jvmtiLineNumberEntry entry{};
+  EXPECT_TRUE(isLineNumberTableReadable(&entry, 0));
+}
+
+// Regression test for the size being corrupted, alongside (or instead of) the
+// pointer, for the same reason as the pointer: a stale/garbage jmethemID's
+// out-params are just as likely to be corrupted together. A negative size
+// must be rejected by the sanity bound before it ever reaches a byte-count
+// computation or a SafeAccess probe.
+TEST_F(LineNumberTableCopyTest, RejectsNegativeSize) {
+  jvmtiLineNumberEntry stack_table[4];
+  jvmtiLineNumberEntry *line_number_table =
+      makeFakeLineNumberTable(stack_table, 4);
+
+  EXPECT_FALSE(isLineNumberTableReadable(line_number_table, -1));
+}
+
+// A well-formed LineNumberTable can never exceed MAX_LINE_NUMBER_TABLE_ENTRIES
+// entries (JVM spec SS4.7.3 caps code_length at 65535 bytes, u2), so an
+// implausibly large size must be rejected outright, independent of whether
+// the pointer happens to be readable.
+TEST_F(LineNumberTableCopyTest, RejectsOversizedTable) {
+  jvmtiLineNumberEntry stack_table[4];
+  jvmtiLineNumberEntry *line_number_table =
+      makeFakeLineNumberTable(stack_table, 4);
+
+  EXPECT_FALSE(isLineNumberTableReadable(line_number_table,
+                                          kMaxLineNumberTableEntries + 1));
 }

--- a/ddprof-lib/src/test/cpp/lookup_resolveMethod_ut.cpp
+++ b/ddprof-lib/src/test/cpp/lookup_resolveMethod_ut.cpp
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2026, Datadog, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Exercises Lookup::resolveMethod()'s two "fill" paths through the public
+// API (fillNativeMethodInfo()/fillJavaMethodInfo() are private, and their
+// ResolveMethodState parameter is a type local to flightRecorder.cpp, so
+// there is no way to call them, or inspect a ResolveMethodState, directly
+// from a separate translation unit -- see the note in
+// lineNumberTableCopy_ut.cpp about faking JVMTI/JNI for this exact code).
+//
+// A. A native frame whose method_id is a mangled C++ symbol (leading "_Z")
+//    drives fillNativeMethodInfo()'s demangling branch. That branch mallocs
+//    state._demangled via abi::__cxa_demangle(), truncates it with
+//    cutArguments(), copies the result into the symbol dictionary, then
+//    frees state._demangled and nulls it out -- all before resolveMethod()
+//    returns. There is no live handle left to assert against directly, so
+//    this test instead asserts the *outcome* of that lifecycle: the
+//    demangled-and-cut name lands in the symbol dictionary, and a second
+//    resolve() of the identical frame hits the MethodMap _mark fast path
+//    (proving the demangle/free cycle ran exactly once, not once per call).
+//
+// B. A Java frame drives fillJavaMethodInfo(), which PushLocalFrame()s a
+//    JNI frame up front and records that in ResolveMethodState::_framePushed.
+//    Because ResolveMethodState is a stack local of Lookup::fillMethod(),
+//    its destructor runs when fillMethod() returns, popping the JNI frame
+//    exactly once via release(). This test fakes jvmtiEnv/JNIEnv/JavaVM
+//    (same pattern as ScopedFakeJni in hotspotMethodId_ut.cpp and
+//    JVMSupportRestartTest in jvmSupport_ut.cpp) to count PushLocalFrame/
+//    PopLocalFrame calls and assert they balance 1:1.
+
+#include <gtest/gtest.h>
+
+#include "../../main/cpp/flightRecorder.h"
+#include "../../main/cpp/gtest_crash_handler.h"
+#include "../../main/cpp/threadLocalData.inline.h"
+#include "../../main/cpp/vmEntry.h"
+
+#include <cstring>
+#include <map>
+#include <string>
+
+static constexpr char LOOKUP_RESOLVE_METHOD_TEST_NAME[] = "LookupResolveMethodTest";
+class LookupResolveMethodGlobalSetup {
+public:
+    LookupResolveMethodGlobalSetup() { installGtestCrashHandler<LOOKUP_RESOLVE_METHOD_TEST_NAME>(); }
+    ~LookupResolveMethodGlobalSetup() { restoreDefaultSignalHandlers(); }
+};
+static LookupResolveMethodGlobalSetup lookup_resolve_method_global_setup;
+
+// ---------------------------------------------------------------------------
+// Test-only friend accessor for VM internals -- same pattern used by
+// hotspotMethodId_ut.cpp / jvmSupport_ut.cpp / frame_ut.cpp. Each test file
+// declares its own local class of this exact name; VM's `friend class
+// VMTestAccessor;` grants it access regardless of which translation unit
+// defines it.
+// ---------------------------------------------------------------------------
+class VMTestAccessor {
+public:
+    static bool getHotspot() { return VM::_hotspot; }
+    static void setHotspot(bool v) { VM::_hotspot = v; }
+    static int getHotspotVersion() { return VM::_hotspot_version; }
+    static void setHotspotVersion(int v) { VM::_hotspot_version = v; }
+    static JavaVM* getVm() { return VM::_vm; }
+    static void setVm(JavaVM* vm) { VM::_vm = vm; }
+    static jvmtiEnv* getJvmti() { return VM::_jvmti; }
+    static void setJvmti(jvmtiEnv* env) { VM::_jvmti = env; }
+};
+
+namespace {
+
+// ===========================================================================
+// A. Native mangled-symbol frame -- fillNativeMethodInfo()'s demangling
+//    branch. No JVMTI/JNI involved: BCI_ERROR's method_id is read as a
+//    plain native_function_name string, never as a jmethodID.
+// ===========================================================================
+
+TEST(LookupResolveMethodNativeDemangleTest, MangledCppSymbolIsDemangledCutAndCachedOnce) {
+    MethodMap method_map;
+    StringDictionary classes;
+    Lookup lookup(/*rec=*/nullptr, &method_map, &classes);
+
+    ASGCT_CallFrame frame{};
+    frame.bci = BCI_ERROR;
+    // Itanium-mangled `foo(int, int)`. abi::__cxa_demangle() must turn this
+    // into "foo(int, int)"; Lookup::cutArguments() then truncates it at the
+    // matching '(' to leave just "foo".
+    frame.native_function_name = "_Z3fooii";
+
+    MethodInfo* mi = lookup.resolveMethod(frame);
+    ASSERT_NE(nullptr, mi);
+    EXPECT_TRUE(mi->_mark);
+    EXPECT_EQ(FRAME_CPP, mi->_type)
+        << "leading _Z must route through the __cxa_demangle() branch, not "
+           "the plain-native-symbol fallback";
+
+    std::map<unsigned int, const char*> symbols;
+    lookup._symbols.collect(symbols);
+    ASSERT_EQ(1u, symbols.count(mi->_name));
+    EXPECT_STREQ("foo", symbols[mi->_name])
+        << "state._demangled, after __cxa_demangle() + cutArguments(), must "
+           "be exactly what got copied into the symbol dictionary";
+    ASSERT_EQ(1u, symbols.count(mi->_sig));
+    EXPECT_STREQ("()L;", symbols[mi->_sig]);
+
+    // A second resolve() of the identical frame must hit MethodMap's _mark
+    // fast path in resolveMethod() and never re-enter fillNativeMethodInfo().
+    // That is the only externally observable proof that the malloc'd
+    // state._demangled buffer was tracked and freed exactly once on the
+    // first call, rather than leaking or being re-demangled per call.
+    MethodInfo* mi_again = lookup.resolveMethod(frame);
+    EXPECT_EQ(mi, mi_again);
+}
+
+// ===========================================================================
+// B. Java frame -- fillJavaMethodInfo()'s JNI PushLocalFrame/PopLocalFrame
+//    balance, faked entirely without a live JVM.
+// ===========================================================================
+
+// Bumped by the mocked JVMTI/JNI function tables below; a fresh instance per
+// test via ScopedFakeJvmAndJni::SetUp().
+struct FakeJvmCounters {
+    int push_local_frame = 0;
+    int pop_local_frame = 0;
+    int deallocate = 0;
+    // When set before resolveMethod() runs, pushLocalFrame() reports failure
+    // (matching JNI's real contract) instead of succeeding -- drives
+    // fillJavaMethodInfo()'s early "nothing to fill" return.
+    bool fail_push_local_frame = false;
+};
+
+class ScopedFakeJvmAndJni {
+public:
+    ScopedFakeJvmAndJni() : _saved_vm(VMTestAccessor::getVm()) {
+        s_instance = this;
+
+        _jni_tbl = JNINativeInterface_{};
+        _jni_tbl.PushLocalFrame = &pushLocalFrame;
+        _jni_tbl.PopLocalFrame = &popLocalFrame;
+        _jni_env.functions = &_jni_tbl;
+
+        _vm_tbl = JNIInvokeInterface_{};
+        _vm_tbl.GetEnv = &getEnv;
+        _vm.functions = &_vm_tbl;
+
+        _jvmti_tbl = jvmtiInterface_1_{};
+        _jvmti_tbl.GetPhase = &getPhase;
+        _jvmti_tbl.GetMethodDeclaringClass = &getMethodDeclaringClass;
+        _jvmti_tbl.GetClassSignature = &getClassSignature;
+        _jvmti_tbl.GetMethodName = &getMethodName;
+        _jvmti_tbl.GetLineNumberTable = &getLineNumberTable;
+        _jvmti_tbl.Deallocate = &deallocate;
+        _jvmti_env.functions = &_jvmti_tbl;
+
+        VMTestAccessor::setVm(reinterpret_cast<JavaVM*>(&_vm));
+    }
+
+    ~ScopedFakeJvmAndJni() {
+        VMTestAccessor::setVm(_saved_vm);
+        s_instance = nullptr;
+    }
+
+    jvmtiEnv* jvmti() { return reinterpret_cast<jvmtiEnv*>(&_jvmti_env); }
+
+    FakeJvmCounters counters;
+
+private:
+    static char* dup(const char* s) {
+        size_t len = strlen(s) + 1;
+        char* copy = (char*)malloc(len);
+        memcpy(copy, s, len);
+        return copy;
+    }
+
+    static jint JNICALL pushLocalFrame(JNIEnv*, jint) {
+        s_instance->counters.push_local_frame++;
+        return s_instance->counters.fail_push_local_frame ? -1 : 0;
+    }
+    static jobject JNICALL popLocalFrame(JNIEnv*, jobject) {
+        s_instance->counters.pop_local_frame++;
+        return nullptr;
+    }
+    static jint JNICALL getEnv(JavaVM*, void** penv, jint) {
+        *penv = reinterpret_cast<JNIEnv*>(&s_instance->_jni_env);
+        return JNI_OK;
+    }
+    static jvmtiError JNICALL getPhase(jvmtiEnv*, jvmtiPhase* phase_ptr) {
+        *phase_ptr = JVMTI_PHASE_LIVE;
+        return JVMTI_ERROR_NONE;
+    }
+    static jvmtiError JNICALL getMethodDeclaringClass(jvmtiEnv*, jmethodID, jclass* declaring_class_ptr) {
+        static int fake_class_storage = 0;
+        *declaring_class_ptr = reinterpret_cast<jclass>(&fake_class_storage);
+        return JVMTI_ERROR_NONE;
+    }
+    static jvmtiError JNICALL getClassSignature(jvmtiEnv*, jclass, char** signature_ptr, char** generic_ptr) {
+        *signature_ptr = dup("Lcom/example/Foo;");
+        if (generic_ptr != nullptr) {
+            *generic_ptr = nullptr;
+        }
+        return JVMTI_ERROR_NONE;
+    }
+    static jvmtiError JNICALL getMethodName(jvmtiEnv*, jmethodID, char** name_ptr,
+                                            char** signature_ptr, char** generic_ptr) {
+        // Deliberately not "run"/"main" (with the exact strncmp lengths
+        // fillJavaMethodInfo checks) so the Thread.run/main entry-frame
+        // detection -- which would need FindClass/GetMethodID/
+        // CallBooleanMethod mocked too -- never fires.
+        *name_ptr = dup("sampleMethod");
+        *signature_ptr = dup("()V");
+        if (generic_ptr != nullptr) {
+            *generic_ptr = nullptr;
+        }
+        return JVMTI_ERROR_NONE;
+    }
+    static jvmtiError JNICALL getLineNumberTable(jvmtiEnv*, jmethodID, jint*, jvmtiLineNumberEntry**) {
+        // No line table: exercises the (very common) "unavailable" path
+        // without needing a second malloc'd buffer and a matching
+        // Deallocate() for it.
+        return JVMTI_ERROR_ABSENT_INFORMATION;
+    }
+    static jvmtiError JNICALL deallocate(jvmtiEnv*, unsigned char* mem) {
+        s_instance->counters.deallocate++;
+        free(mem); // matches the real JVMTI contract; a double-free here aborts the test
+        return JVMTI_ERROR_NONE;
+    }
+
+    static ScopedFakeJvmAndJni* s_instance;
+
+    JavaVM* _saved_vm;
+    JNINativeInterface_ _jni_tbl{};
+    JNIEnv_ _jni_env{};
+    JNIInvokeInterface_ _vm_tbl{};
+    JavaVM_ _vm{};
+    jvmtiInterface_1_ _jvmti_tbl{};
+    _jvmtiEnv _jvmti_env{};
+};
+ScopedFakeJvmAndJni* ScopedFakeJvmAndJni::s_instance = nullptr;
+
+class LookupResolveMethodJavaFrameTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _saved_hotspot = VMTestAccessor::getHotspot();
+        _saved_hotspot_version = VMTestAccessor::getHotspotVersion();
+        // hotspot_version() > 25 makes VMMethod::check_jmethodID_hotspot()
+        // return true immediately (see vmStructs.cpp) without walking any
+        // Method*/ConstMethod* fields -- exactly what lets this test use an
+        // opaque, never-dereferenced jmethodID.
+        VMTestAccessor::setHotspot(true);
+        VMTestAccessor::setHotspotVersion(30);
+
+        ProfiledThread::initCurrentThreadSignalSafe();
+
+        _saved_jvmti = VMTestAccessor::getJvmti();
+    }
+
+    void TearDown() override {
+        VMTestAccessor::setJvmti(_saved_jvmti);
+        VMTestAccessor::setHotspot(_saved_hotspot);
+        VMTestAccessor::setHotspotVersion(_saved_hotspot_version);
+    }
+
+    jvmtiEnv* _saved_jvmti;
+    bool _saved_hotspot;
+    int _saved_hotspot_version;
+};
+
+TEST_F(LookupResolveMethodJavaFrameTest, JniLocalFrameIsPoppedExactlyOnceOnNormalReturn) {
+    ScopedFakeJvmAndJni fake;
+    VMTestAccessor::setJvmti(fake.jvmti());
+
+    MethodMap method_map;
+    StringDictionary classes;
+    Lookup lookup(/*rec=*/nullptr, &method_map, &classes);
+
+    int fake_method_storage = 0;
+    ASGCT_CallFrame frame{};
+    frame.bci = FrameType::encode(FRAME_INTERPRETED, /*bci=*/0);
+    frame.method_id = reinterpret_cast<jmethodID>(&fake_method_storage);
+
+    MethodInfo* mi = lookup.resolveMethod(frame);
+
+    ASSERT_NE(nullptr, mi);
+    EXPECT_TRUE(mi->_mark);
+    EXPECT_EQ(FRAME_INTERPRETED, mi->_type);
+
+    // fillJavaMethodInfo() pushes exactly one JNI local frame up front, and
+    // ResolveMethodState's destructor (running when Lookup::fillMethod()
+    // returns normally) must pop exactly that one frame via release() --
+    // not zero (leaked local ref capacity) and not more than one.
+    EXPECT_EQ(1, fake.counters.push_local_frame);
+    EXPECT_EQ(1, fake.counters.pop_local_frame);
+
+    // The three JVMTI-allocated strings (class signature, method name,
+    // method signature) must each be deallocated exactly once via
+    // ResolveMethodState::release() -- this is what class_name/method_name/
+    // method_sig being copied into the *_raw locals and back into the
+    // volatile state fields (see fillJavaMethodInfo) is for.
+    EXPECT_EQ(3, fake.counters.deallocate);
+}
+
+// Regression test: fillJavaMethodInfo() returning early (PushLocalFrame
+// failed) must not leave a marked-but-empty row for this jmethodID, and must
+// not hand this frame a dangling method-pool key of 0 -- resolveMethod()
+// must fall back to the shared, already-marked unknown-method row, exactly
+// like every other resolution-failed path in fillMethod().
+TEST_F(LookupResolveMethodJavaFrameTest, PushLocalFrameFailureFallsBackToUnknownMethodAndLeavesRowUnmarked) {
+    ScopedFakeJvmAndJni fake;
+    fake.counters.fail_push_local_frame = true;
+    VMTestAccessor::setJvmti(fake.jvmti());
+
+    MethodMap method_map;
+    StringDictionary classes;
+    Lookup lookup(/*rec=*/nullptr, &method_map, &classes);
+
+    int fake_method_storage = 0;
+    jmethodID fake_method = reinterpret_cast<jmethodID>(&fake_method_storage);
+    ASGCT_CallFrame frame{};
+    frame.bci = FrameType::encode(FRAME_INTERPRETED, /*bci=*/0);
+    frame.method_id = fake_method;
+
+    MethodInfo* mi = lookup.resolveMethod(frame);
+
+    ASSERT_NE(nullptr, mi);
+    EXPECT_EQ(&lookup._unknown_method, mi)
+        << "an unfilled row must fall back to the shared unknown-method "
+           "sentinel, not hand back a row with an unallocated key";
+    EXPECT_TRUE(mi->_mark);
+    // PushLocalFrame failed before doing anything else, so no JVMTI calls
+    // (and no matching Deallocate()s) ever happened for this attempt.
+    EXPECT_EQ(1, fake.counters.push_local_frame);
+    EXPECT_EQ(0, fake.counters.pop_local_frame);
+    EXPECT_EQ(0, fake.counters.deallocate);
+
+    // The frame's own MethodMap row (distinct from the shared unknown-method
+    // row above) must stay unmarked and keyless so the next occurrence of
+    // this jmethodID retries the fill instead of reusing a bogus entry.
+    auto it = method_map.find(MethodMap::makeKey(fake_method));
+    ASSERT_NE(method_map.end(), it);
+    EXPECT_FALSE(it->second._mark);
+    EXPECT_EQ(0u, it->second._key);
+}
+
+} // namespace

--- a/ddprof-lib/src/test/cpp/lookup_resolveMethod_ut.cpp
+++ b/ddprof-lib/src/test/cpp/lookup_resolveMethod_ut.cpp
@@ -33,6 +33,7 @@
 #include <gtest/gtest.h>
 
 #include "../../main/cpp/flightRecorder.h"
+#include "../../main/cpp/flightRecorder.inline.h"
 #include "../../main/cpp/gtest_crash_handler.h"
 #include "../../main/cpp/threadLocalData.inline.h"
 #include "../../main/cpp/vmEntry.h"
@@ -128,6 +129,9 @@ struct FakeJvmCounters {
     // (matching JNI's real contract) instead of succeeding -- drives
     // fillJavaMethodInfo()'s early "nothing to fill" return.
     bool fail_push_local_frame = false;
+    // When set, getLineNumberTable() hands back a real (malloc'd) table
+    // instead of JVMTI_ERROR_ABSENT_INFORMATION.
+    bool provide_line_number_table = false;
 };
 
 class ScopedFakeJvmAndJni {
@@ -214,11 +218,20 @@ private:
         }
         return JVMTI_ERROR_NONE;
     }
-    static jvmtiError JNICALL getLineNumberTable(jvmtiEnv*, jmethodID, jint*, jvmtiLineNumberEntry**) {
-        // No line table: exercises the (very common) "unavailable" path
-        // without needing a second malloc'd buffer and a matching
-        // Deallocate() for it.
-        return JVMTI_ERROR_ABSENT_INFORMATION;
+    static jvmtiError JNICALL getLineNumberTable(jvmtiEnv*, jmethodID, jint* entry_count_ptr,
+                                                 jvmtiLineNumberEntry** table_ptr) {
+        if (!s_instance->counters.provide_line_number_table) {
+            // No line table: exercises the (very common) "unavailable" path
+            // without needing a second malloc'd buffer and a matching
+            // Deallocate() for it.
+            return JVMTI_ERROR_ABSENT_INFORMATION;
+        }
+        auto* table = (jvmtiLineNumberEntry*)malloc(sizeof(jvmtiLineNumberEntry));
+        table[0].start_location = 0;
+        table[0].line_number = 42;
+        *entry_count_ptr = 1;
+        *table_ptr = table;
+        return JVMTI_ERROR_NONE;
     }
     static jvmtiError JNICALL deallocate(jvmtiEnv*, unsigned char* mem) {
         s_instance->counters.deallocate++;

--- a/ddprof-lib/src/test/cpp/lookup_resolveMethod_ut.cpp
+++ b/ddprof-lib/src/test/cpp/lookup_resolveMethod_ut.cpp
@@ -355,4 +355,50 @@ TEST_F(LookupResolveMethodJavaFrameTest, PushLocalFrameFailureFallsBackToUnknown
     EXPECT_EQ(0u, it->second._key);
 }
 
+// Regression test: a method's line-number table, fetched once on its first
+// resolve (first_time -- see the `if (first_time)` guard around
+// GetLineNumberTable() in fillJavaMethodInfo()), must survive being
+// re-resolved in a later chunk. writeMethods() clears only mi->_mark between
+// chunks and leaves mi->_key (and thus first_time) alone, so a later resolve
+// of the same jmethodID never calls GetLineNumberTable() again -- the local
+// line_number_table stays null that time, and the assignment into
+// mi->_line_number_table must be skipped rather than clobbering the real
+// table with an empty SharedLineNumberTable(0, nullptr).
+TEST_F(LookupResolveMethodJavaFrameTest, LineNumberTableSurvivesReResolveInALaterChunk) {
+    ScopedFakeJvmAndJni fake;
+    fake.counters.provide_line_number_table = true;
+    VMTestAccessor::setJvmti(fake.jvmti());
+
+    MethodMap method_map;
+    StringDictionary classes;
+    Lookup lookup(/*rec=*/nullptr, &method_map, &classes);
+
+    int fake_method_storage = 0;
+    jmethodID fake_method = reinterpret_cast<jmethodID>(&fake_method_storage);
+    ASGCT_CallFrame frame{};
+    frame.bci = FrameType::encode(FRAME_INTERPRETED, /*bci=*/0);
+    frame.method_id = fake_method;
+
+    MethodInfo* mi = lookup.resolveMethod(frame);
+    ASSERT_NE(nullptr, mi);
+    ASSERT_NE(nullptr, mi->_line_number_table);
+    ASSERT_EQ(42, mi->getLineNumber(0));
+    u32 key_after_first_resolve = mi->_key;
+
+    // Simulate writeMethods() moving to the next chunk: it clears _mark on
+    // every marked row it serializes, but never touches _key.
+    mi->_mark = false;
+
+    MethodInfo* mi_again = lookup.resolveMethod(frame);
+
+    ASSERT_EQ(mi, mi_again) << "same jmethodID must resolve to the same MethodMap row";
+    EXPECT_TRUE(mi_again->_mark);
+    EXPECT_EQ(key_after_first_resolve, mi_again->_key)
+        << "first_time must be false on this second resolve";
+    ASSERT_NE(nullptr, mi_again->_line_number_table)
+        << "the table fetched on the first resolve must not be discarded "
+           "just because this call didn't re-fetch one";
+    EXPECT_EQ(42, mi_again->getLineNumber(0));
+}
+
 } // namespace

--- a/ddprof-lib/src/test/cpp/signalSafety_ut.cpp
+++ b/ddprof-lib/src/test/cpp/signalSafety_ut.cpp
@@ -123,15 +123,6 @@ TEST_F(SignalSafetyTest, SignalHandlerUnwindAfterLongjmpDecrementsOnce) {
     EXPECT_EQ(0, getInSignalDepth());
 }
 
-// Safety property: signalHandlerUnwindAfterLongjmp() saturates at zero;
-// double calls do not underflow.
-TEST_F(SignalSafetyTest, SignalHandlerUnwindAfterLongjmpSaturatesAtZero) {
-    EXPECT_EQ(0, getInSignalDepth());
-    signalHandlerUnwindAfterLongjmp();
-    signalHandlerUnwindAfterLongjmp();
-    EXPECT_EQ(0, getInSignalDepth());
-}
-
 TEST(SignalSafetyTestNoContext, NullProfiledThreadIsNotTrackedSignal) {
     // isInTrackedSignalContext() returns false on null because the
     // SignalHandlerScope never ran — used by Profiler::dlopen_hook so

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/CleanupAfterClassUnloadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/CleanupAfterClassUnloadTest.java
@@ -40,9 +40,13 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * <ol>
  *   <li>cleanupUnreferencedMethods() is now called inside finishChunk(), before
  *       DeleteLocalRef releases the GetLoadedClasses pins.</li>
- *   <li>fillJavaMethodInfo() copies the JVMTI line-number-table into a malloc'd buffer
- *       and immediately calls jvmti-&gt;Deallocate() on the original; cleanup calls free()
- *       on the malloc'd copy, which is safe regardless of class-unload state.</li>
+ *   <li>fillJavaMethodInfo() validates the JVMTI-returned (pointer, size) pair once, at
+ *       capture time (a sanity bound on the size plus a SafeAccess readability probe),
+ *       then holds that exact buffer directly in SharedLineNumberTable -- no private
+ *       copy. Per the JVMTI spec, GetLineNumberTable()'s returned array is a fresh,
+ *       caller-owned allocation decoupled from the Method's lifetime, so once validated
+ *       it stays safe to free with jvmti-&gt;Deallocate() (not free()) regardless of
+ *       class-unload state, whenever cleanup finally evicts the row.</li>
  * </ol>
  *
  * <p>This test reproduces the crash scenario:

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/WriteStackTracesAfterClassUnloadTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/memleak/WriteStackTracesAfterClassUnloadTest.java
@@ -26,11 +26,12 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * Regression test for a SIGSEGV in {@code Profiler::processCallTraces} during
  * {@code Recording::writeStackTraces} triggered by class unload.
  *
- * <p><b>Bug:</b> {@code MethodInfo::_line_number_table->_ptr} held a raw pointer to JVMTI-allocated
- * memory returned by {@code GetLineNumberTable}. When the underlying class was unloaded, the JVM
- * freed that memory, leaving {@code _ptr} dangling. The crash manifested when
- * {@code MethodInfo::getLineNumber(bci)} dereferenced the freed memory while
- * {@code writeStackTraces} iterated traces that still referenced the now-unloaded method.
+ * <p><b>Bug:</b> {@code MethodInfo::_line_number_table->_table} held a raw pointer to JVMTI-allocated
+ * memory returned by {@code GetLineNumberTable}, with no validation of that pointer at capture
+ * time. When the underlying class was unloaded, the JVM freed that memory, leaving the pointer
+ * dangling. The crash manifested when {@code MethodInfo::getLineNumber(bci)} dereferenced the
+ * freed memory while {@code writeStackTraces} iterated traces that still referenced the
+ * now-unloaded method.
  *
  * <p><b>Test scenario (timing-sensitive — catches the bug aggressively under ASan):</b>
  * <ol>
@@ -43,13 +44,18 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *       traces are still in {@code call_trace_storage} when {@code writeStackTraces} runs.</li>
  *   <li>The lambda inside {@code processCallTraces} resolves the unloaded method via
  *       {@code Lookup::resolveMethod} and calls {@code MethodInfo::getLineNumber(bci)} on a
- *       {@code MethodInfo} whose {@code _line_number_table->_ptr} was freed by the JVM →
+ *       {@code MethodInfo} whose {@code _line_number_table->_table} was freed by the JVM →
  *       SIGSEGV without the fix.</li>
  * </ol>
  *
- * <p>With the fix, {@code SharedLineNumberTable} owns a malloc'd copy of the entries
- * (the JVMTI allocation is deallocated immediately at capture time inside
- * {@code Lookup::fillJavaMethodInfo}), so {@code _ptr} stays valid regardless of class unload.
+ * <p>With the fix, {@code Lookup::fillJavaMethodInfo} validates the JVMTI-returned
+ * (pointer, size) pair once, at capture time (a sanity bound on the size plus a
+ * {@code SafeAccess} readability probe), then holds that exact buffer directly in
+ * {@code SharedLineNumberTable} -- no private copy. Per the JVMTI spec, {@code
+ * GetLineNumberTable()}'s returned array is a fresh, caller-owned allocation decoupled
+ * from the {@code Method}'s lifetime, so once validated it stays readable regardless of
+ * class unload; {@code ~SharedLineNumberTable()} frees it with {@code jvmti->Deallocate()}
+ * (not {@code free()}) only when the row is finally evicted from {@code method_map}.
  *
  * <p><b>Limitations:</b>
  * <ul>
@@ -108,7 +114,9 @@ public class WriteStackTracesAfterClassUnloadTest extends AbstractDynamicClassTe
         // 3. Immediately dump several times. The first dump runs writeStackTraces over
         //    the trace_buffer that still contains the unloaded method's traces; subsequent
         //    dumps cover the rotation tail. With the bug, getLineNumber dereferences the
-        //    freed JVMTI memory → SIGSEGV. With the fix, _ptr is a malloc'd copy → safe.
+        //    freed JVMTI memory → SIGSEGV. With the fix, the buffer was validated once at
+        //    capture time and (per the JVMTI spec) is decoupled from the Method's lifetime,
+        //    so it stays readable → safe.
         for (int i = 0; i < 4; i++) {
           profiler.dump(dumpFile);
           Thread.sleep(10);


### PR DESCRIPTION
**What does this PR do?**:

***Crash protection for method symbolication***
Note: This mechanism cannot protect against faults originating from JNI or JVMTI calls, as the faulting PCs are outside the profiler’s address space. Since JNI and JVMTI are public APIs, such faults should generally not occur unless the APIs are misused.
 
Split `resolveMethod()` into a fast, deliberately-unprotected path (already-marked cache hit — provably non-faulting) and a new `fillMethod()` slow path, armed with its own `sigsetjmp/JmpCtxScope` landing pad before touching any VM metadata.

Added `ResolveMethodState`, an RAII holder for the intermediate JNI/JVMTI-owned pointers (`_demangled`, `_class_name`, `_method_name`, `_method_signature`, `_line_number_table`) acquired mid-resolution. `state.release()` frees whatever's still pending — on both the normal path and the `siglongjmp` recovery path — via `jvmti->Deallocate()`.

Added a shared `_unknown_method` row (`Lookup::unknownMethod()`) that lives outside `MethodMap`, so the disarmed recovery branch can return a valid, already-marked row without allocating (a `MethodMap::operator[]` insert can throw `std::bad_alloc`, which must not happen with no landing pad installed).
`fillJavaMethodInfo()` now returns bool so a row is only marked/keyed when it was actually filled, preventing a permanently-stuck empty row when `PushLocalFrame` fails or the JVM isn't in JVMTI_PHASE_START/LIVE.
Added `INJECT_CRASH_LIKELY()` inside the protected window (compiled only under -PenableFaultInjection) to exercise the recovery path under test.

***Line-number-table handling***

`SharedLineNumberTable` no longer makes a private malloc'd copy of the JVMTI buffer — it now holds the buffer JVMTI itself returned and frees it via `jvmti->Deallocate()` instead of `free()`. (The previous copy-then-free() pairing could crash under -XX:NativeMemoryTracking, since HotSpot's Allocate/Deallocate route through NMT-tracked os::malloc/os::free, which add a header free() doesn't know about.)
Validation before trusting the buffer is now: a sanity bound on the reported size (MAX_LINE_NUMBER_TABLE_ENTRIES = 65535, the JVM spec's code_length cap) and a `SafeAccess` probe of the pointer — `isReadableRange()` for a non-zero size, `isReadable()` for the legitimate zero-size case Hotspot returns (calling `isReadableRange(ptr, 0)` would trip its `assert(size > 0)`).
LINE_NUMBER_TABLE_UNREADABLE is now actually incremented when the table is rejected.

***Signal-depth bookkeeping***

`_signal_depth` widened from `uint8_t` to `int`, and `exitSignalScope()/getInSignalDepth()` now assert() on an unmatched exit instead of silently clamping at zero — a pairing bug becomes visible in debug/test builds rather than self-healing invisibly. `isInTrackedSignalContext()` checks `> 0` rather than `!= 0` so a (now theoretically possible) negative depth reads as "not in a signal context" rather than permanently pinning dlopen_hook to its synchronous refresh path.

***Misc***

faultInjection.h/.cpp: `crashNow()`'s declaration and definition are now consistently guarded behind `__FAULT_INJECTION__ || DEBUG`; the unused INJECT_CRASH_ALWAYS() macro (previously only defined in the disabled branch) was removed; Profiler's test-only forced-crash path now calls crashNow() instead of a local null-deref.
counters.h: added METHOD_RESOLUTION_DROPPED_TLS (dump thread couldn't allocate a ProfiledThread, expected to stay 0); trimmed the METHOD_RESOLVE_FAULT_RECOVERED comment (previously explained it as a non-additive subset of STACKWALK_LONGJMP_RECOVERED, tied to the old raw-Method*-only code path — worth re-checking whether that non-additive relationship still holds and re-documenting it, since the comment was dropped rather than updated).

**Motivation**:
`Lookup::resolveMethod()` resolves `jmethodID`s into MethodInfo rows at JFR dump time by calling JVMTI (`GetMethodDeclaringClass`, `GetClassSignature`, `GetMethodName`, `GetLineNumberTable`). If the declaring class was unloaded between sample capture and dump, these calls can return stale/garbage pointers even with `JVMTI_ERROR_NONE` — production crash telemetry confirmed this on stock HotSpot, not just OpenJ9. This PR wraps that resolution path in a `sigsetjmp/siglongjmp` recovery window (building on the pattern already used for `HotspotSupport::resolve()`, #743) and fixes a related correctness/lifetime bug in how the JVMTI line-number-table buffer is validated and owned.


**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
- New lookup_resolveMethod_ut.cpp: exercises fillNativeMethodInfo()'s demangle-cut-cache-free lifecycle, and fillJavaMethodInfo()'s PushLocalFrame/PopLocalFrame balance (normal return and PushLocalFrame failure) via faked JNI/JVMTI, plus a line-number-table-survives-re-resolve-in-a-later-chunk case.

- lineNumberTableCopy_ut.cpp rewritten to match the current hold-not-copy design: rejects an unmapped source, accepts a valid table and confirms it's held (not copied), accepts a zero-size table without tripping the isReadableRange assert, and rejects negative/oversized reported sizes. Ran directly (gtestDebug_lineNumberTableCopy_ut) — all 6 cases pass.

- hotspotMethodId_ut.cpp updated: a rejected method id now resolves to the shared _unknown_method row instead of inserting into MethodMap.

- signalSafety_ut.cpp: removed the now-invalid "saturates at zero" test, since double-exit is now an assert failure by design, not a saturating no-op.
**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-15645](https://datadoghq.atlassian.net/browse/PROF-15645)

Unsure? Have a question? Request a review!


[PROF-15645]: https://datadoghq.atlassian.net/browse/PROF-15645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ