### PR TITLE
fix(nativemem): skip building DWARF unwind tables when cstack mode doesn't need them

### DIFF
--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1609,6 +1609,12 @@ Error Profiler::start(Arguments &args, bool reset) {
   }
 
   args._cstack = _cstack;
+  // From here on, cstackMode() reflects this session's final, resolved mode.
+  // Anything parsed before this point (e.g. ElfParser::parseDwarfInfo() for
+  // the handful of libraries loaded at JVMTI Agent_OnLoad, before this
+  // start() call) must not trust cstackMode() yet -- see cstackResolved()'s
+  // declaration for why.
+  _cstack_resolved.store(true, std::memory_order_release);
   // Prepare JVMSupport for execution
   JVMSupport::initExecution(args, VM::jvmti(), VM::jni());
 

--- a/ddprof-lib/src/main/cpp/profiler.h
+++ b/ddprof-lib/src/main/cpp/profiler.h
@@ -140,6 +140,15 @@ private:
   StackWalkFeatures _features;
   int _safe_mode;
   CStack _cstack;
+  // Set once, immediately after start() resolves _cstack (CSTACK_DEFAULT ->
+  // a concrete mode) and before any sampling begins. _cstack's constructor
+  // default is CSTACK_NO -- a real, user-selectable mode, not a
+  // distinguishable "not yet decided" sentinel -- so code that must tell
+  // "not yet resolved" apart from "resolved, and it's CSTACK_NO" (e.g.
+  // ElfParser::parseDwarfInfo() deciding whether a library parsed before
+  // start() might still need a DWARF table once resolution happens) needs
+  // this, not just cstackMode().
+  std::atomic<bool> _cstack_resolved;
   bool _force_jmethodID;
 
   volatile jvmtiEventMode _thread_events_state;
@@ -228,6 +237,7 @@ public:
         _start_time(0), _stop_time(0), _epoch(0), _timer_id(NULL),
         _total_samples(0), _sample_seq(0), _failures(), _class_map_lock(),
         _max_stack_depth(0), _features(), _safe_mode(0), _cstack(CSTACK_NO),
+        _cstack_resolved(false),
         _force_jmethodID(true),
         _thread_events_state(JVMTI_DISABLE), _libs(Libraries::instance()),
         _num_context_attributes(0), _omit_stacktraces(false),
@@ -278,6 +288,14 @@ public:
 
   inline CStack cstackMode() const {
     return _cstack;
+  }
+
+  // True once start() has resolved _cstack from a request (including
+  // CSTACK_DEFAULT) to the concrete mode it will use for this session. See
+  // the comment on _cstack_resolved for why cstackMode() alone can't tell
+  // "not yet decided" apart from "decided, and it's CSTACK_NO".
+  inline bool cstackResolved() const {
+    return _cstack_resolved.load(std::memory_order_acquire);
   }
 
   inline bool forceJmethodID() const {

--- a/ddprof-lib/src/main/cpp/symbols_linux.cpp
+++ b/ddprof-lib/src/main/cpp/symbols_linux.cpp
@@ -29,6 +29,7 @@
 #include "fdtransferClient.h"
 #include "log.h"
 #include "os.h"
+#include "profiler.h"
 #include "symbols_linux.h"
 
 // Simple address range
@@ -702,6 +703,31 @@ void ElfParser::parseDynamicSection() {
 
 void ElfParser::parseDwarfInfo() {
     if (!DWARF_SUPPORTED) return;
+
+    // Skip entirely when we are certain the table can never be read: it is
+    // consumed only by StackWalker::walkDwarf() (profiler.cpp), which runs
+    // only under CSTACK_DWARF. Gating on cstackMode() alone is NOT safe:
+    // Profiler::_cstack's constructor default is CSTACK_NO (a real,
+    // user-selectable mode, not a distinguishable "unresolved" sentinel), so
+    // a naive `cstackMode() != CSTACK_DWARF` check would also -- silently and
+    // incorrectly -- skip building the table for every library parsed before
+    // Profiler::start() has run and resolved it (the handful parsed at JVMTI
+    // Agent_OnLoad, vmEntry.cpp, before the later VM::VMInit()-triggered
+    // start() call): those libraries are parsed exactly once
+    // (Symbols::parseLibraries tracks _parsed_inodes) and never re-parsed, so
+    // getting this wrong would permanently and silently drop libjvm.so's own
+    // unwind info in a real CSTACK_DWARF session. cstackResolved() -- set
+    // once, immediately after start()'s resolution logic, before any
+    // sampling begins -- disambiguates "not yet decided" from "decided, and
+    // it wasn't DWARF". This is a real cost to skip once resolved-away: at
+    // 150,000 loaded classes this measured at 4.52 MiB across 22 allocations,
+    // unconditionally, even in the common case where the requested default
+    // resolves to CSTACK_VM (whenever HotSpot VMStructs are available)
+    // rather than CSTACK_DWARF.
+    if (Profiler::instance()->cstackResolved() &&
+        Profiler::instance()->cstackMode() != CSTACK_DWARF) {
+      return;
+    }
 
     // Try SFrame first (simpler format, faster parsing, no opcode interpretation).
     ElfProgramHeader* sframe_phdr = findProgramHeader(PT_GNU_SFRAME);


### PR DESCRIPTION
## Summary
- `ElfParser::parseDwarfInfo()` builds SFrame/DWARF unwind tables for every parsed native library unconditionally, even though they're read only by `StackWalker::walkDwarf()` under `CSTACK_DWARF`. Measured at 4.52 MiB / 22 allocations at 150,000 loaded classes, paid even when the resolved mode is `CSTACK_VM` (the common default whenever HotSpot VMStructs are available).
- Adds a gate: skip building once we know for certain the mode isn't `CSTACK_DWARF`. Getting "certain" right requires a dedicated `Profiler::_cstack_resolved` flag, not just comparing `cstackMode()` — `_cstack`'s constructor default is `CSTACK_NO`, a real user-selectable mode, not a distinguishable "not yet decided" sentinel. Since libraries are parsed exactly once (`Symbols::parseLibraries` tracks `_parsed_inodes`), including the handful parsed at JVMTI `Agent_OnLoad` before `Profiler::start()` ever resolves cstack mode, a naive check would permanently and silently skip building the table for those libraries (`libjvm.so` among them) even in an actual `CSTACK_DWARF` session — degrading native-frame unwind quality with no visible error. `_cstack_resolved` is set once, right after `start()`'s resolution logic, before any sampling begins.

## Honest note on measured impact — why this is closed rather than pursued further right now

The corrected fix is safe (verified `cstack=dwarf` still builds the full table, no regression). But re-measuring after fixing the above turned up something worth flagging: on the benchmark workload used to find this (`classes` mode, 150,000 loaded classes), the *real* savings are only ~0.07 MiB, not the ~4.52 MiB originally measured with the buggy gate. Almost the entire native-library set for that workload loads before `Profiler::start()` runs, where the gate must conservatively always build (the eventual mode isn't knowable yet). Only a handful of JDK-internal libraries that load lazily after start (`libmanagement.so`, `libnet.so`, `libnio.so`, etc.) actually benefit.

This fix should have more value for workloads that `dlopen` native libraries *while actively profiling* in a non-DWARF mode (JNI-heavy applications, dynamically-attached native agents) — but that scenario isn't covered by any workload we've measured, so the benefit there is currently unquantified, not just small. Given the added complexity (a new `Profiler` field threaded through a lifecycle-ordering invariant) isn't clearly justified by a measured benefit at this point, closing this without merging. Leaving it open here as reference in case someone has a workload where this matters and wants to pick it up — the fix itself is complete and tested.

## Test plan
- [x] `stackWalker_ut`, `libraries_ut`, `codeCache_ut` (release+debug) all pass
- [x] Verified `cstack=dwarf` builds the full table (`NM_NATIVE_SYMBOLS` = 13.03 MiB, matching the ungated value exactly — no regression)
- [x] Verified `cstack=fp` correctly skips the ~0.07 MiB that's actually skippable for that workload

🤖 Generated with [Claude Code](https://claude.com/claude-code)