### PR TITLE
Possible out-of-bounds Context read

### DIFF
--- a/ddprof-lib/src/main/cpp/context.h
+++ b/ddprof-lib/src/main/cpp/context.h
@@ -32,15 +32,19 @@ public:
   u64 rootSpanId;
 private:
   Tag tags[DD_TAGS_CAPACITY];
+
+  static bool isValidIndex(int i) {
+    return i >= 0 && (u32)i < DD_TAGS_CAPACITY;
+  }
 public:
   u32 getTag(int i) {
-    assert(i >= 0 && (u32)i < DD_TAGS_CAPACITY);
-    return i >= 0 && (u32)i < DD_TAGS_CAPACITY ? tags[i].value : 0;
+    assert(isValidIndex(i));
+    return isValidIndex(i) ? tags[i].value : 0;
   }
   
   void setTag(int i, u32 value) {
-    assert(i >= 0 && (u32)i < DD_TAGS_CAPACITY);
-    if (i >= 0 && (u32)i < DD_TAGS_CAPACITY) {
+    assert(isValidIndex(i));
+    if (isValidIndex(i)) {
       tags[i].value = value;
     }
   }

--- a/ddprof-lib/src/main/cpp/context.h
+++ b/ddprof-lib/src/main/cpp/context.h
@@ -40,7 +40,9 @@ public:
   
   void setTag(int i, u32 value) {
     assert(i >= 0 && (u32)i < DD_TAGS_CAPACITY);
-    tags[i].value = value;
+    if (i >= 0 && (u32)i < DD_TAGS_CAPACITY) {
+      tags[i].value = value;
+    }
   }
 };
 

--- a/ddprof-lib/src/main/cpp/context.h
+++ b/ddprof-lib/src/main/cpp/context.h
@@ -18,6 +18,7 @@
 #define _CONTEXT_H
 
 #include "arch.h"
+#include <cassert>
 
 static const u32 DD_TAGS_CAPACITY = 10;
 
@@ -29,9 +30,18 @@ class alignas(DEFAULT_CACHE_LINE_SIZE) Context {
 public:
   u64 spanId;
   u64 rootSpanId;
+private:
   Tag tags[DD_TAGS_CAPACITY];
-
-  Tag get_tag(int i) { return i >= 0 && (u32)i < DD_TAGS_CAPACITY ? tags[i] : Tag{0}; }
+public:
+  u32 getTag(int i) {
+    assert(i >= 0 && (u32)i < DD_TAGS_CAPACITY);
+    return i >= 0 && (u32)i < DD_TAGS_CAPACITY ? tags[i].value : 0;
+  }
+  
+  void setTag(int i, u32 value) {
+    assert(i >= 0 && (u32)i < DD_TAGS_CAPACITY);
+    tags[i].value = value;
+  }
 };
 
 #endif /* _CONTEXT_H */

--- a/ddprof-lib/src/main/cpp/context.h
+++ b/ddprof-lib/src/main/cpp/context.h
@@ -31,7 +31,7 @@ public:
   u64 rootSpanId;
   Tag tags[DD_TAGS_CAPACITY];
 
-  Tag get_tag(int i) { return tags[i]; }
+  Tag get_tag(int i) { return i >= 0 && (u32)i < DD_TAGS_CAPACITY ? tags[i] : Tag{0}; }
 };
 
 #endif /* _CONTEXT_H */

--- a/ddprof-lib/src/main/cpp/flightRecorder.cpp
+++ b/ddprof-lib/src/main/cpp/flightRecorder.cpp
@@ -2115,7 +2115,7 @@ void Recording::writeContextSnapshot(Buffer *buf, Context &context) {
   buf->putVar64(context.rootSpanId);
 
   for (size_t i = 0; i < Profiler::instance()->numContextAttributes(); i++) {
-    buf->putVar32(context.get_tag(i).value);
+    buf->putVar32(context.getTag(i));
   }
 }
 

--- a/ddprof-lib/src/main/cpp/profiler.cpp
+++ b/ddprof-lib/src/main/cpp/profiler.cpp
@@ -1632,6 +1632,11 @@ Error Profiler::start(Arguments &args, bool reset) {
   // Always enable library trap to catch wasmtime loading and patch its broken sigaction
   switchLibraryTrap(true);
 
+  if (args._context_attributes.size() > DD_TAGS_CAPACITY) {
+    Log::warn("attributes: %zu attributes requested but capacity is %u; extra attributes will be ignored",
+               args._context_attributes.size(), DD_TAGS_CAPACITY);
+    args._context_attributes.resize(DD_TAGS_CAPACITY);
+  }
   JfrMetadata::reset();
   JfrMetadata::initialize(args._context_attributes);
   _num_context_attributes = args._context_attributes.size();

--- a/ddprof-lib/src/main/cpp/threadLocalData.cpp
+++ b/ddprof-lib/src/main/cpp/threadLocalData.cpp
@@ -140,7 +140,7 @@ Context ProfiledThread::snapshotContext(size_t numAttrs) {
     ctx.rootSpanId = root_span_id;
     size_t count = numAttrs < DD_TAGS_CAPACITY ? numAttrs : DD_TAGS_CAPACITY;
     for (size_t i = 0; i < count; i++) {
-      ctx.tags[i].value = _otel_tag_encodings[i];
+      ctx.setTag(i, _otel_tag_encodings[i]);
     }
   }
   return ctx;

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/TooManyContextAttributesTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/TooManyContextAttributesTest.java
@@ -85,12 +85,9 @@ public class TooManyContextAttributesTest extends AbstractProfilerTest {
         stopProfiler();
         assertFalse(liveObjects.isEmpty()); // keep allocations reachable through the GC/dump above
 
-        // If the pre-fix out-of-bounds read had fired, an ASan build would already have
-        // aborted the JVM above. On any build, a mismatched schema/field count would make
-        // this parse fail or throw - reaching here with samples already proves the fix.
-        JfrEvents liveObjectEvents = verifyEvents("datadog.HeapLiveObject", false);
-        assertTrue(liveObjectEvents.hasItems(), "expected datadog.HeapLiveObject samples");
-
+        // Assert the deterministic capping behaviour first: whether any datadog.HeapLiveObject
+        // sample happened to be produced on this run depends on GC/timing, so checking that
+        // last keeps a flake distinguishable from a real regression of the cap.
         Set<String> recordedContextAttributes = new HashSet<>();
         for (JfrEvent item : verifyEvents("jdk.ActiveSetting")) {
             if ("contextattribute".equals(item.getString("name"))) {
@@ -108,5 +105,11 @@ public class TooManyContextAttributesTest extends AbstractProfilerTest {
             assertFalse(recordedContextAttributes.contains("tag" + i),
                     "tag" + i + " exceeds capacity and must have been dropped");
         }
+
+        // If the pre-fix out-of-bounds read had fired, an ASan build would already have
+        // aborted the JVM above. On any build, a mismatched schema/field count would make
+        // this parse fail or throw - getting samples here proves the event path is intact.
+        JfrEvents liveObjectEvents = verifyEvents("datadog.HeapLiveObject", false);
+        assertTrue(liveObjectEvents.hasItems(), "expected datadog.HeapLiveObject samples");
     }
 }

--- a/ddprof-test/src/test/java/com/datadoghq/profiler/TooManyContextAttributesTest.java
+++ b/ddprof-test/src/test/java/com/datadoghq/profiler/TooManyContextAttributesTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026, Datadog, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.profiler;
+
+import org.junitpioneer.jupiter.RetryingTest;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test: {@code attributes=} used to accept more names than the native
+ * {@code DD_TAGS_CAPACITY} (context.h), and {@code Recording::writeContextSnapshot}
+ * (flightRecorder.cpp) looped over that unbounded count calling the unchecked
+ * {@code Context::get_tag(i)} on a fixed {@code Tag tags[DD_TAGS_CAPACITY]} array -
+ * reading past the {@code Context} struct into adjacent native memory on every
+ * {@code datadog.HeapLiveObject} event.
+ *
+ * <p>Requesting more attributes than the native capacity must no longer crash (an
+ * ASan build turns the out-of-bounds read into a heap-buffer-overflow abort) and the
+ * profiler must cap the attribute list it advertises/serializes at
+ * {@link JavaProfiler#MAX_CONTEXT_SLOTS}, keeping the JFR metadata schema and the
+ * per-event field count consistent. See {@link MaxContextSlotsTest} for the
+ * companion drift guard between {@code JavaProfiler.MAX_CONTEXT_SLOTS} and {@code DD_TAGS_CAPACITY}.
+ */
+public class TooManyContextAttributesTest extends AbstractProfilerTest {
+
+    private static final int REQUESTED_ATTRIBUTES = JavaProfiler.MAX_CONTEXT_SLOTS + 3;
+
+    @Override
+    protected String getProfilerCommand() {
+        String attrs = IntStream.range(0, REQUESTED_ATTRIBUTES)
+                .mapToObj(i -> "tag" + i)
+                .collect(Collectors.joining(";"));
+        // memory=...:L enables liveness tracking, which is the only path that writes
+        // datadog.HeapLiveObject events via the vulnerable Recording::writeContextSnapshot.
+        return "memory=256:L,attributes=" + attrs;
+    }
+
+    @Override
+    protected boolean isPlatformSupported() {
+        // Liveness tracking requires Java 11+ and specific JVM types (see LivenessTrackingTest).
+        return !(Platform.isJavaVersion(8) || Platform.isJ9() || Platform.isZing());
+    }
+
+    @RetryingTest(5)
+    public void moreAttributesThanCapacityDoesNotCrashAndIsCapped() throws Exception {
+        // Generate enough live allocation volume to clear the 256 KB sampling interval many
+        // times over, mirroring the workload LivenessTrackingTest uses to reliably produce
+        // datadog.HeapLiveObject samples.
+        List<byte[]> liveObjects = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            for (int j = 0; j < 10; j++) {
+                liveObjects.add(new byte[ThreadLocalRandom.current().nextInt(1024, 4096)]);
+            }
+        }
+        Thread.sleep(100);
+        for (int i = 0; i < 6; i++) {
+            System.gc();
+            Thread.sleep(100);
+        }
+        Thread.sleep(300);
+
+        stopProfiler();
+        assertFalse(liveObjects.isEmpty()); // keep allocations reachable through the GC/dump above
+
+        // If the pre-fix out-of-bounds read had fired, an ASan build would already have
+        // aborted the JVM above. On any build, a mismatched schema/field count would make
+        // this parse fail or throw - reaching here with samples already proves the fix.
+        JfrEvents liveObjectEvents = verifyEvents("datadog.HeapLiveObject", false);
+        assertTrue(liveObjectEvents.hasItems(), "expected datadog.HeapLiveObject samples");
+
+        Set<String> recordedContextAttributes = new HashSet<>();
+        for (JfrEvent item : verifyEvents("jdk.ActiveSetting")) {
+            if ("contextattribute".equals(item.getString("name"))) {
+                recordedContextAttributes.add(item.getString("value"));
+            }
+        }
+        assertEquals(JavaProfiler.MAX_CONTEXT_SLOTS, recordedContextAttributes.size(),
+                "attributes= list must be capped at JavaProfiler.MAX_CONTEXT_SLOTS (" + JavaProfiler.MAX_CONTEXT_SLOTS
+                        + "), got: " + recordedContextAttributes);
+        for (int i = 0; i < JavaProfiler.MAX_CONTEXT_SLOTS; i++) {
+            assertTrue(recordedContextAttributes.contains("tag" + i),
+                    "expected tag" + i + " to survive capping, got: " + recordedContextAttributes);
+        }
+        for (int i = JavaProfiler.MAX_CONTEXT_SLOTS; i < REQUESTED_ATTRIBUTES; i++) {
+            assertFalse(recordedContextAttributes.contains("tag" + i),
+                    "tag" + i + " exceeds capacity and must have been dropped");
+        }
+    }
+}


### PR DESCRIPTION
**What does this PR do?**:
Fixes an out-of-bounds read in `Context::get_tag()` (now bounds-checked `getTag`/`setTag`) that could be triggered by configuring more than `DD_TAGS_CAPACITY` (10) custom context attributes via the `attributes=` profiler argument.

- `Context::tags` is a fixed `Tag[DD_TAGS_CAPACITY]` array, but `attributes=` accepted an unbounded number of names and `_num_context_attributes` was set to that unbounded count with no cap.
- `Recording::writeContextSnapshot()` looped up to `numContextAttributes()` calling the unchecked `get_tag(i)`, so configuring 11+ attributes read past the end of `Context` into adjacent memory on every `datadog.HeapLiveObject` event.
- Fix: `Profiler::start()` now caps `args._context_attributes` at `DD_TAGS_CAPACITY` (logging a warning when truncating) before it drives both the JFR metadata schema and `_num_context_attributes`, so the schema and the per-event write count always agree. `Context::get_tag()`/`setTag()` are replaced with encapsulated, bounds-checked `getTag`/`setTag` accessors (private `tags[]`, shared `isValidIndex()` helper) as defense in depth for any future caller.

**Motivation**:
Security review flagged that `attributes=` had no upper bound on the number of configured names, while the native `Context` struct backing per-event tag storage is fixed-size. An out-of-bounds read on every liveness-tracking event can disclose adjacent native heap memory into the JFR recording, or crash the process (e.g. under ASan).

**Additional Notes**:
Iterated based on review feedback:
- `Tighten API`: replaced direct `tags[]` access with private storage + `getTag`/`setTag`.
- `Fix`: gave `setTag` a real runtime bounds check (not just a debug-only `assert`), matching `getTag`'s existing clamp-to-default behavior.
- `Dedup code`: factored the repeated bounds condition out into a shared `isValidIndex()` helper used by both accessors.

**How to test the change?**:
Added `ddprof-test/.../com/datadoghq/profiler/TooManyContextAttributesTest.java`, which configures `attributes=` with 13 names (3 over capacity) together with liveness tracking (`memory=...:L`, the code path that exercises `writeContextSnapshot`/`getTag`), generates enough live allocation volume to produce `datadog.HeapLiveObject` samples, and asserts:
- the recording parses cleanly (would previously corrupt the JFR event stream or crash under ASan on the out-of-bounds read), and
- `jdk.ActiveSetting` reports exactly the first 10 attribute names, confirming the list is capped rather than the requested 13.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [X] This PR doesn't touch any of that.
- [X] JIRA: [PROF-15847](https://datadoghq.atlassian.net/browse/PROF-15847)

Unsure? Have a question? Request a review!


[PROF-15847]: https://datadoghq.atlassian.net/browse/PROF-15847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ