### PR TITLE
Adopt JmpCtxScope for setting stack walk siglongjmp protection

### DIFF
--- a/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
+++ b/ddprof-lib/src/main/cpp/hotspot/hotspotSupport.cpp
@@ -279,7 +279,7 @@ __attribute__((no_sanitize("address"))) int HotspotSupport::walkVM(void* ucontex
     // then we end up with multiple HotspotSupport::walkVM() calls on stack,
     // each one sets up sigjmp_buf, they need to be chained to jump back to
     // correct location.
-    sigjmp_buf* prev_jmp_buf = prof_thread->getJmpCtx();
+    JmpCtxScope jmp_scope(prof_thread);
     // Should be preserved across sigsetjmp/siglongjmp
     volatile int depth = 0;
     int actual_max_depth = truncated ? max_depth + 1 : max_depth;
@@ -288,7 +288,7 @@ __attribute__((no_sanitize("address"))) int HotspotSupport::walkVM(void* ucontex
         // checkFault() does a siglongjmp from inside segvHandler, bypassing
         // segvHandler's SignalHandlerScope destructor.  Compensate.
         SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP();
-        prof_thread->setJmpCtx(prev_jmp_buf);
+        jmp_scope.restore();
         if (depth < max_depth) {
             fillFrame(frames[depth++], BCI_ERROR, "break_not_walkable");
         }
@@ -301,7 +301,7 @@ __attribute__((no_sanitize("address"))) int HotspotSupport::walkVM(void* ucontex
         return depth;
     }
 
-    prof_thread->setJmpCtx(&crash_protection_ctx);
+    jmp_scope.install(&crash_protection_ctx);
     VMThread* vm_thread = VMThread::current();
     if (vm_thread != NULL && !vm_thread->isThreadAccessible()) {
         Counters::increment(WALKVM_THREAD_INACCESSIBLE);
@@ -991,7 +991,7 @@ __attribute__((no_sanitize("address"))) int HotspotSupport::walkVM(void* ucontex
     }
 
     done:
-    prof_thread->setJmpCtx(prev_jmp_buf);
+    jmp_scope.restore();
 
     // Drop unknown leaf frame - it provides no useful information and breaks
     // aggregation by lumping unrelated samples under a single "unknown" entry
@@ -1263,13 +1263,13 @@ int HotspotSupport::walkJavaStack(StackWalkRequest& request) {
   }
   const bool prev_unwinding_java = prof_thread->is_unwinding_Java();
   sigjmp_buf crash_protection_ctx;
-  sigjmp_buf* prev_jmp_buf = prof_thread->getJmpCtx();
+  JmpCtxScope jmp_scope(prof_thread);
 
   if (sigsetjmp(crash_protection_ctx, 1) != 0) {
     // checkFault() does a siglongjmp from inside segvHandler, bypassing
     // segvHandler's SignalHandlerScope destructor. Compensate.
     SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP();
-    prof_thread->setJmpCtx(prev_jmp_buf);
+    jmp_scope.restore();
     // A recovered siglongjmp bypasses AsyncSampleMutex destructors, so restore
     // the per-thread guard to its pre-walk value.
     prof_thread->set_unwinding_Java(prev_unwinding_java);
@@ -1278,7 +1278,7 @@ int HotspotSupport::walkJavaStack(StackWalkRequest& request) {
     }
     return java_frames;
   }
-  prof_thread->setJmpCtx(&crash_protection_ctx);
+  jmp_scope.install(&crash_protection_ctx);
 
   if (features.mixed) {
     java_frames = walkVM(ucontext, frames, max_depth, features, eventTypeFromBCI(request.event_type), lock_index, truncated);
@@ -1332,7 +1332,6 @@ int HotspotSupport::walkJavaStack(StackWalkRequest& request) {
     }
   }
 
-  prof_thread->setJmpCtx(prev_jmp_buf);
   return java_frames;
 }
 

--- a/ddprof-lib/src/main/cpp/stackWalker.cpp
+++ b/ddprof-lib/src/main/cpp/stackWalker.cpp
@@ -8,6 +8,7 @@
 #include "stackWalker.inline.h"
 #include "dwarf.h"
 #include "faultInjection.h"
+#include "guards.h"
 #include "profiler.h"
 #include "stackFrame.h"
 #include "symbols.h"
@@ -52,13 +53,13 @@ int StackWalker::walkFP(void* ucontext, const void** callchain, int max_depth, S
     }
 
     sigjmp_buf crash_protection_ctx;
-    sigjmp_buf* prev_jmp_buf = prof_thread->getJmpCtx();
+    JmpCtxScope jmp_scope(prof_thread);
 
     if (sigsetjmp(crash_protection_ctx, 1) != 0) {
         // checkFault() does a siglongjmp from inside segvHandler, bypassing
         // segvHandler's SignalHandlerScope destructor. Compensate.
         SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP();
-        prof_thread->setJmpCtx(prev_jmp_buf);
+        jmp_scope.restore();
         if (truncated) {
             *truncated = true;
             if (depth > max_depth) {
@@ -67,7 +68,7 @@ int StackWalker::walkFP(void* ucontext, const void** callchain, int max_depth, S
         }
         return depth;
     }
-    prof_thread->setJmpCtx(&crash_protection_ctx);
+    jmp_scope.install(&crash_protection_ctx);
 
     // Walk until the bottom of the stack or until the first Java frame
     while (depth < actual_max_depth) {
@@ -97,8 +98,6 @@ int StackWalker::walkFP(void* ucontext, const void** callchain, int max_depth, S
         sp = fp + (FRAME_PC_SLOT + 1) * sizeof(void*);
         fp = (uintptr_t)SafeAccess::load(INJECT_FAULT_ADDRESS_LIKELY((void**)fp));
     }
-
-    prof_thread->setJmpCtx(prev_jmp_buf);
 
     if (truncated && depth > max_depth) {
         *truncated = true;
@@ -140,13 +139,13 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
     }
 
     sigjmp_buf crash_protection_ctx;
-    sigjmp_buf* prev_jmp_buf = prof_thread->getJmpCtx();
+    JmpCtxScope jmp_scope(prof_thread);
 
     if (sigsetjmp(crash_protection_ctx, 1) != 0) {
         // checkFault() does a siglongjmp from inside segvHandler, bypassing
         // segvHandler's SignalHandlerScope destructor. Compensate.
         SIGNAL_HANDLER_UNWIND_AFTER_LONGJMP();
-        prof_thread->setJmpCtx(prev_jmp_buf);
+        jmp_scope.restore();
         if (truncated) {
             *truncated = true;
             if (depth > max_depth) {
@@ -155,7 +154,7 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
         }
         return depth;
     }
-    prof_thread->setJmpCtx(&crash_protection_ctx);
+    jmp_scope.install(&crash_protection_ctx);
 
     // Walk until the bottom of the stack or until the first Java frame
     while (depth < actual_max_depth) {
@@ -232,8 +231,6 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
             break;
         }
     }
-
-    prof_thread->setJmpCtx(prev_jmp_buf);
 
     if (truncated && depth > max_depth) {
         *truncated = true;


### PR DESCRIPTION
**What does this PR do?**:
Replaces the hand-rolled `sigjmp_buf* prev = prof_thread->getJmpCtx(); ... prof_thread->setJmpCtx(prev);` siglongjmp-chaining pattern with the RAII `JmpCtxScope` guard (introduced in #743 for `HotspotSupport::resolve()`) across the remaining stack-walking entry points:

- `HotspotSupport::walkVM()`
- `HotspotSupport::walkJavaStack()`
- `StackWalker::walkFP()`
- `StackWalker::walkDwarf()`

Per site:
- `sigjmp_buf* prev_jmp_buf = getJmpCtx();` → `JmpCtxScope jmp_scope(prof_thread);`
- `setJmpCtx(&crash_protection_ctx);` → `jmp_scope.install(&crash_protection_ctx);`
- In the sigsetjmp fault-recovery branch: `setJmpCtx(prev_jmp_buf);` → `jmp_scope.restore();` (still an explicit disarm before touching anything else that could fault)
- On the normal exit path, the trailing `setJmpCtx(prev_jmp_buf);` is dropped in `walkFP`/`walkDwarf`/`walkJavaStack` — nothing after the walk loop can fault, so the guard's destructor restoring at function exit is sufficient. In `walkVM`, the explicit `jmp_scope.restore()` at the `done:` label is kept, since post-walk work in that frame (leaf-drop, counters) doesn't need the landing pad held live.

`guards.h` is now included by `stackWalker.cpp` (`hotspotSupport.cpp` already had it from #743).

**Motivation**:
Consolidate the siglongjmp landing-pad save/restore/chain logic behind one RAII abstraction instead of four duplicated get/set call sites, so every exit path (normal return, fault recovery, `goto`) is guaranteed to reinstate the previous landing pad without relying on the author remembering to add the restore call.

**Additional Notes**:
No functional/behavioral change intended — this is a pure refactor onto the existing `JmpCtxScope` abstraction from #743. `JmpCtxScope`'s constructor snapshots the previous landing pad before `install()` overwrites it, and `restore()`/the destructor always write that fixed snapshot, so it is safe to call `restore()` explicitly and then let the destructor run again at scope exit.

**How to test the change?**:
`./gradlew buildDebug` compiles clean. No behavior change, so existing stack-walking/crash-protection test coverage applies unchanged.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-15845](https://datadoghq.atlassian.net/browse/PROF-15845)

Unsure? Have a question? Request a review!

[PROF-15845]: https://datadoghq.atlassian.net/browse/PROF-15845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
