### PR TITLE
ci: skip 8-ibm slow tests + add amd64 debug gdb watchdog

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -62,6 +62,13 @@ jobs:
               echo "enabled=false" >> $GITHUB_OUTPUT
             fi
           fi
+          # IBM SDK 8 (OpenJ9 2.9) deadlocks inside JVMTI during the slow/e2e suite
+          # (class-unload + System.gc() + profiler.dump/stop); regular testDebug passes.
+          # Eclipse OpenJ9 8 (8-j9) and 17-j9 slow suites pass, so this is
+          # IBM-SDK-8-specific. Recurring nightly + release slow-test hangs since ~2026-08-19.
+          if [[ "${{ matrix.java_version }}" == "8-ibm" && "${{ inputs.slow_tests }}" == "true" ]]; then
+            echo "enabled=false" >> $GITHUB_OUTPUT
+          fi
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: steps.set_enabled.outputs.enabled == 'true'
         with:
@@ -93,7 +100,7 @@ jobs:
         if: steps.set_enabled.outputs.enabled == 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y curl zip unzip libgtest-dev libgmock-dev binutils
+          sudo apt-get install -y curl zip unzip libgtest-dev libgmock-dev binutils gdb
           # Install debug symbols for system libraries
           sudo apt-get install -y libc6-dbg
           if [[ ${{ matrix.java_version }} =~ "-zing" ]]; then
@@ -124,6 +131,23 @@ jobs:
             fi
           fi
 
+          # GDB watchdog for debug config: dumps all native threads if the JVM hangs
+          # inside JVMTI (e.g. the IBM SDK 8 slow-suite deadlock) before the 180-min
+          # job timeout fires, so a thread dump lands in the test-reports artifact.
+          # prepare_reports.sh copies build/logs/gdb-watchdog.log on failure.
+          if [[ "${{ matrix.config }}" == "debug" ]]; then
+            mkdir -p build/logs
+            (
+              sleep 1200  # 20 minutes — well past the normal ~6 min runtime
+              echo "::warning::GDB watchdog triggered after 20 minutes"
+              for pid in $(pgrep -f 'java.*ddprof-test'); do
+                echo "=== Thread dump for PID $pid ===" >> build/logs/gdb-watchdog.log
+                gdb -batch -ex 'thread apply all bt full' -p "$pid" >> build/logs/gdb-watchdog.log 2>&1 || true
+              done
+            ) &
+            GDB_WATCHDOG_PID=$!
+          fi
+
           # GraalVM pre-allocates fixed memory that conflicts with ASan's shadow range
           # [0x00007fff7000-0x10007fff7fff]; vm.mmap_rnd_bits tuning does not help (google/sanitizers#856).
           if [[ "${{ matrix.config }}" == "asan" && "${{ matrix.java_version }}" =~ graal ]]; then
@@ -151,6 +175,11 @@ jobs:
               ./gradlew --stop 2>/dev/null || true
             fi
           done
+
+          # Kill the watchdog if tests finished before it fired
+          if [[ -n "${GDB_WATCHDOG_PID:-}" ]]; then
+            kill "$GDB_WATCHDOG_PID" 2>/dev/null || true
+          fi
 
           if [ $EXIT_CODE -ne 0 ]; then
             echo "glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64" >> failures_glibc-${{ matrix.java_version }}-${{ matrix.config }}-amd64.txt


### PR DESCRIPTION
**What does this PR do?**:
Skips the slow/e2e test suite for `8-ibm` (IBM SDK 8 / OpenJ9 2.9) and adds a GDB watchdog to the amd64 `debug` test job.

**Motivation**:
The Validated Release pipeline (and the nightly slow run) has been hanging to the 180-min timeout on `test-linux-glibc-amd64 (8-ibm, debug)` since ~2026-08-19. The hang is isolated to IBM SDK 8:
- `8-j9` (Eclipse OpenJ9 8) slow debug → ✓ 3m14s
- `17-j9` slow debug → ✓ 2m42s
- `8-ibm` regular `testDebug` → ✓ 6m34s; `8-ibm` asan slow → ✓ 2m40s
- `8-ibm` slow debug → ✗ 3h0m15s (hung)

The deadlock is inside JVMTI during the slow suite (class-unload + `System.gc()` + `profiler.dump()/stop()`). `@Timeout(60)` on the slow tests cannot break a native JVMTI deadlock. The amd64 debug job had no watchdog, so no thread dump existed to pinpoint the exact test.

This unblocks the release by gating `8-ibm` out of the slow suite (slow_tests-gated, so regular `testDebug` on 8-ibm still runs in PR/ci). OpenJ9 slow coverage is retained via `8-j9` and `17-j9`. The GDB watchdog (20-min sleep, fires before the 180-min job timeout) mirrors the existing aarch64-asan watchdog so any future amd64 debug hang self-captures a native thread dump into the `test-reports` artifact.

**Additional Notes**:
Root cause of the IBM-SDK-8-specific deadlock is still open (prime suspect: #713 "Restore priming and fix races on acquire/release ProfiledThread", Aug 18 — nightly slow hangs began ~Aug 19). The watchdog will pinpoint it on the next hang.

**How to test the change?**:
CI-only change. The next nightly slow run and the next release dispatch will exercise it: `8-ibm` slow jobs are skipped; any amd64 debug job that hangs past 20 min produces `build/logs/gdb-watchdog.log` (copied into `test-reports` by `prepare_reports.sh`).

**For Datadog employees**:
- [x] This PR doesn't touch any of that.
- [ ] JIRA: N/A
