### PR TITLE
Fix release.sh script

### DIFF
--- a/utils/release.sh
+++ b/utils/release.sh
@@ -664,7 +664,7 @@ if gh workflow run release-validated.yml \
     --field dry_run="$DRY_RUN" \
     --field skip_tests="$SKIP_TESTS" \
     --field request_id="$REQUEST_ID" \
-    ${SOURCE_SHA_FIELD:-} > "$WORKFLOW_OUTPUT" 2> "$WORKFLOW_ERROR"; then
+    "${SOURCE_SHA_FIELD:-}" > "$WORKFLOW_OUTPUT" 2> "$WORKFLOW_ERROR"; then
 
     WORKFLOW_SUCCESS=true
     echo ""

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -648,10 +648,14 @@ REQUEST_ID="release-$(date -u +%Y%m%dT%H%M%SZ)-$$-$RANDOM"
 
 # In retry mode, don't pass source_sha — the branch HEAD may have moved since
 # the original run, and the workflow rejects SHA mismatches.
-if [ -n "$RETRY_RUN_ID" ]; then
-    SOURCE_SHA_FIELD=""
-else
-    SOURCE_SHA_FIELD="--field source_sha=$COMMIT_SHA"
+#
+# This must stay an array. A quoted scalar collapses "--field" and its
+# key=value argument into one argv token, which gh rejects with
+# "unknown flag: --field source_sha"; an unquoted scalar would silently
+# word-split and also emit a stray empty argument in retry mode.
+SOURCE_SHA_ARGS=()
+if [ -z "$RETRY_RUN_ID" ]; then
+    SOURCE_SHA_ARGS=(--field "source_sha=$COMMIT_SHA")
 fi
 
 # Trigger the workflow
@@ -664,7 +668,7 @@ if gh workflow run release-validated.yml \
     --field dry_run="$DRY_RUN" \
     --field skip_tests="$SKIP_TESTS" \
     --field request_id="$REQUEST_ID" \
-    "${SOURCE_SHA_FIELD:-}" > "$WORKFLOW_OUTPUT" 2> "$WORKFLOW_ERROR"; then
+    "${SOURCE_SHA_ARGS[@]}" > "$WORKFLOW_OUTPUT" 2> "$WORKFLOW_ERROR"; then
 
     WORKFLOW_SUCCESS=true
     echo ""


### PR DESCRIPTION
**What does this PR do?**:
Fix following script error.
```
In utils/release.sh line 667:
    ${SOURCE_SHA_FIELD:-} > "$WORKFLOW_OUTPUT" 2> "$WORKFLOW_ERROR"; then
    ^-------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
```

**Motivation**:
Fix release.sh script that results CI failure.

**Additional Notes**:
<!-- Anything else we should know when reviewing? -->

**How to test the change?**:
CI no longer fail.

**For Datadog employees**:
- [ ] If this PR touches code that signs or publishes builds or packages, or handles
  credentials of any kind, I've requested a security review (run the `dd:platform-security-review`
  skill, or file a request via the [PSEC review form](https://datadoghq.atlassian.net/jira/software/c/projects/PSEC/forms/form/direct/7861446195161534/37715)).
  `bewaire` also runs automatically on every PR.
- [X] This PR doesn't touch any of that.
- [ ] JIRA: [JIRA-XXXX]

Unsure? Have a question? Request a review!
