### PR TITLE
ci: guard amd64 post-test steps with set_enabled

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -186,17 +186,17 @@ jobs:
             exit 1
           fi
       - name: Generate Unwinding Report
-        if: success() && matrix.config == 'debug'
+        if: success() && matrix.config == 'debug' && steps.set_enabled.outputs.enabled == 'true'
         run: |
           ./gradlew -PCI :ddprof-test:unwindingReport --no-daemon
       - name: Add Unwinding Report to Job Summary
-        if: success() && matrix.config == 'debug' && hashFiles('ddprof-test/build/reports/unwinding-summary.md') != ''
+        if: success() && matrix.config == 'debug' && steps.set_enabled.outputs.enabled == 'true' && hashFiles('ddprof-test/build/reports/unwinding-summary.md') != ''
         run: |
           echo "## 🔧 Unwinding Quality Report - ${{ matrix.java_version }} (amd64)" >> $GITHUB_STEP_SUMMARY
           cat ddprof-test/build/reports/unwinding-summary.md >> $GITHUB_STEP_SUMMARY
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: success()
+        if: success() && steps.set_enabled.outputs.enabled == 'true'
         with:
           name: (build) test-linux-glibc-amd64 (${{ matrix.java_version }}, ${{ matrix.config }}, ${{ inputs.slow_tests && 'slow' || 'regular' }})
           path: build/


### PR DESCRIPTION
**What does this PR do?**:
Guards the amd64 post-test steps (Generate Unwinding Report, Add Unwinding Report to Job Summary, Upload build artifacts) with `steps.set_enabled.outputs.enabled == 'true'`.

**Motivation**:
Follow-up to #760. When a matrix job is disabled via `set_enabled` (e.g. `8-ibm` slow tests), the `checkout` step is skipped (guarded by `enabled == 'true'`), but these post-test steps only gated on `success() && matrix.config == 'debug'` — no `enabled` check. So they ran without a checked-out repo and failed with **exit code 127** (`./gradlew: command not found`), which cascaded into spurious `if: failure()` upload steps firing.

This caused the re-dispatched release ([run 33188807730](https://github.com/DataDog/java-profiler/actions/runs/33188807730)) to fail on `pre-release-slow-tests / test-linux-glibc-amd64 (8-ibm, debug)` in 7s — not the hang (that was excluded), but the unguarded unwinding-report step.

**How to test the change?**:
CI-only. The next release dispatch / nightly slow run will confirm `8-ibm` slow jobs skip cleanly (exit 0, no spurious failures).

**For Datadog employees**:
- [x] This PR doesn't touch any of that.
- [ ] JIRA: PROF-15853
